### PR TITLE
refactor: fix layout jump and improve Budget UX (user contribution)

### DIFF
--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import ChapterCard from "../ChapterCard";
 import GlossaryTrigger, { GLOSSARY } from "../GlossaryTrigger";
+import { Check } from "lucide-react"; // Import the proper icon
 
 interface BudgetTabProps {
   inputs: WaterfallInputs;
@@ -16,7 +17,7 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const budgetInputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-focus on mount
+  // Auto-focus on mount if empty
   useEffect(() => {
     if (inputs.budget === 0) {
       budgetInputRef.current?.focus();
@@ -32,7 +33,6 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
     return parseInt(str.replace(/[^0-9]/g, '')) || 0;
   };
 
-  // Auto-select all text on focus for easy overwriting
   const handleFocus = () => {
     setIsFocused(true);
     setTimeout(() => {
@@ -40,12 +40,10 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
     }, 0);
   };
 
-  // Handle Enter key to blur input and advance
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
       budgetInputRef.current?.blur();
-      // Advance to next section if budget is entered
       if (inputs.budget > 0 && onAdvance) {
         setTimeout(() => onAdvance(), 100);
       }
@@ -55,45 +53,19 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
   const isCompleted = inputs.budget > 0;
 
   return (
-    <div className="space-y-4 pb-8">
-      {/* Clear instruction box for first-time users */}
-      {!isCompleted && (
-        <div
-          className="p-5 border border-gold/40 bg-gold/5"
-          style={{ borderRadius: 'var(--radius-lg)' }}
-        >
-          <h3 className="text-base font-bold text-gold mb-3 uppercase tracking-wide">
-            👉 Start Here
-          </h3>
-          <p className="text-sm text-text-primary leading-relaxed mb-3">
-            Enter your film's total production budget below.
-          </p>
-          <p className="text-sm text-text-mid mb-2">
-            This is called your <span className="text-gold font-semibold">"negative cost"</span> in the industry.
-          </p>
-          <div className="mt-4 pt-3 border-t border-gold/20">
-            <p className="text-xs text-text-dim mb-1">
-              Example amounts:
-            </p>
-            <div className="flex gap-3 flex-wrap">
-              <span className="font-mono text-xs text-text-mid bg-bg-surface px-2 py-1 rounded">$250,000</span>
-              <span className="font-mono text-xs text-text-mid bg-bg-surface px-2 py-1 rounded">$750,000</span>
-              <span className="font-mono text-xs text-text-mid bg-bg-surface px-2 py-1 rounded">$2,500,000</span>
-            </div>
-          </div>
-        </div>
-      )}
+    <div className="space-y-6 pb-8">
+      {/*
+         FIX 1: We removed the conditional "Start Here" block from the top.
+         Now the ChapterCard is always the first thing the user sees.
+      */}
 
-      {/* Production Budget Section */}
       <ChapterCard
         chapter="01"
         title="BUDGET"
         isActive={true}
-        glossaryTrigger={
-          <GlossaryTrigger {...GLOSSARY.negativeCost} />
-        }
+        glossaryTrigger={<GlossaryTrigger {...GLOSSARY.negativeCost} />}
       >
-        {/* Budget Input */}
+        {/* Input Section */}
         <div>
           <div className="mb-3">
             <div className="flex items-baseline gap-2">
@@ -101,15 +73,21 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
               <span className="text-xs text-text-dim italic">aka "Negative Cost"</span>
             </div>
           </div>
+
           <div
             className={cn(
-              "flex items-center rounded-md transition-all",
+              "flex items-center rounded-md transition-all relative", // Added relative for icon positioning
               "bg-bg-surface border",
-              isFocused ? "border-border-active shadow-focus" : isCompleted ? "border-gold-muted" : "border-border-default"
+              isFocused
+                ? "border-border-active shadow-focus"
+                : isCompleted
+                  ? "border-gold/50" // FIX 2: Softer gold border when done
+                  : "border-border-default"
             )}
             style={{ borderRadius: 'var(--radius-md)' }}
           >
             <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
+
             <input
               ref={budgetInputRef}
               type="text"
@@ -120,16 +98,49 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
               onBlur={() => setIsFocused(false)}
               onKeyDown={handleKeyDown}
               placeholder="750,000"
-              className="flex-1 bg-transparent py-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim placeholder:text-base tabular-nums"
+              className="flex-1 bg-transparent py-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim placeholder:text-base tabular-nums pr-12" // Added pr-12 to prevent text hitting the icon
             />
-            {isCompleted && (
-              <span className="pr-4 text-xl">✅</span>
-            )}
+
+            {/* FIX 3: Replaced Emoji with Lucide Icon */}
+            <div className={cn(
+              "absolute right-4 transition-all duration-300 transform",
+              isCompleted ? "opacity-100 scale-100" : "opacity-0 scale-50"
+            )}>
+              <Check className="w-6 h-6 text-gold" />
+            </div>
           </div>
+
           <p className="mt-2 text-sm text-text-dim">
             Enter your full production budget and hit Next
           </p>
         </div>
+
+        {/*
+           FIX 4: Moved "Start Here" instructions BELOW the input.
+           This prevents the input from jumping around when you type.
+        */}
+        {!isCompleted && (
+          <div
+            className="mt-8 p-5 border border-gold/20 bg-gold/5 animate-fade-in"
+            style={{ borderRadius: 'var(--radius-lg)' }}
+          >
+            <h3 className="text-sm font-bold text-gold mb-2 uppercase tracking-wide flex items-center gap-2">
+              👉 Quick Tip
+            </h3>
+            <p className="text-sm text-text-primary leading-relaxed mb-3">
+              This is your "negative cost." It's the total amount of money it takes to get the film "in the can" and finished.
+            </p>
+
+            <div className="mt-3 pt-3 border-t border-gold/10">
+              <p className="text-xs text-text-dim mb-2">Example amounts:</p>
+              <div className="flex gap-2 flex-wrap">
+                <button onClick={() => onUpdateInput('budget', 250000)} className="font-mono text-xs text-text-mid bg-bg-void border border-white/10 px-2 py-1 rounded hover:border-gold/50 transition-colors">$250k</button>
+                <button onClick={() => onUpdateInput('budget', 750000)} className="font-mono text-xs text-text-mid bg-bg-void border border-white/10 px-2 py-1 rounded hover:border-gold/50 transition-colors">$750k</button>
+                <button onClick={() => onUpdateInput('budget', 2500000)} className="font-mono text-xs text-text-mid bg-bg-void border border-white/10 px-2 py-1 rounded hover:border-gold/50 transition-colors">$2.5M</button>
+              </div>
+            </div>
+          </div>
+        )}
       </ChapterCard>
     </div>
   );


### PR DESCRIPTION
MAJOR FIXES by user feedback:

1. STABLE LAYOUT - Fixed "jumping" behavior:
   - Moved "Quick Tip" box BELOW input (was above)
   - Input position now stays fixed when typing
   - No more jarring layout shifts

2. PROFESSIONAL ICON:
   - Replaced emoji ✅ with Lucide Check icon
   - Absolute positioning prevents text overlap
   - Smooth fade-in animation (scale + opacity)

3. INTERACTIVE EXAMPLES - GENIUS:
   - Made example amounts ($250k, $750k, $2.5M) clickable
   - Users can instantly test values without typing
   - Huge UX improvement for first-time users

4. BETTER MESSAGING:
   - Changed "Start Here" to "Quick Tip" (less bossy)
   - Clearer explanation of "negative cost"

5. POLISH:
   - Added pr-12 to input (prevents text overlap with icon)
   - Softer gold border (border-gold/50)
   - Better spacing (space-y-6)

This refactor eliminates the "nutty" jumping behavior and makes the Budget section significantly more user-friendly.

Credit: User identified and fixed the layout issue I missed.

https://claude.ai/code/session_01UpxBWjMS3uUaL8tsoimTav