### PR TITLE
fix: improve Budget tab UX - remove guilds, auto-select inputs

### DIFF
--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -1,6 +1,6 @@
-import { WaterfallInputs, GuildState, formatCompactCurrency } from "@/lib/waterfall";
-import { Minus, Plus, Check, ChevronDown, ChevronUp } from "lucide-react";
-import { useState } from "react";
+import { WaterfallInputs, GuildState } from "@/lib/waterfall";
+import { Minus, Plus, ChevronDown, ChevronUp } from "lucide-react";
+import { useState, useRef } from "react";
 import { useHaptics } from "@/hooks/use-haptics";
 import { cn } from "@/lib/utils";
 import ChapterCard from "../ChapterCard";
@@ -13,11 +13,12 @@ interface BudgetTabProps {
   onToggleGuild: (guild: keyof GuildState) => void;
 }
 
-const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild }: BudgetTabProps) => {
+const BudgetTab = ({ inputs, onUpdateInput }: BudgetTabProps) => {
   const haptics = useHaptics();
   const [isFocused, setIsFocused] = useState(false);
   const [showFeeDetails, setShowFeeDetails] = useState(false);
-  const [justToggled, setJustToggled] = useState<string | null>(null);
+  const budgetInputRef = useRef<HTMLInputElement>(null);
+  const salesExpInputRef = useRef<HTMLInputElement>(null);
 
   const formatValue = (value: number | undefined) => {
     if (value === undefined || value === 0) return '';
@@ -34,36 +35,19 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild }: BudgetTabPr
     return `$${value}`;
   };
 
+  // Auto-select all text on focus for easy overwriting
+  const handleFocus = (ref: React.RefObject<HTMLInputElement>) => {
+    setIsFocused(true);
+    // Small delay to ensure the input is focused before selecting
+    setTimeout(() => {
+      ref.current?.select();
+    }, 0);
+  };
+
   // Calculate off-the-top total for display
   const offTopTotal = inputs.budget > 0
     ? (inputs.budget * 0.01) + (inputs.budget * (inputs.salesFee / 100)) + inputs.salesExp
     : 0;
-
-  // Guild calculations
-  const hypotheticalRevenue = inputs.budget * 1.2;
-  const sagAmount = hypotheticalRevenue * 0.045;
-  const wgaAmount = hypotheticalRevenue * 0.012;
-  const dgaAmount = hypotheticalRevenue * 0.012;
-
-  const totalGuildsCost =
-    (guilds.sag ? sagAmount : 0) +
-    (guilds.wga ? wgaAmount : 0) +
-    (guilds.dga ? dgaAmount : 0);
-
-  const handleToggle = (guild: keyof GuildState) => {
-    haptics.light();
-    setJustToggled(guild);
-    onToggleGuild(guild);
-    setTimeout(() => setJustToggled(null), 200);
-  };
-
-  const guildOptions = [
-    { key: 'sag' as keyof GuildState, name: 'SAG-AFTRA', subtitle: 'Actors', rate: '4.5%', amount: sagAmount },
-    { key: 'wga' as keyof GuildState, name: 'WGA', subtitle: 'Writers', rate: '1.2%', amount: wgaAmount },
-    { key: 'dga' as keyof GuildState, name: 'DGA', subtitle: 'Directors', rate: '1.2%', amount: dgaAmount },
-  ];
-
-  const activeGuildCount = [guilds.sag, guilds.wga, guilds.dga].filter(Boolean).length;
 
   return (
     <div className="space-y-4 pb-8">
@@ -91,14 +75,15 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild }: BudgetTabPr
           >
             <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
             <input
+              ref={budgetInputRef}
               type="text"
               inputMode="numeric"
               value={formatValue(inputs.budget)}
               onChange={(e) => onUpdateInput('budget', parseValue(e.target.value))}
-              onFocus={() => setIsFocused(true)}
+              onFocus={() => handleFocus(budgetInputRef)}
               onBlur={() => setIsFocused(false)}
-              placeholder="2,000,000"
-              className="flex-1 bg-transparent py-4 pr-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim tabular-nums"
+              placeholder="Enter your budget"
+              className="flex-1 bg-transparent py-4 pr-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim placeholder:text-base tabular-nums"
             />
           </div>
           <p className="mt-2 text-xs text-text-dim">
@@ -197,10 +182,13 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild }: BudgetTabPr
                   >
                     <span className="pl-4 pr-2 font-mono text-text-dim">$</span>
                     <input
+                      ref={salesExpInputRef}
                       type="text"
                       inputMode="numeric"
                       value={formatValue(inputs.salesExp)}
                       onChange={(e) => onUpdateInput('salesExp', parseValue(e.target.value))}
+                      onFocus={() => handleFocus(salesExpInputRef)}
+                      onBlur={() => setIsFocused(false)}
                       placeholder="75,000"
                       className="flex-1 bg-transparent py-3 pr-4 outline-none font-mono text-text-primary text-right placeholder:text-text-dim tabular-nums"
                     />
@@ -211,102 +199,6 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild }: BudgetTabPr
           </div>
         )}
       </ChapterCard>
-
-      {/* Guild Residuals Section - Only show after budget entered */}
-      {inputs.budget > 0 && (
-        <ChapterCard
-          chapter="01"
-          title="GUILDS"
-          isActive={activeGuildCount > 0}
-          glossaryTrigger={
-            <GlossaryTrigger {...GLOSSARY.guildResiduals} />
-          }
-        >
-          <div className="mb-3 flex items-center justify-between">
-            <span className="text-xs font-bold uppercase tracking-wider text-text-dim">
-              Select if signatory
-            </span>
-            {activeGuildCount > 0 && (
-              <span className="text-xs text-text-dim">{activeGuildCount} selected</span>
-            )}
-          </div>
-
-          <div className="space-y-3">
-            {guildOptions.map((guild) => {
-              const isSelected = guilds[guild.key];
-              const wasJustToggled = justToggled === guild.key;
-
-              return (
-                <button
-                  key={guild.key}
-                  onClick={() => handleToggle(guild.key)}
-                  className={cn(
-                    "w-full p-4 border flex items-center justify-between transition-all duration-150",
-                    isSelected
-                      ? "bg-gold-subtle border-gold-muted"
-                      : "bg-bg-surface border-border-default hover:border-text-dim",
-                    wasJustToggled && "scale-[1.01]"
-                  )}
-                  style={{ borderRadius: 'var(--radius-md)' }}
-                >
-                  <div className="flex items-center gap-3">
-                    {/* Checkbox */}
-                    <div
-                      className={cn(
-                        "w-5 h-5 flex items-center justify-center border transition-all duration-150",
-                        isSelected
-                          ? "bg-gold border-gold"
-                          : "bg-transparent border-border-default"
-                      )}
-                      style={{ borderRadius: 'var(--radius-sm)' }}
-                    >
-                      {isSelected && (
-                        <Check className="w-3 h-3 text-black" />
-                      )}
-                    </div>
-
-                    <div className="text-left">
-                      <span className={cn(
-                        "font-medium text-sm transition-colors",
-                        isSelected ? "text-text-primary" : "text-text-mid"
-                      )}>
-                        {guild.name}
-                      </span>
-                      <span className="text-xs text-text-dim ml-2">{guild.subtitle}</span>
-                    </div>
-                  </div>
-
-                  <div className="text-right">
-                    <span className="font-mono text-sm text-text-dim">{guild.rate}</span>
-                    {isSelected && (
-                      <span className="font-mono text-xs text-gold ml-2">
-                        -{formatCompactCurrency(guild.amount)}
-                      </span>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-
-          {/* Total Impact */}
-          {totalGuildsCost > 0 && (
-            <div className="mt-4 pt-4 border-t border-border-subtle flex items-center justify-between">
-              <span className="text-sm text-text-dim">Total residuals</span>
-              <span className="font-mono text-lg text-gold">
-                -{formatCompactCurrency(totalGuildsCost)}
-              </span>
-            </div>
-          )}
-
-          {/* Hint text */}
-          {activeGuildCount === 0 && (
-            <p className="mt-4 text-center text-xs text-text-dim">
-              Most SVOD buyouts are non-union. Skip if the buyer handles residuals.
-            </p>
-          )}
-        </ChapterCard>
-      )}
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -33,8 +33,8 @@
     --text-dim: #8A8A8A;                /* Labels, helper text, phase markers. */
 
     /* BORDERS */
-    --border-default: #2A2A2A;          /* Card borders, dividers. */
-    --border-subtle: #1A1A1A;           /* Inner dividers, low-emphasis separation. */
+    --border-default: #333333;          /* Card borders, dividers. Slightly visible. */
+    --border-subtle: #1F1F1F;           /* Inner dividers, low-emphasis separation. */
     --border-active: rgba(255, 215, 0, 0.5); /* Active/focused input borders. */
 
     /* STATUS COLORS */


### PR DESCRIPTION
- Remove Guilds section from Budget tab (simplified flow)
- Add auto-select on input focus (tap and type immediately)
- Change placeholder from number to "Enter your budget"
- Make card borders slightly more visible (#333 vs #2A2A2A)
- Add refs for proper input selection behavior

https://claude.ai/code/session_01RzUNwKBBsMywEwYHHNQScK