### PR TITLE
feat: strip down UI + add mid-flow email capture

### DIFF
--- a/src/components/EmailGateModal.tsx
+++ b/src/components/EmailGateModal.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+import { useHaptics } from "@/hooks/use-haptics";
+import { ArrowRight, Loader2, Mail, X } from "lucide-react";
+import { z } from "zod";
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+
+const emailSchema = z.string().email("Please enter a valid email");
+
+interface EmailGateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  onSkip: () => void;
+}
+
+const EmailGateModal = ({ isOpen, onClose, onSuccess, onSkip }: EmailGateModalProps) => {
+  const { toast } = useToast();
+  const haptics = useHaptics();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const result = emailSchema.safeParse(email);
+    if (!result.success) {
+      haptics.error();
+      toast({
+        title: "Invalid Email",
+        description: "Please enter a valid email address",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    haptics.medium();
+    setLoading(true);
+
+    try {
+      const redirectUrl = `${window.location.origin}/calculator`;
+      const { error } = await supabase.auth.signInWithOtp({
+        email: email.trim(),
+        options: {
+          emailRedirectTo: redirectUrl,
+        },
+      });
+      if (error) throw error;
+
+      haptics.success();
+      setSent(true);
+
+      // Auto-continue after showing confirmation
+      setTimeout(() => {
+        onSuccess();
+      }, 2000);
+    } catch (error: any) {
+      haptics.error();
+      toast({
+        title: "Error",
+        description: error.message || "Failed to send link",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="w-[calc(100%-2rem)] max-w-sm mx-auto bg-black border-[#1A1A1A] p-0 gap-0">
+        {/* Gold accent */}
+        <div className="h-[2px] w-full bg-gold" />
+
+        {sent ? (
+          // Success state
+          <div className="p-6 text-center">
+            <div className="w-12 h-12 border border-gold/50 flex items-center justify-center mx-auto mb-4">
+              <Mail className="w-6 h-6 text-gold" />
+            </div>
+            <p className="font-bebas text-xl tracking-wider text-white mb-2">
+              CHECK YOUR EMAIL
+            </p>
+            <p className="text-white/40 text-sm mb-4">
+              Link sent to <span className="text-gold font-mono">{email}</span>
+            </p>
+            <p className="text-white/30 text-xs">
+              Continuing to your model...
+            </p>
+          </div>
+        ) : (
+          // Email form
+          <form onSubmit={handleSubmit} className="p-6">
+            <p className="font-bebas text-xl tracking-wider text-white text-center mb-1">
+              SAVE YOUR PROGRESS
+            </p>
+            <p className="text-white/40 text-xs text-center mb-6">
+              Get a link to return to your model anytime
+            </p>
+
+            <div className="space-y-4">
+              <input
+                type="email"
+                inputMode="email"
+                autoComplete="email"
+                autoFocus
+                placeholder="you@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full h-12 px-4 bg-[#0A0A0A] border border-[#2A2A2A] text-white placeholder:text-white/30 font-mono text-sm focus:border-gold focus:outline-none transition-colors"
+              />
+
+              <button
+                type="submit"
+                disabled={loading || !email}
+                className="w-full h-12 font-black text-sm tracking-wider bg-gold text-black hover:bg-gold-bright disabled:opacity-40 transition-all active:scale-[0.98]"
+              >
+                {loading ? (
+                  <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+                ) : (
+                  <span className="flex items-center justify-center gap-2">
+                    SEND LINK
+                    <ArrowRight className="w-4 h-4" />
+                  </span>
+                )}
+              </button>
+            </div>
+
+            {/* Skip - tiny, for dev testing */}
+            <button
+              type="button"
+              onClick={onSkip}
+              className="w-full mt-4 py-2 text-white/30 hover:text-white/50 text-[11px] tracking-wider transition-colors"
+            >
+              continue without saving
+            </button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EmailGateModal;

--- a/src/components/calculator/ProgressBar.tsx
+++ b/src/components/calculator/ProgressBar.tsx
@@ -30,15 +30,13 @@ const ProgressBar = ({
         {/* Chapter badges row */}
         <div className="relative flex items-center justify-between">
           {/* Connection line (background) */}
-          <div className="absolute left-6 right-6 top-1/2 h-[2px] bg-[#1A1A1A] -translate-y-1/2" />
+          <div className="absolute left-4 right-4 top-1/2 h-[1px] bg-[#1A1A1A] -translate-y-1/2" />
 
           {/* Progress fill line */}
           <div
-            className="absolute left-6 top-1/2 h-[2px] -translate-y-1/2 transition-all duration-500 ease-out"
+            className="absolute left-4 top-1/2 h-[1px] -translate-y-1/2 transition-all duration-300 ease-out bg-gold"
             style={{
-              width: `calc(${progress}% * (100% - 48px) / 100%)`,
-              background: 'linear-gradient(90deg, #D4AF37 0%, #F9E076 100%)',
-              boxShadow: '0 0 10px rgba(212, 175, 55, 0.5)',
+              width: `calc(${progress}% * (100% - 32px) / 100%)`,
             }}
           />
 
@@ -56,36 +54,14 @@ const ProgressBar = ({
                   onClick={() => isCompleted && onStepClick?.(stepNum)}
                   disabled={!isCompleted}
                   className={cn(
-                    "relative w-10 h-10 rounded-full flex items-center justify-center font-mono text-sm font-bold transition-all duration-300",
-                    // Active state - gold fill + glow
-                    isActive && [
-                      "bg-gold text-black",
-                      "shadow-[0_0_20px_rgba(212,175,55,0.6),0_0_40px_rgba(212,175,55,0.3)]",
-                      "ring-2 ring-gold-highlight ring-offset-2 ring-offset-[#0A0A0A]",
-                    ],
-                    // Completed state - gold outline + checkmark
-                    isCompleted && [
-                      "bg-[#0A0A0A] border-2 border-gold text-gold",
-                      "hover:bg-gold/10 cursor-pointer",
-                    ],
-                    // Future state - muted
-                    isFuture && [
-                      "bg-[#0A0A0A] border border-[#2A2A2A] text-white/30",
-                    ]
+                    "w-8 h-8 rounded-full flex items-center justify-center font-mono text-xs font-bold transition-all duration-200",
+                    isActive && "bg-gold text-black",
+                    isCompleted && "bg-transparent border border-gold text-gold hover:bg-gold/10 cursor-pointer",
+                    isFuture && "bg-transparent border border-[#2A2A2A] text-white/30"
                   )}
                 >
-                  {/* Inner glow for active */}
-                  {isActive && (
-                    <div
-                      className="absolute inset-0 rounded-full animate-pulse-slow"
-                      style={{
-                        background: 'radial-gradient(circle, rgba(249, 224, 118, 0.3) 0%, transparent 70%)',
-                      }}
-                    />
-                  )}
-
                   {/* Badge content */}
-                  <span className="relative">
+                  <span>
                     {isCompleted ? (
                       <Check className="w-4 h-4" />
                     ) : (

--- a/src/components/calculator/StandardStepIcon.tsx
+++ b/src/components/calculator/StandardStepIcon.tsx
@@ -6,30 +6,16 @@ interface StandardStepIconProps {
 }
 
 /**
- * Standardized icon treatment for all calculator steps
- * - Consistent w-14 h-14 container
- * - Consistent w-7 h-7 icon size
- * - Consistent glow effect (blur 15px, scale 2)
- * - Consistent border and background opacity
+ * Clean, minimal icon for calculator steps
  */
 export const StandardStepIcon = ({ icon: Icon, label }: StandardStepIconProps) => {
   return (
-    <div className="relative inline-block mb-6">
-      {/* Standard glow effect */}
-      <div
-        className="absolute inset-0 animate-pulse-slow"
-        style={{
-          background: 'radial-gradient(circle, rgba(212, 175, 55, 0.2) 0%, transparent 70%)',
-          filter: 'blur(15px)',
-          transform: 'scale(2)',
-        }}
-      />
-      {/* Standard icon container */}
-      <div className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center">
-        <Icon className="w-7 h-7 text-gold" />
+    <div className="inline-block mb-4">
+      <div className="w-10 h-10 border border-gold/30 flex items-center justify-center">
+        <Icon className="w-5 h-5 text-gold" />
       </div>
       {label && (
-        <p className="text-white/40 text-xs mt-3 uppercase tracking-widest text-center">
+        <p className="text-white/30 text-[10px] mt-2 uppercase tracking-widest text-center">
           {label}
         </p>
       )}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 import { useHaptics } from "@/hooks/use-haptics";
 import { ArrowRight } from "lucide-react";
 import filmmakerLogo from "@/assets/filmmaker-logo.jpg";
@@ -10,107 +9,63 @@ const Index = () => {
   const navigate = useNavigate();
   const haptics = useHaptics();
   const [animationPhase, setAnimationPhase] = useState<
-    'dark' | 'logo' | 'glow' | 'tagline' | 'complete'
+    'dark' | 'logo' | 'tagline' | 'complete'
   >('dark');
 
   useEffect(() => {
-    // Premium animation sequence
+    // Faster, cleaner animation sequence (1.8s total)
     const timers = [
-      setTimeout(() => setAnimationPhase('logo'), 400),
-      setTimeout(() => setAnimationPhase('glow'), 1000),
-      setTimeout(() => setAnimationPhase('tagline'), 1600),
-      setTimeout(() => setAnimationPhase('complete'), 2600),
+      setTimeout(() => setAnimationPhase('logo'), 300),
+      setTimeout(() => setAnimationPhase('tagline'), 900),
+      setTimeout(() => setAnimationPhase('complete'), 1800),
     ];
     return () => timers.forEach(clearTimeout);
   }, []);
 
   const handleStartClick = () => {
     haptics.medium();
-    navigate("/auth");
+    navigate("/calculator");
   };
 
   const showLogo = animationPhase !== 'dark';
-  const showGlow = ['glow', 'tagline', 'complete'].includes(animationPhase);
   const showTagline = ['tagline', 'complete'].includes(animationPhase);
-  const isRevealing = animationPhase === 'complete';
+  const isComplete = animationPhase === 'complete';
 
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden bg-black">
 
-      {/* ═══════════════════════════════════════════════════════════════════
-          CINEMATIC SPLASH
-          ═══════════════════════════════════════════════════════════════════ */}
+      {/* CINEMATIC SPLASH - Clean, minimal */}
       <div
-        className={`fixed inset-0 z-[100] flex items-center justify-center transition-all duration-700 ${
-          isRevealing ? 'opacity-0 pointer-events-none' : 'opacity-100'
+        className={`fixed inset-0 z-[100] flex items-center justify-center transition-all duration-500 ${
+          isComplete ? 'opacity-0 pointer-events-none' : 'opacity-100'
         }`}
         style={{ backgroundColor: '#000000' }}
       >
         <div className="flex flex-col items-center">
-          {/* Logo with Growing Glow */}
-          <div className="relative">
-            {/* Outer glow - appears second */}
-            <div
-              className={`absolute transition-all duration-700 ${
-                showGlow ? 'opacity-100 scale-100' : 'opacity-0 scale-75'
-              }`}
-              style={{
-                width: '280px',
-                height: '280px',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                background: 'radial-gradient(circle, rgba(212, 175, 55, 0.35) 0%, rgba(212, 175, 55, 0.15) 40%, transparent 70%)',
-                filter: 'blur(50px)',
-              }}
+          {/* Logo - simple fade in */}
+          <div
+            className={`transition-all duration-500 ${
+              showLogo ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+            }`}
+          >
+            <img
+              src={filmmakerLogo}
+              alt="Filmmaker.OG"
+              className="w-24 h-24 object-contain"
             />
-            {/* Inner glow */}
-            <div
-              className={`absolute transition-all duration-500 ${
-                showGlow ? 'opacity-100' : 'opacity-0'
-              }`}
-              style={{
-                width: '160px',
-                height: '160px',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                background: 'radial-gradient(circle, rgba(249, 224, 118, 0.4) 0%, transparent 60%)',
-                filter: 'blur(25px)',
-              }}
-            />
-            {/* Logo */}
-            <div
-              className={`relative z-10 transition-all duration-700 ${
-                showLogo ? 'opacity-100 scale-100' : 'opacity-0 scale-90'
-              }`}
-            >
-              <img
-                src={filmmakerLogo}
-                alt="Filmmaker.OG"
-                className="w-28 h-28 sm:w-36 sm:h-36 object-contain"
-                style={{
-                  filter: showGlow ? 'drop-shadow(0 0 50px rgba(212, 175, 55, 0.6))' : 'none',
-                  transition: 'filter 0.6s ease',
-                }}
-              />
-            </div>
           </div>
 
-          {/* Gold Underline */}
+          {/* Gold line */}
           <div
-            className={`mt-6 h-[2px] bg-gold transition-all duration-700 ${
-              showGlow ? 'w-52 opacity-100' : 'w-0 opacity-0'
+            className={`mt-5 h-[1px] bg-gold transition-all duration-500 ${
+              showLogo ? 'w-32 opacity-100' : 'w-0 opacity-0'
             }`}
-            style={{
-              boxShadow: showGlow ? '0 0 25px rgba(212, 175, 55, 0.7)' : 'none',
-            }}
           />
 
           {/* Tagline */}
           <p
-            className={`mt-6 text-sm tracking-[0.35em] uppercase transition-all duration-500 ${
-              showTagline ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+            className={`mt-5 text-xs tracking-[0.3em] uppercase transition-all duration-400 ${
+              showTagline ? 'opacity-100' : 'opacity-0'
             }`}
             style={{ color: '#D4AF37' }}
           >
@@ -119,106 +74,78 @@ const Index = () => {
         </div>
       </div>
 
-      {/* ═══════════════════════════════════════════════════════════════════
-          HEADER - With hamburger menu (z-[200] to stay above splash)
-          ═══════════════════════════════════════════════════════════════════ */}
-      {animationPhase === 'complete' && <Header />}
+      {/* HEADER */}
+      {isComplete && <Header />}
 
-      {/* ═══════════════════════════════════════════════════════════════════
-          HERO
-          ═══════════════════════════════════════════════════════════════════ */}
+      {/* HERO - Clean and focused */}
       <main
-        className={`flex-1 flex flex-col items-center justify-center px-6 pb-20 transition-all duration-700 ${
-          animationPhase === 'complete' ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+        className={`flex-1 flex flex-col items-center justify-center px-6 pb-24 transition-all duration-500 ${
+          isComplete ? 'opacity-100' : 'opacity-0'
         }`}
-        style={{ transitionDelay: animationPhase === 'complete' ? '200ms' : '0ms' }}
       >
         <div className="w-full max-w-sm flex flex-col items-center text-center">
 
-          {/* Logo with Strong Glow */}
-          <div className="relative mb-10">
-            {/* Outer glow ring - MORE VISIBLE */}
+          {/* Logo - subtle glow only */}
+          <div className="relative mb-8">
             <div
-              className="absolute animate-pulse-slow"
+              className="absolute inset-0 -m-8"
               style={{
-                width: '320px',
-                height: '320px',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                background: 'radial-gradient(circle, rgba(212, 175, 55, 0.25) 0%, rgba(212, 175, 55, 0.1) 40%, transparent 65%)',
-                filter: 'blur(40px)',
+                background: 'radial-gradient(circle, rgba(212, 175, 55, 0.15) 0%, transparent 70%)',
+                filter: 'blur(30px)',
               }}
             />
-            {/* Inner warm glow */}
-            <div
-              className="absolute"
-              style={{
-                width: '180px',
-                height: '180px',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                background: 'radial-gradient(circle, rgba(249, 224, 118, 0.3) 0%, rgba(212, 175, 55, 0.15) 50%, transparent 70%)',
-                filter: 'blur(20px)',
-              }}
-            />
-            {/* Logo - BIGGER */}
             <img
               src={filmmakerLogo}
               alt="Filmmaker.OG"
-              className="w-28 h-28 sm:w-32 sm:h-32 object-contain relative z-10"
-              style={{
-                filter: 'drop-shadow(0 0 40px rgba(212, 175, 55, 0.5))',
-              }}
+              className="w-24 h-24 object-contain relative z-10"
             />
           </div>
 
-          {/* Title - BIGGER */}
-          <h1 className="font-bebas text-3xl sm:text-4xl tracking-[0.1em] text-white mb-5 leading-tight">
+          {/* Title */}
+          <h1 className="font-bebas text-3xl tracking-[0.08em] text-white mb-4 leading-tight">
             STREAMER ACQUISITION
             <br />
             <span className="text-gold">CALCULATOR</span>
           </h1>
 
-          {/* Subtitle - BIGGER */}
-          <p className="text-white/60 text-base sm:text-lg leading-relaxed mb-10 max-w-xs">
-            See exactly how the money flows before you sign.
-            Model deals like the agencies do.
+          {/* Subtitle - one clear line */}
+          <p className="text-white/50 text-sm leading-relaxed mb-8 max-w-[280px]">
+            Model your deal like the agencies do.
+            See where every dollar goes.
           </p>
 
-          {/* CTA - WITH GLOW */}
-          <Button
+          {/* CTA - Clean, no shimmer */}
+          <button
             onClick={handleStartClick}
-            className="w-full max-w-xs h-16 text-lg font-black tracking-[0.12em] rounded-none bg-gold-cta text-black hover:brightness-110 transition-all duration-200 touch-press group"
+            className="w-full max-w-[280px] h-14 text-sm font-black tracking-[0.12em] bg-gold text-black hover:bg-gold-bright transition-colors active:scale-[0.98]"
             style={{
-              boxShadow: '0 0 50px rgba(212, 175, 55, 0.45), 0 0 100px rgba(212, 175, 55, 0.2)',
+              boxShadow: '0 0 30px rgba(212, 175, 55, 0.25)',
             }}
           >
-            <span className="flex items-center justify-center gap-3">
+            <span className="flex items-center justify-center gap-2">
               RUN THE NUMBERS
-              <ArrowRight size={20} className="group-hover:translate-x-1 transition-transform duration-200" />
+              <ArrowRight size={18} />
             </span>
-          </Button>
+          </button>
 
-          {/* Trust signal */}
-          <p className="text-white/40 text-xs tracking-[0.15em] uppercase mt-8">
-            Free · No account needed
+          {/* Subtle hint */}
+          <p className="text-white/30 text-[11px] tracking-wider mt-6">
+            Takes about 2 minutes
           </p>
         </div>
       </main>
 
-      {/* ═══════════════════════════════════════════════════════════════════
-          FOOTER - Better positioned
-          ═══════════════════════════════════════════════════════════════════ */}
+      {/* FOOTER */}
       <footer
-        className={`py-4 pb-6 text-center transition-all duration-500 ${
-          animationPhase === 'complete' ? 'opacity-100' : 'opacity-0'
+        className={`py-4 text-center transition-all duration-500 ${
+          isComplete ? 'opacity-100' : 'opacity-0'
         }`}
-        style={{ transitionDelay: animationPhase === 'complete' ? '400ms' : '0ms' }}
+        style={{
+          paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
+        }}
       >
-        <p className="text-xs tracking-wider text-white/30">
-          Educational purposes only · Not financial advice
+        <p className="text-[10px] tracking-wider text-white/20">
+          Educational purposes only
         </p>
       </footer>
     </div>


### PR DESCRIPTION
Homepage:
- Faster splash animation (1.8s vs 2.6s)
- Removed stacked glows, single subtle glow only
- Cleaner copy and smaller elements
- Goes directly to calculator (not auth)

Calculator:
- Removed shimmer effect on CTA buttons
- Swipe hints now visible (opacity-20 vs opacity-0)
- Email gate modal appears after guilds step (step 2)
- Skip button kept small for dev testing

Progress bar:
- Smaller badges (w-8 vs w-10)
- Removed pulsing glow on active badge
- Faster animation (duration-300 vs duration-500)
- Thinner connection line

Step icons:
- Removed animated pulse glow
- Smaller and cleaner (w-10 vs w-14)

https://claude.ai/code/session_01Pkenc6xyw23FamsQvS8aNK