### PR TITLE
feat: Apply mini-app architecture to Budget & Deal tabs

### DIFF
--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from "react";
-import { DollarSign, ArrowRight, Check, X } from "lucide-react";
+import { DollarSign, ArrowRight, ArrowLeft, Check, X } from "lucide-react";
 import { WaterfallInputs } from "@/lib/waterfall";
 import { cn } from "@/lib/utils";
 
 interface BudgetInputProps {
   inputs: WaterfallInputs;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onBack?: () => void;
   onNext: () => void;
 }
 
@@ -15,7 +16,7 @@ interface BudgetInputProps {
  * Step 1 of Budget Tab: Collect the production budget
  * with quick amount buttons and validation.
  */
-const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
+const BudgetInput = ({ inputs, onUpdateInput, onBack, onNext }: BudgetInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -75,6 +76,24 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
 
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* Step Label + Back Button */}
+      <div className="flex items-center justify-between">
+        {onBack ? (
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-xs text-text-dim hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            <span>Back</span>
+          </button>
+        ) : (
+          <div />
+        )}
+        <span className="text-xs font-mono text-gold/70 uppercase tracking-widest">
+          Step 1 of 2 • Budget
+        </span>
+      </div>
+
       {/* Hero Header */}
       <div className="text-center mb-6">
         <div className="relative inline-block mb-4">
@@ -87,10 +106,10 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
             }}
           />
           <div 
-            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <DollarSign className="w-7 h-7 text-gold" />
+            <DollarSign className="w-8 h-8 text-gold" />
           </div>
         </div>
 

--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -1,0 +1,214 @@
+import { useState, useRef, useEffect } from "react";
+import { DollarSign, ArrowRight, Check, X } from "lucide-react";
+import { WaterfallInputs } from "@/lib/waterfall";
+import { cn } from "@/lib/utils";
+
+interface BudgetInputProps {
+  inputs: WaterfallInputs;
+  onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onNext: () => void;
+}
+
+/**
+ * BudgetInput - Budget data collection screen
+ * 
+ * Step 1 of Budget Tab: Collect the production budget
+ * with quick amount buttons and validation.
+ */
+const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus on mount
+  useEffect(() => {
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 100);
+  }, []);
+
+  const formatValue = (value: number | undefined) => {
+    if (value === undefined || value === 0) return '';
+    return value.toLocaleString();
+  };
+
+  const parseValue = (str: string) => {
+    return parseInt(str.replace(/[^0-9]/g, '')) || 0;
+  };
+
+  const handleFocus = () => {
+    setIsFocused(true);
+    setTimeout(() => {
+      inputRef.current?.select();
+    }, 0);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      inputRef.current?.blur();
+      if (inputs.budget > 0) {
+        setTimeout(() => onNext(), 100);
+      }
+    }
+  };
+
+  const handleClear = () => {
+    onUpdateInput('budget', 0);
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  };
+
+  const handleQuickAmount = (amount: number) => {
+    onUpdateInput('budget', amount);
+  };
+
+  const isCompleted = inputs.budget > 0;
+
+  const quickAmounts = [
+    { value: 250000, label: '$250K' },
+    { value: 750000, label: '$750K' },
+    { value: 1500000, label: '$1.5M' },
+    { value: 2500000, label: '$2.5M' },
+    { value: 5000000, label: '$5M' },
+  ];
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      {/* Hero Header */}
+      <div className="text-center mb-6">
+        <div className="relative inline-block mb-4">
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'radial-gradient(circle, rgba(212, 175, 55, 0.15) 0%, transparent 70%)',
+              filter: 'blur(15px)',
+              transform: 'scale(2)',
+            }}
+          />
+          <div 
+            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            style={{ borderRadius: 'var(--radius-md)' }}
+          >
+            <DollarSign className="w-7 h-7 text-gold" />
+          </div>
+        </div>
+
+        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+          Production Budget
+        </h2>
+        <p className="text-white/50 text-xs max-w-xs mx-auto">
+          Enter your total negative cost
+        </p>
+      </div>
+
+      {/* Main Input Card */}
+      <div className="matte-section overflow-hidden">
+        {/* Section header */}
+        <div className="matte-section-header px-5 py-3 flex items-center justify-between">
+          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+            Total Budget
+          </span>
+          {isCompleted && (
+            <span className="text-xs text-gold font-mono flex items-center gap-1">
+              <Check className="w-3 h-3" />
+            </span>
+          )}
+        </div>
+
+        {/* Budget Input */}
+        <div className="p-5">
+          <div
+            className={cn(
+              "flex items-center transition-all relative",
+              "bg-bg-surface border",
+              isFocused
+                ? "border-border-active shadow-focus"
+                : isCompleted
+                  ? "border-gold/50"
+                  : "border-border-default"
+            )}
+            style={{ borderRadius: 'var(--radius-md)' }}
+          >
+            <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
+
+            <input
+              ref={inputRef}
+              type="text"
+              inputMode="numeric"
+              value={formatValue(inputs.budget)}
+              onChange={(e) => onUpdateInput('budget', parseValue(e.target.value))}
+              onFocus={handleFocus}
+              onBlur={() => setIsFocused(false)}
+              onKeyDown={handleKeyDown}
+              placeholder="750,000"
+              className="flex-1 bg-transparent py-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim placeholder:text-base tabular-nums pr-2"
+            />
+
+            {/* Clear button */}
+            {isCompleted && (
+              <button
+                onClick={handleClear}
+                className="mr-3 p-1.5 text-text-dim hover:text-white hover:bg-white/10 rounded transition-colors"
+                aria-label="Clear budget"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+
+          <p className="mt-2 text-xs text-text-dim text-center">
+            Enter your full production budget
+          </p>
+        </div>
+
+        {/* Quick Amounts */}
+        <div className="px-5 pb-5">
+          <div
+            className="p-4 border border-gold/20 bg-gold/[0.03]"
+            style={{ borderRadius: 'var(--radius-lg)' }}
+          >
+            <p className="text-xs text-text-dim mb-3 uppercase tracking-wide font-medium text-center">
+              Quick amounts
+            </p>
+            <div className="flex gap-2 flex-wrap justify-center">
+              {quickAmounts.map((qa) => (
+                <button
+                  key={qa.value}
+                  onClick={() => handleQuickAmount(qa.value)}
+                  className={cn(
+                    "font-mono text-xs px-3 py-2 rounded transition-colors border",
+                    inputs.budget === qa.value
+                      ? "bg-gold/20 border-gold text-gold"
+                      : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
+                  )}
+                >
+                  {qa.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Continue Button */}
+      {isCompleted && (
+        <button
+          onClick={onNext}
+          className={cn(
+            "w-full py-4 flex items-center justify-center gap-3",
+            "bg-gold/10 border border-gold/30 text-gold",
+            "hover:bg-gold/20 hover:border-gold/50 transition-all",
+            "active:scale-[0.98]"
+          )}
+          style={{ borderRadius: 'var(--radius-md)' }}
+        >
+          <span className="text-sm font-bold uppercase tracking-wider">Continue to Capital Stack</span>
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BudgetInput;

--- a/src/components/calculator/budget/BudgetOverviewWiki.tsx
+++ b/src/components/calculator/budget/BudgetOverviewWiki.tsx
@@ -1,0 +1,50 @@
+import { DollarSign, Sparkles, Lightbulb, Target } from "lucide-react";
+import { WikiScreen } from "../stack";
+
+interface BudgetOverviewWikiProps {
+  onContinue: () => void;
+}
+
+/**
+ * BudgetOverviewWiki - Introduction to Negative Cost concept
+ * 
+ * Step 0 of Budget Tab: Educate user on what the budget means
+ * before they enter their number.
+ */
+const BudgetOverviewWiki = ({ onContinue }: BudgetOverviewWikiProps) => {
+  return (
+    <WikiScreen
+      icon={DollarSign}
+      title="What is the"
+      titleHighlight="Negative Cost?"
+      subtitle="The foundation of every financial projection for your film."
+      stepLabel="Step 1 of 4 / Budget"
+      sections={[
+        {
+          icon: DollarSign,
+          title: "Your Total Production Budget",
+          content: "The negative cost is every dollar it takes to get your film from development through final delivery. It's called 'negative' because it's the cost to create the negative (the original master).",
+          highlight: "This number is the foundation of every investor projection.",
+        },
+        {
+          icon: Sparkles,
+          title: "What's Typically Included",
+          content: "Development, pre-production, principal photography, post-production, music licensing, deliverables, insurance, legal, and contingency.",
+          highlight: "It does NOT include marketing or distribution costs—those come later.",
+        },
+        {
+          icon: Target,
+          title: "Why Investors Care",
+          content: "Your budget determines your breakeven point—the minimum sale price needed to pay everyone back. A lower budget means a lower bar to clear.",
+          highlight: "Investors want to know you can make a sellable film at a realistic price.",
+        },
+      ]}
+      proTip={{
+        text: "If you don't have a locked budget yet, use a realistic estimate. You can always adjust—the goal is to understand how the math works at different budget levels.",
+      }}
+      onContinue={onContinue}
+    />
+  );
+};
+
+export default BudgetOverviewWiki;

--- a/src/components/calculator/budget/index.ts
+++ b/src/components/calculator/budget/index.ts
@@ -1,0 +1,11 @@
+// Budget Mini-App Components
+// Step-based architecture matching Stack tab pattern
+
+// Reuse WikiScreen from stack for consistency
+export { WikiScreen } from '../stack';
+
+// Step 0: Overview
+export { default as BudgetOverviewWiki } from './BudgetOverviewWiki';
+
+// Step 1: Input
+export { default as BudgetInput } from './BudgetInput';

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -1,0 +1,265 @@
+import { useState, useRef, useEffect } from "react";
+import { Handshake, ArrowRight, Check, Target, TrendingUp, TrendingDown } from "lucide-react";
+import { WaterfallInputs, GuildState, formatCompactCurrency, calculateBreakeven } from "@/lib/waterfall";
+import { CapitalSelections } from "../steps/CapitalSelectStep";
+import { cn } from "@/lib/utils";
+
+interface DealInputProps {
+  inputs: WaterfallInputs;
+  guilds: GuildState;
+  selections: CapitalSelections;
+  onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onNext: () => void;
+}
+
+/**
+ * DealInput - Acquisition price input screen
+ * 
+ * Step 1 of Deal Tab: Collect acquisition/revenue projection
+ * with breakeven context and status indicator.
+ */
+const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealInputProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus on mount
+  useEffect(() => {
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 100);
+  }, []);
+
+  const formatValue = (value: number | undefined) => {
+    if (value === undefined || value === 0) return '';
+    return value.toLocaleString();
+  };
+
+  const parseValue = (str: string) => {
+    return parseInt(str.replace(/[^0-9]/g, '')) || 0;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      inputRef.current?.blur();
+      if (inputs.revenue > 0) {
+        setTimeout(() => onNext(), 100);
+      }
+    }
+  };
+
+  // Calculate breakeven
+  const breakeven = calculateBreakeven(inputs, guilds, selections);
+  const hasRevenue = inputs.revenue > 0;
+  const cushion = inputs.revenue - breakeven;
+  const isAboveBreakeven = cushion > 0;
+  const percentAbove = breakeven > 0 ? ((inputs.revenue - breakeven) / breakeven) * 100 : 0;
+
+  // Quick scenario buttons based on budget
+  const budget = inputs.budget || 1000000;
+  const scenarios = [
+    { label: '100%', multiplier: 1.0, desc: 'At budget' },
+    { label: '115%', multiplier: 1.15, desc: 'Solid' },
+    { label: '130%', multiplier: 1.3, desc: 'Strong' },
+    { label: '150%', multiplier: 1.5, desc: 'Exceptional' },
+  ];
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      {/* Hero Header */}
+      <div className="text-center mb-6">
+        <div className="relative inline-block mb-4">
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'radial-gradient(circle, rgba(212, 175, 55, 0.15) 0%, transparent 70%)',
+              filter: 'blur(15px)',
+              transform: 'scale(2)',
+            }}
+          />
+          <div 
+            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            style={{ borderRadius: 'var(--radius-md)' }}
+          >
+            <Handshake className="w-7 h-7 text-gold" />
+          </div>
+        </div>
+
+        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+          Acquisition Price
+        </h2>
+        <p className="text-white/50 text-xs max-w-xs mx-auto">
+          What the distributor pays for your film
+        </p>
+      </div>
+
+      {/* Breakeven Context Card */}
+      {Number.isFinite(breakeven) && breakeven > 0 && (
+        <div
+          className="p-4 border border-border-default bg-bg-surface flex items-center justify-between"
+          style={{ borderRadius: 'var(--radius-md)' }}
+        >
+          <div className="flex items-center gap-3">
+            <Target className="w-5 h-5 text-gold/60" />
+            <div>
+              <span className="text-xs font-bold uppercase tracking-wider text-text-dim block">Your Breakeven</span>
+              <span className="font-mono text-lg text-text-primary">
+                {formatCompactCurrency(breakeven)}
+              </span>
+            </div>
+          </div>
+          <div className="text-right">
+            <span className="text-xs text-text-dim block">Minimum to recoup</span>
+            <span className="text-xs text-text-dim">all costs + returns</span>
+          </div>
+        </div>
+      )}
+
+      {/* Main Input Card */}
+      <div className="matte-section overflow-hidden">
+        {/* Section header */}
+        <div className="matte-section-header px-5 py-3 flex items-center justify-between">
+          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+            Acquisition Amount
+          </span>
+          {hasRevenue && (
+            <span className="text-xs text-gold font-mono flex items-center gap-1">
+              <Check className="w-3 h-3" />
+            </span>
+          )}
+        </div>
+
+        {/* Revenue Input */}
+        <div className="p-5">
+          <div
+            className={cn(
+              "flex items-center transition-all relative",
+              "bg-bg-surface border",
+              isFocused
+                ? "border-border-active shadow-focus"
+                : hasRevenue
+                  ? "border-gold/50"
+                  : "border-border-default"
+            )}
+            style={{ borderRadius: 'var(--radius-md)' }}
+          >
+            <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
+
+            <input
+              ref={inputRef}
+              type="text"
+              inputMode="numeric"
+              value={formatValue(inputs.revenue)}
+              onChange={(e) => onUpdateInput('revenue', parseValue(e.target.value))}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              onKeyDown={handleKeyDown}
+              placeholder="3,500,000"
+              className="flex-1 bg-transparent py-4 pr-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim tabular-nums"
+            />
+          </div>
+
+          <p className="mt-2 text-xs text-text-dim text-center">
+            Enter an acquisition price to see your position
+          </p>
+        </div>
+
+        {/* Status Indicator */}
+        {hasRevenue && Number.isFinite(breakeven) && (
+          <div
+            className={cn(
+              "mx-5 mb-5 p-4 border flex items-center justify-between",
+              isAboveBreakeven
+                ? "border-status-success bg-[rgba(0,255,100,0.08)]"
+                : "border-status-danger bg-[rgba(255,82,82,0.08)]"
+            )}
+            style={{ borderRadius: 'var(--radius-md)' }}
+          >
+            <div className="flex items-center gap-3">
+              {isAboveBreakeven ? (
+                <TrendingUp className="w-5 h-5 text-status-success" />
+              ) : (
+                <TrendingDown className="w-5 h-5 text-status-danger" />
+              )}
+              <div>
+                <p className={cn(
+                  "text-xs font-bold uppercase tracking-wider mb-0.5",
+                  isAboveBreakeven ? "text-status-success" : "text-status-danger"
+                )}>
+                  {isAboveBreakeven ? 'Above Breakeven' : 'Below Breakeven'}
+                </p>
+                <p className="text-sm font-mono text-text-primary">
+                  {isAboveBreakeven
+                    ? `+${formatCompactCurrency(Math.abs(cushion))} cushion`
+                    : `${formatCompactCurrency(Math.abs(cushion))} shortfall`}
+                </p>
+              </div>
+            </div>
+            {isAboveBreakeven && percentAbove > 0 && (
+              <span className="text-2xl font-mono text-status-success">
+                +{percentAbove.toFixed(0)}%
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Quick Scenarios */}
+        <div className="px-5 pb-5">
+          <div
+            className="p-4 border border-gold/20 bg-gold/[0.03]"
+            style={{ borderRadius: 'var(--radius-lg)' }}
+          >
+            <p className="text-xs text-text-dim mb-3 uppercase tracking-wide font-medium text-center">
+              Quick scenarios (% of budget)
+            </p>
+            <div className="grid grid-cols-4 gap-2">
+              {scenarios.map((s) => {
+                const value = Math.round(budget * s.multiplier);
+                const isSelected = inputs.revenue === value;
+                return (
+                  <button
+                    key={s.label}
+                    onClick={() => onUpdateInput('revenue', value)}
+                    className={cn(
+                      "text-center p-2 rounded transition-colors border",
+                      isSelected
+                        ? "bg-gold/20 border-gold"
+                        : "bg-bg-void border-white/10 hover:border-gold/50"
+                    )}
+                  >
+                    <span className={cn(
+                      "font-mono text-sm block",
+                      isSelected ? "text-gold" : "text-text-mid"
+                    )}>
+                      {s.label}
+                    </span>
+                    <span className="text-[9px] text-text-dim">{s.desc}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Continue Button */}
+      {hasRevenue && (
+        <button
+          onClick={onNext}
+          className={cn(
+            "w-full py-4 flex items-center justify-center gap-3",
+            "bg-gold/10 border border-gold/30 text-gold",
+            "hover:bg-gold/20 hover:border-gold/50 transition-all",
+            "active:scale-[0.98]"
+          )}
+          style={{ borderRadius: 'var(--radius-md)' }}
+        >
+          <span className="text-sm font-bold uppercase tracking-wider">See the Waterfall</span>
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DealInput;

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Handshake, ArrowRight, Check, Target, TrendingUp, TrendingDown } from "lucide-react";
+import { Handshake, ArrowRight, ArrowLeft, Check, Target, TrendingUp, TrendingDown } from "lucide-react";
 import { WaterfallInputs, GuildState, formatCompactCurrency, calculateBreakeven } from "@/lib/waterfall";
 import { CapitalSelections } from "../steps/CapitalSelectStep";
 import { cn } from "@/lib/utils";
@@ -9,6 +9,7 @@ interface DealInputProps {
   guilds: GuildState;
   selections: CapitalSelections;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onBack?: () => void;
   onNext: () => void;
 }
 
@@ -18,7 +19,7 @@ interface DealInputProps {
  * Step 1 of Deal Tab: Collect acquisition/revenue projection
  * with breakeven context and status indicator.
  */
-const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealInputProps) => {
+const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }: DealInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -66,6 +67,24 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
 
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* Step Label + Back Button */}
+      <div className="flex items-center justify-between">
+        {onBack ? (
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-xs text-text-dim hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            <span>Back</span>
+          </button>
+        ) : (
+          <div />
+        )}
+        <span className="text-xs font-mono text-gold/70 uppercase tracking-widest">
+          Step 1 of 2 • Deal
+        </span>
+      </div>
+
       {/* Hero Header */}
       <div className="text-center mb-6">
         <div className="relative inline-block mb-4">
@@ -78,10 +97,10 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
             }}
           />
           <div 
-            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <Handshake className="w-7 h-7 text-gold" />
+            <Handshake className="w-8 h-8 text-gold" />
           </div>
         </div>
 

--- a/src/components/calculator/deal/DealOverviewWiki.tsx
+++ b/src/components/calculator/deal/DealOverviewWiki.tsx
@@ -1,0 +1,56 @@
+import { DollarSign, Target, TrendingUp, Handshake } from "lucide-react";
+import { WikiScreen } from "../stack";
+
+interface DealOverviewWikiProps {
+  onContinue: () => void;
+}
+
+/**
+ * DealOverviewWiki - Introduction to Acquisition/Deal concepts
+ * 
+ * Step 0 of Deal Tab: Educate user on acquisition price and breakeven
+ * before they enter their revenue projection.
+ */
+const DealOverviewWiki = ({ onContinue }: DealOverviewWikiProps) => {
+  return (
+    <WikiScreen
+      icon={Handshake}
+      title="Modeling the"
+      titleHighlight="Acquisition Deal"
+      subtitle="Understanding what distributors pay—and what you need."
+      stepLabel="Step 3 of 4 / Deal Modeling"
+      sections={[
+        {
+          icon: DollarSign,
+          title: "The Acquisition Price",
+          content: "When a streamer or distributor buys your film, they pay an acquisition price—a flat fee for distribution rights.",
+          highlight: "This number determines whether your investors get paid.",
+        },
+        {
+          icon: Target,
+          title: "Understanding Breakeven",
+          content: "Your breakeven is the minimum sale price needed to pay back all costs: sales fees, guild residuals, marketing, debt service, and investor returns.",
+          highlight: "We've already calculated this from your capital stack.",
+        },
+        {
+          icon: TrendingUp,
+          title: "How Distributors Think",
+          content: "Distributors buy films they believe will generate more than they pay. They assess genre, cast, festival buzz, and comparable titles.",
+          highlight: "A $1.5M acquisition for a $1M film is only possible if they expect $3M+ in revenue.",
+        },
+        {
+          icon: Handshake,
+          title: "Test Different Scenarios",
+          content: "Enter an acquisition price to see if it clears your breakeven. Try different numbers to understand your negotiating position.",
+          highlight: "What's the minimum you can accept? What's your dream scenario?",
+        },
+      ]}
+      proTip={{
+        text: "Most indie deals close between 100-130% of budget. Exceptional films with festival buzz or star power can command more. If your breakeven requires 150%+ of budget, you may need to restructure your capital stack.",
+      }}
+      onContinue={onContinue}
+    />
+  );
+};
+
+export default DealOverviewWiki;

--- a/src/components/calculator/deal/index.ts
+++ b/src/components/calculator/deal/index.ts
@@ -1,0 +1,11 @@
+// Deal Mini-App Components
+// Step-based architecture matching Stack/Budget pattern
+
+// Reuse WikiScreen from stack for consistency
+export { WikiScreen } from '../stack';
+
+// Step 0: Overview
+export { default as DealOverviewWiki } from './DealOverviewWiki';
+
+// Step 1: Input
+export { default as DealInput } from './DealInput';

--- a/src/components/calculator/shared/StepIndicator.tsx
+++ b/src/components/calculator/shared/StepIndicator.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+
+interface StepIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+  labels?: string[];
+  className?: string;
+}
+
+/**
+ * StepIndicator - Visual progress through multi-step flows
+ * 
+ * Displays dots/segments to show where user is in the flow.
+ * Uses gold for completed/active, dim for upcoming.
+ */
+const StepIndicator = ({ 
+  currentStep, 
+  totalSteps, 
+  labels,
+  className 
+}: StepIndicatorProps) => {
+  return (
+    <div className={cn("flex flex-col items-center gap-2", className)}>
+      {/* Step label */}
+      {labels && labels[currentStep] && (
+        <span className="text-xs font-mono text-gold/80 uppercase tracking-widest">
+          {labels[currentStep]}
+        </span>
+      )}
+      
+      {/* Progress dots */}
+      <div className="flex items-center gap-2">
+        {Array.from({ length: totalSteps }).map((_, index) => {
+          const isCompleted = index < currentStep;
+          const isActive = index === currentStep;
+          
+          return (
+            <div
+              key={index}
+              className={cn(
+                "h-1.5 rounded-full transition-all duration-300",
+                isActive 
+                  ? "w-6 bg-gold" 
+                  : isCompleted
+                    ? "w-3 bg-gold/60"
+                    : "w-3 bg-white/20"
+              )}
+            />
+          );
+        })}
+      </div>
+      
+      {/* Numeric indicator */}
+      <span className="text-[10px] text-text-dim font-mono">
+        Step {currentStep + 1} of {totalSteps}
+      </span>
+    </div>
+  );
+};
+
+export default StepIndicator;

--- a/src/components/calculator/shared/index.ts
+++ b/src/components/calculator/shared/index.ts
@@ -1,0 +1,1 @@
+export { default as StepIndicator } from './StepIndicator';

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -1,254 +1,82 @@
+import { useState, useCallback } from "react";
 import { WaterfallInputs, GuildState } from "@/lib/waterfall";
-import { useState, useRef, useEffect } from "react";
-import { cn } from "@/lib/utils";
-import ChapterCard from "../ChapterCard";
-import GlossaryTrigger, { GLOSSARY } from "../GlossaryTrigger";
-import { Sparkles, X, DollarSign, FileText, Lightbulb, Info } from "lucide-react";
+import { useHaptics } from "@/hooks/use-haptics";
+
+// Import budget mini-app components
+import { BudgetOverviewWiki, BudgetInput } from "../budget";
 
 interface BudgetTabProps {
   inputs: WaterfallInputs;
   guilds: GuildState;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
   onToggleGuild: (guild: keyof GuildState) => void;
-  onAdvance?: () => void;
+  onAdvance?: () => void; // Called when user completes Budget and wants to go to Stack
 }
 
+/**
+ * BudgetTab - Step Router (Mini-App Architecture)
+ * 
+ * This tab manages navigation between isolated mini-app screens.
+ * Each screen has ONE job: educate (Wiki) or collect data (Input).
+ * 
+ * Step Map:
+ * 0 = BudgetOverviewWiki (intro to negative cost concept)
+ * 1 = BudgetInput (enter budget + quick amounts)
+ * 
+ * On completion, advances to Stack tab.
+ */
 const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
-  const [isFocused, setIsFocused] = useState(false);
-  const budgetInputRef = useRef<HTMLInputElement>(null);
+  const haptics = useHaptics();
+  
+  // Start at step 0 if no budget, otherwise show input
+  const [currentStep, setCurrentStep] = useState(() => {
+    return inputs.budget > 0 ? 1 : 0;
+  });
 
-  // Auto-focus on mount if empty
-  useEffect(() => {
-    if (inputs.budget === 0) {
-      budgetInputRef.current?.focus();
+  // Navigation helpers
+  const goToStep = useCallback((step: number) => {
+    haptics.light();
+    setCurrentStep(step);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [haptics]);
+
+  const nextStep = useCallback(() => {
+    goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  // Handle completion - advance to Stack tab
+  const handleComplete = useCallback(() => {
+    haptics.medium();
+    if (onAdvance) {
+      onAdvance();
     }
-  }, []);
+  }, [haptics, onAdvance]);
 
-  const formatValue = (value: number | undefined) => {
-    if (value === undefined || value === 0) return '';
-    return value.toLocaleString();
-  };
+  // Render the current step
+  const renderStep = () => {
+    switch (currentStep) {
+      // Step 0: Overview Wiki
+      case 0:
+        return <BudgetOverviewWiki onContinue={nextStep} />;
 
-  const parseValue = (str: string) => {
-    return parseInt(str.replace(/[^0-9]/g, '')) || 0;
-  };
+      // Step 1: Budget Input
+      case 1:
+        return (
+          <BudgetInput
+            inputs={inputs}
+            onUpdateInput={onUpdateInput}
+            onNext={handleComplete}
+          />
+        );
 
-  const handleFocus = () => {
-    setIsFocused(true);
-    setTimeout(() => {
-      budgetInputRef.current?.select();
-    }, 0);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      budgetInputRef.current?.blur();
-      if (inputs.budget > 0 && onAdvance) {
-        setTimeout(() => onAdvance(), 100);
-      }
+      default:
+        return <BudgetOverviewWiki onContinue={nextStep} />;
     }
   };
-
-  const handleClear = () => {
-    onUpdateInput('budget', 0);
-    setTimeout(() => {
-      budgetInputRef.current?.focus();
-    }, 0);
-  };
-
-  const isCompleted = inputs.budget > 0;
 
   return (
-    <div className="space-y-6 pb-8">
-      {/* Wiki-Style Onboarding Guide - Shows only when budget is empty */}
-      {!isCompleted && (
-        <div className="space-y-4 animate-fade-in">
-          {/* Header */}
-          <div className="flex items-center space-x-2 text-gold/80 text-xs font-mono uppercase tracking-widest">
-            <FileText className="w-3 h-3" />
-            <span>Step 1 of 4 / Budget</span>
-          </div>
-
-          {/* Main Guide Card */}
-          <div
-            className="bg-bg-surface border border-border-default p-5 space-y-5"
-            style={{ borderRadius: 'var(--radius-lg)' }}
-          >
-            {/* Section 1: What This Is */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <DollarSign className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">What is the "Negative Cost"?</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  The negative cost is your <span className="text-white font-medium">total production budget</span>—every dollar it takes to get your film from development through final delivery. It's called "negative" because it's the cost to create the negative (the original print). This number is the foundation of every financial projection.
-                </p>
-              </div>
-            </div>
-
-            {/* Section 2: What's Included */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <Sparkles className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">What's typically included</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  Development, pre-production, principal photography, post-production, music licensing, deliverables, insurance, legal, and contingency. <span className="text-white font-medium">It does NOT include marketing or distribution costs</span>—those come later.
-                </p>
-              </div>
-            </div>
-
-            {/* Section 3: Why It Matters */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <Lightbulb className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">Why investors care</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  Your budget determines your <span className="text-white font-medium">breakeven point</span>—the minimum sale price needed to pay everyone back. A lower budget means a lower bar to clear. Investors want to know you can make a sellable film at a price the market will pay.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pro Tip Callout */}
-          <div className="bg-blue-900/10 border-l-4 border-blue-500/50 p-4 flex items-start space-x-3" style={{ borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}>
-            <Info className="w-4 h-4 text-blue-400 mt-0.5 flex-shrink-0" />
-            <div className="text-xs text-blue-200/80 leading-relaxed">
-              <span className="font-bold text-blue-200">Pro Tip:</span> If you don't have a locked budget yet, use a realistic estimate. You can always adjust—the goal here is to understand how the math works at different budget levels.
-            </div>
-          </div>
-        </div>
-      )}
-
-      <ChapterCard
-        chapter="01"
-        title="BUDGET"
-        isActive={true}
-        glossaryTrigger={<GlossaryTrigger {...GLOSSARY.negativeCost} />}
-      >
-        {/* Input Section */}
-        <div>
-          <div className="mb-3">
-            <div className="flex items-baseline gap-2">
-              <span className="text-sm font-semibold text-text-primary uppercase tracking-wide">Production Budget</span>
-              <span className="text-xs text-text-dim italic">aka "Negative Cost"</span>
-            </div>
-          </div>
-
-          <div
-            className={cn(
-              "flex items-center rounded-md transition-all relative",
-              "bg-bg-surface border",
-              isFocused
-                ? "border-border-active shadow-focus"
-                : isCompleted
-                  ? "border-gold/50"
-                  : "border-border-default"
-            )}
-            style={{ borderRadius: 'var(--radius-md)' }}
-          >
-            <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
-
-            <input
-              ref={budgetInputRef}
-              type="text"
-              inputMode="numeric"
-              value={formatValue(inputs.budget)}
-              onChange={(e) => onUpdateInput('budget', parseValue(e.target.value))}
-              onFocus={handleFocus}
-              onBlur={() => setIsFocused(false)}
-              onKeyDown={handleKeyDown}
-              placeholder="750,000"
-              className="flex-1 bg-transparent py-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim placeholder:text-base tabular-nums pr-2"
-            />
-
-            {/* Clear button - shows when there's a value */}
-            {isCompleted && (
-              <button
-                onClick={handleClear}
-                className="mr-3 p-1.5 text-text-dim hover:text-white hover:bg-white/10 rounded transition-colors"
-                aria-label="Clear budget"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            )}
-          </div>
-
-          <p className="mt-2 text-sm text-text-dim">
-            Enter your full production budget and hit Next
-          </p>
-        </div>
-
-        {/* Quick Amounts - ALWAYS visible */}
-        <div
-          className="mt-6 p-4 border border-gold/20 bg-gold/[0.03]"
-          style={{ borderRadius: 'var(--radius-lg)' }}
-        >
-          <p className="text-xs text-text-dim mb-3 uppercase tracking-wide font-medium">Quick amounts:</p>
-          <div className="flex gap-2 flex-wrap">
-            <button 
-              onClick={() => onUpdateInput('budget', 250000)} 
-              className={cn(
-                "font-mono text-xs px-3 py-2 rounded transition-colors border",
-                inputs.budget === 250000 
-                  ? "bg-gold/20 border-gold text-gold" 
-                  : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
-              )}
-            >
-              $250k
-            </button>
-            <button 
-              onClick={() => onUpdateInput('budget', 750000)} 
-              className={cn(
-                "font-mono text-xs px-3 py-2 rounded transition-colors border",
-                inputs.budget === 750000 
-                  ? "bg-gold/20 border-gold text-gold" 
-                  : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
-              )}
-            >
-              $750k
-            </button>
-            <button 
-              onClick={() => onUpdateInput('budget', 1500000)} 
-              className={cn(
-                "font-mono text-xs px-3 py-2 rounded transition-colors border",
-                inputs.budget === 1500000 
-                  ? "bg-gold/20 border-gold text-gold" 
-                  : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
-              )}
-            >
-              $1.5M
-            </button>
-            <button 
-              onClick={() => onUpdateInput('budget', 2500000)} 
-              className={cn(
-                "font-mono text-xs px-3 py-2 rounded transition-colors border",
-                inputs.budget === 2500000 
-                  ? "bg-gold/20 border-gold text-gold" 
-                  : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
-              )}
-            >
-              $2.5M
-            </button>
-            <button 
-              onClick={() => onUpdateInput('budget', 5000000)} 
-              className={cn(
-                "font-mono text-xs px-3 py-2 rounded transition-colors border",
-                inputs.budget === 5000000 
-                  ? "bg-gold/20 border-gold text-gold" 
-                  : "bg-bg-void border-white/10 text-text-mid hover:border-gold/50"
-              )}
-            >
-              $5M
-            </button>
-          </div>
-        </div>
-      </ChapterCard>
+    <div className="pb-8">
+      {renderStep()}
     </div>
   );
 };

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -23,12 +23,13 @@ interface BudgetTabProps {
  * 0 = BudgetOverviewWiki (intro to negative cost concept)
  * 1 = BudgetInput (enter budget + quick amounts)
  * 
+ * Smart Start: Skips wiki if budget already entered.
  * On completion, advances to Stack tab.
  */
 const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
   const haptics = useHaptics();
   
-  // Start at step 0 if no budget, otherwise show input
+  // Smart start: Skip wiki if budget already entered
   const [currentStep, setCurrentStep] = useState(() => {
     return inputs.budget > 0 ? 1 : 0;
   });
@@ -42,6 +43,10 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
 
   const nextStep = useCallback(() => {
     goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  const prevStep = useCallback(() => {
+    goToStep(Math.max(0, currentStep - 1));
   }, [currentStep, goToStep]);
 
   // Handle completion - advance to Stack tab
@@ -65,6 +70,7 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
           <BudgetInput
             inputs={inputs}
             onUpdateInput={onUpdateInput}
+            onBack={prevStep}
             onNext={handleComplete}
           />
         );

--- a/src/components/calculator/tabs/DealTab.tsx
+++ b/src/components/calculator/tabs/DealTab.tsx
@@ -24,12 +24,13 @@ interface DealTabProps {
  * 0 = DealOverviewWiki (intro to acquisition/breakeven concepts)
  * 1 = DealInput (enter revenue + see breakeven status)
  * 
+ * Smart Start: Skips wiki if revenue already entered.
  * On completion, advances to Waterfall tab.
  */
 const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealTabProps) => {
   const haptics = useHaptics();
   
-  // Start at step 0 if no revenue, otherwise show input
+  // Smart start: Skip wiki if revenue already entered
   const [currentStep, setCurrentStep] = useState(() => {
     return inputs.revenue > 0 ? 1 : 0;
   });
@@ -43,6 +44,10 @@ const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealT
 
   const nextStep = useCallback(() => {
     goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  const prevStep = useCallback(() => {
+    goToStep(Math.max(0, currentStep - 1));
   }, [currentStep, goToStep]);
 
   // Handle completion - advance to Waterfall tab
@@ -68,6 +73,7 @@ const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealT
             guilds={guilds}
             selections={selections}
             onUpdateInput={onUpdateInput}
+            onBack={prevStep}
             onNext={handleComplete}
           />
         );

--- a/src/components/calculator/tabs/DealTab.tsx
+++ b/src/components/calculator/tabs/DealTab.tsx
@@ -1,259 +1,85 @@
-import { WaterfallInputs, GuildState, formatCompactCurrency, calculateBreakeven } from "@/lib/waterfall";
+import { useState, useCallback } from "react";
+import { WaterfallInputs, GuildState } from "@/lib/waterfall";
 import { CapitalSelections } from "../steps/CapitalSelectStep";
-import { useState, useRef, useEffect } from "react";
-import { cn } from "@/lib/utils";
-import ChapterCard from "../ChapterCard";
-import GlossaryTrigger, { GLOSSARY } from "../GlossaryTrigger";
-import { DollarSign, FileText, Target, TrendingUp, Handshake, Info } from "lucide-react";
+import { useHaptics } from "@/hooks/use-haptics";
+
+// Import deal mini-app components
+import { DealOverviewWiki, DealInput } from "../deal";
 
 interface DealTabProps {
   inputs: WaterfallInputs;
   guilds: GuildState;
   selections: CapitalSelections;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
-  onAdvance?: () => void;
+  onAdvance?: () => void; // Called when user completes Deal and wants to go to Waterfall
 }
 
+/**
+ * DealTab - Step Router (Mini-App Architecture)
+ * 
+ * This tab manages navigation between isolated mini-app screens.
+ * Each screen has ONE job: educate (Wiki) or collect data (Input).
+ * 
+ * Step Map:
+ * 0 = DealOverviewWiki (intro to acquisition/breakeven concepts)
+ * 1 = DealInput (enter revenue + see breakeven status)
+ * 
+ * On completion, advances to Waterfall tab.
+ */
 const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealTabProps) => {
-  const [isFocused, setIsFocused] = useState(false);
-  const revenueInputRef = useRef<HTMLInputElement>(null);
+  const haptics = useHaptics();
+  
+  // Start at step 0 if no revenue, otherwise show input
+  const [currentStep, setCurrentStep] = useState(() => {
+    return inputs.revenue > 0 ? 1 : 0;
+  });
 
-  // Auto-focus on mount if revenue not entered
-  useEffect(() => {
-    if (inputs.revenue === 0) {
-      revenueInputRef.current?.focus();
+  // Navigation helpers
+  const goToStep = useCallback((step: number) => {
+    haptics.light();
+    setCurrentStep(step);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [haptics]);
+
+  const nextStep = useCallback(() => {
+    goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  // Handle completion - advance to Waterfall tab
+  const handleComplete = useCallback(() => {
+    haptics.medium();
+    if (onAdvance) {
+      onAdvance();
     }
-  }, []);
+  }, [haptics, onAdvance]);
 
-  const formatValue = (value: number | undefined) => {
-    if (value === undefined || value === 0) return '';
-    return value.toLocaleString();
-  };
+  // Render the current step
+  const renderStep = () => {
+    switch (currentStep) {
+      // Step 0: Overview Wiki
+      case 0:
+        return <DealOverviewWiki onContinue={nextStep} />;
 
-  const parseValue = (str: string) => {
-    return parseInt(str.replace(/[^0-9]/g, '')) || 0;
-  };
+      // Step 1: Deal Input
+      case 1:
+        return (
+          <DealInput
+            inputs={inputs}
+            guilds={guilds}
+            selections={selections}
+            onUpdateInput={onUpdateInput}
+            onNext={handleComplete}
+          />
+        );
 
-  // Handle Enter key to advance
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      revenueInputRef.current?.blur();
-      if (inputs.revenue > 0 && onAdvance) {
-        setTimeout(() => onAdvance(), 100);
-      }
+      default:
+        return <DealOverviewWiki onContinue={nextStep} />;
     }
   };
-
-  // Use the algebraic breakeven calculation
-  const breakeven = calculateBreakeven(inputs, guilds, selections);
-
-  // Calculate cushion
-  const cushion = inputs.revenue - breakeven;
-  const isAboveBreakeven = cushion > 0;
-  const percentAbove = breakeven > 0 ? ((inputs.revenue - breakeven) / breakeven) * 100 : 0;
-  const hasRevenue = inputs.revenue > 0;
 
   return (
-    <div className="space-y-6 pb-8">
-      {/* Wiki-Style Onboarding Guide - Shows only when revenue not entered */}
-      {!hasRevenue && (
-        <div className="space-y-4 animate-fade-in">
-          {/* Header */}
-          <div className="flex items-center space-x-2 text-gold/80 text-xs font-mono uppercase tracking-widest">
-            <FileText className="w-3 h-3" />
-            <span>Step 3 of 4 / Deal Modeling</span>
-          </div>
-
-          {/* Main Guide Card */}
-          <div
-            className="bg-bg-surface border border-border-default p-5 space-y-5"
-            style={{ borderRadius: 'var(--radius-lg)' }}
-          >
-            {/* Section 1: What This Is */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <DollarSign className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">What is the "Acquisition Price"?</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  When a streamer or distributor buys your film, they pay an <span className="text-white font-medium">acquisition price</span>—a flat fee for distribution rights. This is the number that determines whether your investors get paid, and whether you see any backend.
-                </p>
-              </div>
-            </div>
-
-            {/* Section 2: What's Your Breakeven */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <Target className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">Understanding breakeven</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  Your <span className="text-white font-medium">breakeven</span> is the minimum sale price needed to pay back all costs: sales fees, guild residuals, marketing expenses, debt service, and investor returns. We've already calculated this based on your capital stack. The question is: will the market pay enough?
-                </p>
-              </div>
-            </div>
-
-            {/* Section 3: The Distributor's Perspective */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <TrendingUp className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">How distributors think</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  Distributors buy films they believe will generate more than they pay. They're assessing <span className="text-white font-medium">genre, cast, festival buzz, and comparable titles</span>. A $1.5M acquisition for a $1M film is great for you—but only if the distributor believes they'll make $3M+ in revenue.
-                </p>
-              </div>
-            </div>
-
-            {/* Section 4: What You'll Do */}
-            <div className="flex items-start space-x-4">
-              <div className="p-2 bg-gold/10" style={{ borderRadius: 'var(--radius-md)' }}>
-                <Handshake className="w-5 h-5 text-gold" />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-white mb-1">Test different scenarios</h3>
-                <p className="text-xs text-text-dim leading-relaxed">
-                  Enter an acquisition price to see if it clears your breakeven. Try different numbers to understand your negotiating position. <span className="text-white font-medium">What's the minimum you can accept? What's your dream scenario?</span>
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Pro Tip Callout */}
-          <div className="bg-blue-900/10 border-l-4 border-blue-500/50 p-4 flex items-start space-x-3" style={{ borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}>
-            <Info className="w-4 h-4 text-blue-400 mt-0.5 flex-shrink-0" />
-            <div className="text-xs text-blue-200/80 leading-relaxed">
-              <span className="font-bold text-blue-200">Pro Tip:</span> Most indie deals close between 100-130% of budget. Exceptional films with festival buzz or star power can command more. If your breakeven requires 150%+ of budget, you may need to restructure your capital stack.
-            </div>
-          </div>
-        </div>
-      )}
-
-      <ChapterCard
-        chapter="03"
-        title="DEAL"
-        isActive={true}
-        glossaryTrigger={
-          <GlossaryTrigger {...GLOSSARY.acquisition} />
-        }
-      >
-        {/* Breakeven context */}
-        <div
-          className="mb-6 p-4 border border-border-default bg-bg-surface flex items-center justify-between"
-          style={{ borderRadius: 'var(--radius-md)' }}
-        >
-          <div>
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-xs font-bold uppercase tracking-wider text-text-dim">Your breakeven</span>
-              <GlossaryTrigger {...GLOSSARY.breakeven} />
-            </div>
-            <span className="font-mono text-xl text-text-primary">
-              {Number.isFinite(breakeven) ? formatCompactCurrency(breakeven) : '—'}
-            </span>
-          </div>
-          <div className="text-right">
-            <span className="text-xs text-text-dim block">Minimum to recoup</span>
-            <span className="text-xs text-text-dim">all costs + returns</span>
-          </div>
-        </div>
-
-        {/* Acquisition Input */}
-        <div className="mb-6">
-          <div className="mb-3">
-            <div className="flex items-baseline gap-2">
-              <span className="text-sm font-semibold text-text-primary uppercase tracking-wide">Acquisition Price</span>
-              <span className="text-xs text-text-dim italic">what the distributor pays</span>
-            </div>
-          </div>
-          <div
-            className={cn(
-              "flex items-center transition-all",
-              "bg-bg-surface border",
-              isFocused ? "border-border-active shadow-focus" : hasRevenue ? "border-gold/50" : "border-border-default"
-            )}
-            style={{ borderRadius: 'var(--radius-md)' }}
-          >
-            <span className="pl-4 pr-2 font-mono text-xl text-text-dim">$</span>
-            <input
-              ref={revenueInputRef}
-              type="text"
-              inputMode="numeric"
-              value={formatValue(inputs.revenue)}
-              onChange={(e) => onUpdateInput('revenue', parseValue(e.target.value))}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
-              onKeyDown={handleKeyDown}
-              placeholder="3,500,000"
-              className="flex-1 bg-transparent py-4 pr-4 outline-none font-mono text-[22px] text-text-primary text-right placeholder:text-text-dim tabular-nums"
-            />
-          </div>
-          <p className="mt-2 text-xs text-text-dim">
-            {hasRevenue
-              ? "Press Enter or click Next to see the waterfall."
-              : "Enter an acquisition price to see your position"}
-          </p>
-        </div>
-
-        {/* Status indicator */}
-        {hasRevenue && Number.isFinite(breakeven) && (
-          <div
-            className={cn(
-              "p-4 border flex items-center justify-between mb-6",
-              isAboveBreakeven
-                ? "border-status-success bg-[rgba(0,255,100,0.08)]"
-                : "border-status-danger bg-[rgba(255,82,82,0.08)]"
-            )}
-            style={{ borderRadius: 'var(--radius-md)' }}
-          >
-            <div>
-              <p className={cn(
-                "text-xs font-bold uppercase tracking-wider mb-1",
-                isAboveBreakeven ? "text-status-success" : "text-status-danger"
-              )}>
-                {isAboveBreakeven ? 'Above breakeven' : 'Below breakeven'}
-              </p>
-              <p className="text-lg font-mono text-text-primary">
-                {isAboveBreakeven
-                  ? `+${formatCompactCurrency(Math.abs(cushion))} cushion`
-                  : `${formatCompactCurrency(Math.abs(cushion))} shortfall`}
-              </p>
-            </div>
-            {isAboveBreakeven && percentAbove > 0 && (
-              <span className="text-2xl font-mono text-status-success">
-                +{percentAbove.toFixed(0)}%
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* Quick reference */}
-        <div
-          className="p-4 border border-border-default bg-bg-surface"
-          style={{ borderRadius: 'var(--radius-md)' }}
-        >
-          <p className="text-xs text-text-dim text-center mb-4 font-bold uppercase tracking-wider">
-            Typical acquisition ranges
-          </p>
-          <div className="grid grid-cols-3 gap-3 text-center">
-            <div className="p-3 border border-border-subtle" style={{ borderRadius: 'var(--radius-md)' }}>
-              <span className="text-sm text-text-mid font-mono block">100-110%</span>
-              <span className="text-[10px] text-text-dim">baseline</span>
-            </div>
-            <div className="p-3 border border-gold/30 bg-gold/5" style={{ borderRadius: 'var(--radius-md)' }}>
-              <span className="text-sm text-gold font-mono block">115-130%</span>
-              <span className="text-[10px] text-text-dim">strong</span>
-            </div>
-            <div className="p-3 border border-border-subtle" style={{ borderRadius: 'var(--radius-md)' }}>
-              <span className="text-sm text-text-mid font-mono block">130%+</span>
-              <span className="text-[10px] text-text-dim">exceptional</span>
-            </div>
-          </div>
-        </div>
-      </ChapterCard>
+    <div className="pb-8">
+      {renderStep()}
     </div>
   );
 };

--- a/src/components/calculator/tabs/StackTab.tsx
+++ b/src/components/calculator/tabs/StackTab.tsx
@@ -43,12 +43,24 @@ interface StackTabProps {
  * 9  = DefermentsWiki
  * 10 = DefermentsInput
  * 11 = StackSummary
+ * 
+ * Smart Start: If any capital data exists, skip to summary.
  */
 const StackTab = ({ inputs, onUpdateInput, onAdvance }: StackTabProps) => {
   const haptics = useHaptics();
   
-  // Single piece of state: which step are we on?
-  const [currentStep, setCurrentStep] = useState(0);
+  // Smart start: Check if user has any capital stack data
+  const hasStackData = 
+    inputs.credits > 0 || 
+    inputs.debt > 0 || 
+    inputs.mezzanineDebt > 0 || 
+    inputs.equity > 0 || 
+    inputs.deferments > 0;
+  
+  // If user has data, start at summary (step 11); otherwise start at overview (step 0)
+  const [currentStep, setCurrentStep] = useState(() => {
+    return hasStackData ? 11 : 0;
+  });
 
   // Navigation helpers
   const goToStep = useCallback((step: number) => {


### PR DESCRIPTION
## Summary

Applies the same step-based mini-app architecture from Stack Tab to Budget and Deal tabs for consistent UX across all input flows.

## Changes

### Budget Tab (`src/components/calculator/budget/`)
| File | Purpose |
|------|---------|
| `BudgetOverviewWiki.tsx` | Step 0: Education on negative cost concept |
| `BudgetInput.tsx` | Step 1: Budget entry with quick amount buttons |
| `index.ts` | Barrel exports |

**Flow:** Wiki → Input → advances to Stack

### Deal Tab (`src/components/calculator/deal/`)
| File | Purpose |
|------|---------|
| `DealOverviewWiki.tsx` | Step 0: Education on acquisition/breakeven |
| `DealInput.tsx` | Step 1: Revenue input with breakeven status indicator |
| `index.ts` | Barrel exports |

**Flow:** Wiki → Input → advances to Waterfall

### Architecture Pattern
Both tabs now follow the established pattern:
- **Tab component** = Step Router (manages `currentStep` state)
- **Wiki screens** = Education (reuse `WikiScreen` from stack)
- **Input screens** = Data collection with validation

### Smart Defaults
- If user already has data entered, skip wiki and show input directly
- Haptic feedback on navigation
- Smooth scroll to top on step change

## Testing Checklist
- [ ] Budget wiki displays correctly
- [ ] Budget input accepts values and quick amounts work
- [ ] Budget "Continue" advances to Stack tab
- [ ] Deal wiki displays correctly  
- [ ] Deal input shows breakeven context
- [ ] Quick scenario buttons calculate correctly
- [ ] Above/below breakeven indicator works
- [ ] Deal "Continue" advances to Waterfall tab

## Phase Progress
| Phase | Scope | Status |
|-------|-------|--------|
| 1 | Stack Tab mini-app | ✅ Complete |
| **2** | **Budget/Deal tabs** | ✅ **This PR** |
| 3 | Consistency pass | Next |