### PR TITLE
style: standardize header styling with Electric Gold and matte grey

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,11 +16,11 @@ const Header = ({ title }: HeaderProps) => {
 
   return (
     <>
-      {/* Header Bar - Frosted Glass */}
+      {/* Header Bar - Matte Grey */}
       <header
         className="fixed top-0 left-0 right-0 z-[150]"
         style={{
-          backgroundColor: "rgba(10, 10, 10, 0.85)",
+          backgroundColor: "#1A1A1A",
           backdropFilter: "blur(14px)",
           WebkitBackdropFilter: "blur(14px)",
         }}
@@ -51,7 +51,7 @@ const Header = ({ title }: HeaderProps) => {
         <div
           className="h-[1px] w-full"
           style={{
-            background: "linear-gradient(90deg, transparent 0%, rgba(212, 175, 55, 0.5) 20%, rgba(212, 175, 55, 0.5) 80%, transparent 100%)",
+            background: "linear-gradient(90deg, transparent 0%, rgba(255, 215, 0, 0.45) 20%, rgba(255, 215, 0, 0.45) 80%, transparent 100%)",
           }}
         />
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@
     --bg-card: #070707;                 /* Card surfaces. Floats on the void. */
     --bg-surface: #141414;              /* Input fields, interactive areas. */
     --bg-elevated: #111111;             /* Headers, section dividers within cards. */
+    --bg-header: #1A1A1A;               /* App bar and tab bar. Matte grey. */
 
     /* THE GOLD SYSTEM (Electric)
        Rule: Gold = Attention. Use sparingly. If everything is gold, nothing is. */
@@ -248,10 +249,10 @@
     height: var(--tabbar-h);
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    background: rgba(0, 0, 0, 0.9);
+    background: var(--bg-header);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
-    border-top: 1px solid var(--border-subtle);
+    border-top: 1px solid var(--gold-muted);
     padding: 0 var(--space-sm);
     padding-bottom: env(safe-area-inset-bottom);
     z-index: 50;

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -242,12 +242,12 @@ const Calculator = () => {
 
   return (
     <div className="min-h-screen bg-bg-void flex flex-col">
-      {/* Header - Frosted Glass */}
+      {/* Header - Matte Grey */}
       <header
         className="fixed top-0 left-0 right-0 z-50 flex items-center px-4"
         style={{
           height: 'var(--appbar-h)',
-          backgroundColor: 'rgba(0, 0, 0, 0.9)',
+          backgroundColor: '#1A1A1A',
           backdropFilter: 'blur(14px)',
           WebkitBackdropFilter: 'blur(14px)',
         }}
@@ -268,12 +268,12 @@ const Calculator = () => {
         <MobileMenu />
       </header>
 
-      {/* Gold line separator */}
+      {/* Gold line separator - Electric Gold */}
       <div
         className="fixed left-0 right-0 h-[1px] z-50"
         style={{
           top: 'var(--appbar-h)',
-          background: "linear-gradient(90deg, transparent 0%, var(--gold-muted) 20%, var(--gold-muted) 80%, transparent 100%)",
+          background: "linear-gradient(90deg, transparent 0%, rgba(255, 215, 0, 0.45) 20%, rgba(255, 215, 0, 0.45) 80%, transparent 100%)",
         }}
       />
 


### PR DESCRIPTION
- Add --bg-header: #1A1A1A token to design system
- Update Header gold line to Electric Gold (#FFD700)
- Update Calculator header to use matte grey (#1A1A1A)
- Update TabBar to use --bg-header and gold border
- Ensures consistent header styling across all pages

https://claude.ai/code/session_01RzUNwKBBsMywEwYHHNQScK