### PR TITLE
fix: mobile menu with true black background and brand-compliant colors

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { useHaptics } from "@/hooks/use-haptics";
 
 interface MobileMenuProps {
@@ -80,22 +79,25 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
 
   return (
     <>
-      {/* Hamburger Button - Touch-friendly sizing */}
+      {/* Hamburger Button */}
       <button
         onClick={handleOpenMenu}
-        className="w-12 h-12 flex items-center justify-center hover:opacity-80 transition-all duration-100 touch-press -mr-1"
+        className="w-12 h-12 flex items-center justify-center hover:opacity-80 transition-all duration-100 -mr-1"
         aria-label="Open menu"
       >
-        <Menu className="w-6 h-6 icon-bounce" style={{ color: '#D4AF37' }} />
+        <Menu className="w-6 h-6 text-gold" />
       </button>
 
-      {/* Full-screen Black Overlay Menu */}
+      {/* Full-screen Menu Overlay */}
       {isOpen && (
-        <div className="fixed inset-0 z-50 bg-background flex flex-col animate-fade-in safe-top">
-          {/* Close Button - Touch-friendly */}
+        <div
+          className="fixed inset-0 z-[200] flex flex-col"
+          style={{ backgroundColor: '#000000' }}
+        >
+          {/* Close Button */}
           <button
             onClick={handleCloseMenu}
-            className="absolute top-6 right-4 w-14 h-14 flex items-center justify-center text-foreground hover:text-gold transition-all duration-100 touch-press"
+            className="absolute top-6 right-4 w-14 h-14 flex items-center justify-center text-white hover:text-gold transition-colors"
             aria-label="Close menu"
           >
             <X className="w-7 h-7" />
@@ -108,14 +110,9 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
               FILMMAKER.OG
             </span>
 
-            {/* Navigation Links - Increased gap for better touch targets */}
+            {/* Navigation Links */}
             <nav className="flex flex-col items-center gap-10">
               {menuLinks.map((link) => {
-                const linkClass = link.isHighlighted 
-                  ? "font-bebas text-4xl font-bold tracking-wider transition-colors touch-press"
-                  : "font-bebas text-4xl text-foreground hover:text-gold transition-colors tracking-wider touch-press";
-                const linkStyle = link.isHighlighted ? { color: '#D4AF37' } : undefined;
-                
                 const handleLinkClick = () => {
                   haptics.light();
                   if (link.onClick) {
@@ -124,13 +121,14 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
                     setIsOpen(false);
                   }
                 };
-                
+
                 return link.onClick ? (
                   <button
                     key={link.label}
                     onClick={handleLinkClick}
-                    className={linkClass}
-                    style={linkStyle}
+                    className={`font-bebas text-4xl tracking-wider transition-colors ${
+                      link.isHighlighted ? 'text-gold' : 'text-white hover:text-gold'
+                    }`}
                   >
                     {link.label}
                   </button>
@@ -139,8 +137,9 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
                     key={link.label}
                     to={link.href}
                     onClick={handleLinkClick}
-                    className={linkClass}
-                    style={linkStyle}
+                    className={`font-bebas text-4xl tracking-wider transition-colors ${
+                      link.isHighlighted ? 'text-gold' : 'text-white hover:text-gold'
+                    }`}
                   >
                     {link.label}
                   </Link>
@@ -151,54 +150,53 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
                     onClick={handleLinkClick}
                     target={link.href.startsWith("http") ? "_blank" : undefined}
                     rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
-                    className={linkClass}
-                    style={linkStyle}
+                    className={`font-bebas text-4xl tracking-wider transition-colors ${
+                      link.isHighlighted ? 'text-gold' : 'text-white hover:text-gold'
+                    }`}
                   >
                     {link.label}
                   </a>
                 );
               })}
-              
+
               {/* Legal Button */}
               <button
                 onClick={handleLegalClick}
-                className="font-bebas text-4xl text-foreground hover:text-gold transition-colors tracking-wider"
+                className="font-bebas text-4xl text-white hover:text-gold transition-colors tracking-wider"
               >
                 LEGAL
               </button>
 
-              {/* Sign Out - Only show if handler provided */}
+              {/* Sign Out */}
               {onSignOut && (
                 <button
                   onClick={() => {
                     setIsOpen(false);
                     onSignOut();
                   }}
-                  className="font-bebas text-4xl tracking-wider transition-colors mt-8"
-                  style={{ color: '#666666' }}
-                  onMouseEnter={(e) => e.currentTarget.style.color = '#aa4444'}
-                  onMouseLeave={(e) => e.currentTarget.style.color = '#666666'}
+                  className="font-bebas text-4xl tracking-wider text-white/40 hover:text-white/60 transition-colors mt-8 flex items-center gap-3"
                 >
-                  <span className="flex items-center gap-3">
-                    <LogOut className="w-6 h-6" />
-                    SIGN OUT
-                  </span>
+                  <LogOut className="w-6 h-6" />
+                  SIGN OUT
                 </button>
               )}
             </nav>
           </div>
 
-          {/* Footer - With safe area padding */}
-          <div className="pb-12 text-center space-y-3 safe-bottom">
+          {/* Footer */}
+          <div
+            className="pb-12 text-center space-y-3"
+            style={{ paddingBottom: 'max(3rem, env(safe-area-inset-bottom))' }}
+          >
             <a
               href="https://www.instagram.com/filmmaker.og"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-gold transition-colors text-sm tracking-widest block py-2"
+              className="text-white/40 hover:text-gold transition-colors text-sm tracking-widest block py-2"
             >
-              @filmmaker.og (IG)
+              @filmmaker.og
             </a>
-            <span className="text-muted-foreground text-sm tracking-widest block py-1">
+            <span className="text-white/30 text-sm tracking-widest block py-1">
               thefilmmaker.og@gmail.com
             </span>
           </div>
@@ -207,13 +205,13 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
 
       {/* Legal Modal */}
       <Dialog open={showLegalModal} onOpenChange={setShowLegalModal}>
-        <DialogContent className="bg-surface border-border max-w-md">
+        <DialogContent className="bg-[#0A0A0A] border-[#1A1A1A] max-w-md">
           <DialogHeader>
             <DialogTitle className="font-bebas text-2xl text-gold tracking-wider">
               LEGAL DISCLAIMER
             </DialogTitle>
           </DialogHeader>
-          <p className="text-muted-foreground text-sm leading-relaxed">
+          <p className="text-white/50 text-sm leading-relaxed">
             {legalText}
           </p>
         </DialogContent>
@@ -221,13 +219,13 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
 
       {/* About Modal */}
       <Dialog open={showAboutModal} onOpenChange={setShowAboutModal}>
-        <DialogContent className="bg-surface border-border max-w-lg">
+        <DialogContent className="bg-[#0A0A0A] border-[#1A1A1A] max-w-lg">
           <DialogHeader>
             <DialogTitle className="font-bebas text-2xl text-gold tracking-wider">
               DEMOCRATIZING THE BUSINESS OF FILM
             </DialogTitle>
           </DialogHeader>
-          <div className="text-zinc-400 text-sm leading-relaxed space-y-4">
+          <div className="text-white/50 text-sm leading-relaxed space-y-4">
             <p>
               We provide institutional-grade film finance intelligence to producers operating in the $1M–$10M budget range.
             </p>
@@ -246,41 +244,37 @@ const MobileMenu = ({ onOpenLegal, onSignOut }: MobileMenuProps) => {
 
       {/* Contact Modal */}
       <Dialog open={showContactModal} onOpenChange={setShowContactModal}>
-        <DialogContent className="bg-surface border-border max-w-md">
+        <DialogContent className="bg-[#0A0A0A] border-[#1A1A1A] max-w-md">
           <DialogHeader>
             <DialogTitle className="font-bebas text-2xl text-gold tracking-wider">
               CONTACT
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="flex items-center justify-between bg-black/50 border border-zinc-800 rounded px-4 py-3">
-              <span className="text-zinc-300 text-sm">thefilmmaker.og@gmail.com</span>
-              <Button
-                variant="ghost"
-                size="sm"
+            <div className="flex items-center justify-between bg-black border border-[#1A1A1A] px-4 py-3">
+              <span className="text-white/70 text-sm">thefilmmaker.og@gmail.com</span>
+              <button
                 onClick={handleCopyEmail}
-                className="text-gold hover:text-gold/80 hover:bg-transparent p-2"
+                className="text-gold hover:text-gold/80 p-2 transition-colors"
               >
                 {copiedEmail ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-              </Button>
+              </button>
             </div>
-            <div className="flex items-center justify-between bg-black/50 border border-zinc-800 rounded px-4 py-3">
+            <div className="flex items-center justify-between bg-black border border-[#1A1A1A] px-4 py-3">
               <a
                 href="https://www.instagram.com/filmmaker.og"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-zinc-300 text-sm hover:text-gold transition-colors"
+                className="text-white/70 text-sm hover:text-gold transition-colors"
               >
                 www.instagram.com/filmmaker.og
               </a>
-              <Button
-                variant="ghost"
-                size="sm"
+              <button
                 onClick={handleCopyInsta}
-                className="text-gold hover:text-gold/80 hover:bg-transparent p-2"
+                className="text-gold hover:text-gold/80 p-2 transition-colors"
               >
                 {copiedInsta ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-              </Button>
+              </button>
             </div>
           </div>
         </DialogContent>


### PR DESCRIPTION
- Forced true black (#000000) on menu overlay
- Removed all zinc-* colors (not brand compliant)
- Using white with opacity for text hierarchy
- Removed rounded corners (sharp edges per brand guide)
- Fixed z-index to ensure menu appears above everything
- Proper safe-area padding for notched phones

https://claude.ai/code/session_01Pkenc6xyw23FamsQvS8aNK