### PR TITLE
fix: enforce consistent Inter font across app and glossary dialogs

### DIFF
--- a/src/components/calculator/GlossaryTrigger.tsx
+++ b/src/components/calculator/GlossaryTrigger.tsx
@@ -43,7 +43,7 @@ const GlossaryTrigger = ({
 
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent
-          className="bg-bg-card border-border-default rounded-xl max-w-sm"
+          className="bg-bg-card border-border-default rounded-xl max-w-sm font-sans"
           style={{ borderRadius: 'var(--radius-xl)' }}
         >
           <DialogHeader>
@@ -51,11 +51,11 @@ const GlossaryTrigger = ({
               {title}
             </DialogTitle>
           </DialogHeader>
-          <DialogDescription className="text-text-mid text-sm leading-relaxed">
+          <DialogDescription className="font-sans text-text-mid text-sm leading-relaxed">
             {description}
           </DialogDescription>
           {details && (
-            <div className="mt-4 space-y-3 text-sm text-text-mid">
+            <div className="mt-4 space-y-3 text-sm text-text-mid font-sans">
               {details}
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -102,10 +102,11 @@
     --radius: 14px;                     /* Default to --radius-lg */
   }
 
-  /* Force true black on html and body */
+  /* Force true black on html and body + base font */
   html, body {
     background-color: #000000;
     color: #FFFFFF;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   }
 
   /* Entrance animation utility (transform + opacity only for GPU acceleration) */


### PR DESCRIPTION
- Add font-family: Inter to html/body base styles
- Add font-sans class to glossary dialog content
- Ensures all body text uses Inter consistently

Font system (3 fonts max):
1. Bebas Neue - headings, titles
2. Inter - body text, labels, descriptions
3. Roboto Mono - numbers

https://claude.ai/code/session_01RzUNwKBBsMywEwYHHNQScK