### PR TITLE
feat: add progress line + more visible card borders

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,8 +33,8 @@
     --text-dim: #8A8A8A;                /* Labels, helper text, phase markers. */
 
     /* BORDERS */
-    --border-default: #333333;          /* Card borders, dividers. Slightly visible. */
-    --border-subtle: #1F1F1F;           /* Inner dividers, low-emphasis separation. */
+    --border-default: #404040;          /* Card borders, dividers. More visible for depth. */
+    --border-subtle: #252525;           /* Inner dividers, low-emphasis separation. */
     --border-active: rgba(255, 215, 0, 0.5); /* Active/focused input borders. */
 
     /* STATUS COLORS */

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -287,6 +287,17 @@ const Calculator = () => {
         }}
       />
 
+      {/* Progress line - fills as you advance through tabs */}
+      <div
+        className="fixed left-0 h-[2px] z-50 transition-all duration-500 ease-out"
+        style={{
+          top: 'calc(var(--appbar-h) + 1px)',
+          width: `${TAB_TO_STEP[activeTab] * 25}%`,
+          background: 'linear-gradient(90deg, rgba(255, 215, 0, 0.8) 0%, rgba(255, 215, 0, 0.4) 100%)',
+          boxShadow: '0 0 8px rgba(255, 215, 0, 0.3)',
+        }}
+      />
+
        {/* Spacer for fixed header */}
        <div style={{ height: 'var(--appbar-h)' }} />
 


### PR DESCRIPTION
- Added thin gold progress line under header
- Line fills 25% → 50% → 75% → 100% as you advance tabs
- Subtle glow effect on progress line
- Card borders now #404040 (more visible depth)
- Inner dividers now #252525 (better separation)

https://claude.ai/code/session_01RzUNwKBBsMywEwYHHNQScK