### PR TITLE
feat: Phase 3 consistency pass — navigation, smart start, step labels

### DIFF
--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from "react";
-import { DollarSign, ArrowRight, Check, X } from "lucide-react";
+import { DollarSign, ArrowRight, ArrowLeft, Check, X } from "lucide-react";
 import { WaterfallInputs } from "@/lib/waterfall";
 import { cn } from "@/lib/utils";
 
 interface BudgetInputProps {
   inputs: WaterfallInputs;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onBack?: () => void;
   onNext: () => void;
 }
 
@@ -15,7 +16,7 @@ interface BudgetInputProps {
  * Step 1 of Budget Tab: Collect the production budget
  * with quick amount buttons and validation.
  */
-const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
+const BudgetInput = ({ inputs, onUpdateInput, onBack, onNext }: BudgetInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -75,6 +76,24 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
 
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* Step Label + Back Button */}
+      <div className="flex items-center justify-between">
+        {onBack ? (
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-xs text-text-dim hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            <span>Back</span>
+          </button>
+        ) : (
+          <div />
+        )}
+        <span className="text-xs font-mono text-gold/70 uppercase tracking-widest">
+          Step 1 of 2 • Budget
+        </span>
+      </div>
+
       {/* Hero Header */}
       <div className="text-center mb-6">
         <div className="relative inline-block mb-4">
@@ -87,10 +106,10 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
             }}
           />
           <div 
-            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <DollarSign className="w-7 h-7 text-gold" />
+            <DollarSign className="w-8 h-8 text-gold" />
           </div>
         </div>
 

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Handshake, ArrowRight, Check, Target, TrendingUp, TrendingDown } from "lucide-react";
+import { Handshake, ArrowRight, ArrowLeft, Check, Target, TrendingUp, TrendingDown } from "lucide-react";
 import { WaterfallInputs, GuildState, formatCompactCurrency, calculateBreakeven } from "@/lib/waterfall";
 import { CapitalSelections } from "../steps/CapitalSelectStep";
 import { cn } from "@/lib/utils";
@@ -9,6 +9,7 @@ interface DealInputProps {
   guilds: GuildState;
   selections: CapitalSelections;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
+  onBack?: () => void;
   onNext: () => void;
 }
 
@@ -18,7 +19,7 @@ interface DealInputProps {
  * Step 1 of Deal Tab: Collect acquisition/revenue projection
  * with breakeven context and status indicator.
  */
-const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealInputProps) => {
+const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }: DealInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -66,6 +67,24 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
 
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* Step Label + Back Button */}
+      <div className="flex items-center justify-between">
+        {onBack ? (
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-xs text-text-dim hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" />
+            <span>Back</span>
+          </button>
+        ) : (
+          <div />
+        )}
+        <span className="text-xs font-mono text-gold/70 uppercase tracking-widest">
+          Step 1 of 2 • Deal
+        </span>
+      </div>
+
       {/* Hero Header */}
       <div className="text-center mb-6">
         <div className="relative inline-block mb-4">
@@ -78,10 +97,10 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
             }}
           />
           <div 
-            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <Handshake className="w-7 h-7 text-gold" />
+            <Handshake className="w-8 h-8 text-gold" />
           </div>
         </div>
 

--- a/src/components/calculator/shared/StepIndicator.tsx
+++ b/src/components/calculator/shared/StepIndicator.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+
+interface StepIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+  labels?: string[];
+  className?: string;
+}
+
+/**
+ * StepIndicator - Visual progress through multi-step flows
+ * 
+ * Displays dots/segments to show where user is in the flow.
+ * Uses gold for completed/active, dim for upcoming.
+ */
+const StepIndicator = ({ 
+  currentStep, 
+  totalSteps, 
+  labels,
+  className 
+}: StepIndicatorProps) => {
+  return (
+    <div className={cn("flex flex-col items-center gap-2", className)}>
+      {/* Step label */}
+      {labels && labels[currentStep] && (
+        <span className="text-xs font-mono text-gold/80 uppercase tracking-widest">
+          {labels[currentStep]}
+        </span>
+      )}
+      
+      {/* Progress dots */}
+      <div className="flex items-center gap-2">
+        {Array.from({ length: totalSteps }).map((_, index) => {
+          const isCompleted = index < currentStep;
+          const isActive = index === currentStep;
+          
+          return (
+            <div
+              key={index}
+              className={cn(
+                "h-1.5 rounded-full transition-all duration-300",
+                isActive 
+                  ? "w-6 bg-gold" 
+                  : isCompleted
+                    ? "w-3 bg-gold/60"
+                    : "w-3 bg-white/20"
+              )}
+            />
+          );
+        })}
+      </div>
+      
+      {/* Numeric indicator */}
+      <span className="text-[10px] text-text-dim font-mono">
+        Step {currentStep + 1} of {totalSteps}
+      </span>
+    </div>
+  );
+};
+
+export default StepIndicator;

--- a/src/components/calculator/shared/index.ts
+++ b/src/components/calculator/shared/index.ts
@@ -1,0 +1,1 @@
+export { default as StepIndicator } from './StepIndicator';

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -23,12 +23,13 @@ interface BudgetTabProps {
  * 0 = BudgetOverviewWiki (intro to negative cost concept)
  * 1 = BudgetInput (enter budget + quick amounts)
  * 
+ * Smart Start: Skips wiki if budget already entered.
  * On completion, advances to Stack tab.
  */
 const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
   const haptics = useHaptics();
   
-  // Start at step 0 if no budget, otherwise show input
+  // Smart start: Skip wiki if budget already entered
   const [currentStep, setCurrentStep] = useState(() => {
     return inputs.budget > 0 ? 1 : 0;
   });
@@ -42,6 +43,10 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
 
   const nextStep = useCallback(() => {
     goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  const prevStep = useCallback(() => {
+    goToStep(Math.max(0, currentStep - 1));
   }, [currentStep, goToStep]);
 
   // Handle completion - advance to Stack tab
@@ -65,6 +70,7 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
           <BudgetInput
             inputs={inputs}
             onUpdateInput={onUpdateInput}
+            onBack={prevStep}
             onNext={handleComplete}
           />
         );

--- a/src/components/calculator/tabs/DealTab.tsx
+++ b/src/components/calculator/tabs/DealTab.tsx
@@ -24,12 +24,13 @@ interface DealTabProps {
  * 0 = DealOverviewWiki (intro to acquisition/breakeven concepts)
  * 1 = DealInput (enter revenue + see breakeven status)
  * 
+ * Smart Start: Skips wiki if revenue already entered.
  * On completion, advances to Waterfall tab.
  */
 const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealTabProps) => {
   const haptics = useHaptics();
   
-  // Start at step 0 if no revenue, otherwise show input
+  // Smart start: Skip wiki if revenue already entered
   const [currentStep, setCurrentStep] = useState(() => {
     return inputs.revenue > 0 ? 1 : 0;
   });
@@ -43,6 +44,10 @@ const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealT
 
   const nextStep = useCallback(() => {
     goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  const prevStep = useCallback(() => {
+    goToStep(Math.max(0, currentStep - 1));
   }, [currentStep, goToStep]);
 
   // Handle completion - advance to Waterfall tab
@@ -68,6 +73,7 @@ const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealT
             guilds={guilds}
             selections={selections}
             onUpdateInput={onUpdateInput}
+            onBack={prevStep}
             onNext={handleComplete}
           />
         );

--- a/src/components/calculator/tabs/StackTab.tsx
+++ b/src/components/calculator/tabs/StackTab.tsx
@@ -43,12 +43,24 @@ interface StackTabProps {
  * 9  = DefermentsWiki
  * 10 = DefermentsInput
  * 11 = StackSummary
+ * 
+ * Smart Start: If any capital data exists, skip to summary.
  */
 const StackTab = ({ inputs, onUpdateInput, onAdvance }: StackTabProps) => {
   const haptics = useHaptics();
   
-  // Single piece of state: which step are we on?
-  const [currentStep, setCurrentStep] = useState(0);
+  // Smart start: Check if user has any capital stack data
+  const hasStackData = 
+    inputs.credits > 0 || 
+    inputs.debt > 0 || 
+    inputs.mezzanineDebt > 0 || 
+    inputs.equity > 0 || 
+    inputs.deferments > 0;
+  
+  // If user has data, start at summary (step 11); otherwise start at overview (step 0)
+  const [currentStep, setCurrentStep] = useState(() => {
+    return hasStackData ? 11 : 0;
+  });
 
   // Navigation helpers
   const goToStep = useCallback((step: number) => {


### PR DESCRIPTION
## Summary

Phase 3 consistency pass ensuring uniform UX patterns across all three tabs in the mini-app architecture.

## Changes

### 🔙 Back Button Navigation

| Component | Before | After |
|-----------|--------|-------|
| `BudgetInput` | No back button | ✅ Back to wiki |
| `DealInput` | No back button | ✅ Back to wiki |

### 📍 Step Labels

All input screens now display consistent step indicators:
- **Budget**: `Step 1 of 2 • Budget`
- **Deal**: `Step 1 of 2 • Deal`
- Stack inputs already had labels via `StackInputCard`

### 🚀 Smart Start Logic

| Tab | Behavior |
|-----|----------|
| **Budget** | Skip wiki → input if `budget > 0` |
| **Stack** | Skip to summary if any capital data exists |
| **Deal** | Skip wiki → input if `revenue > 0` |

### 📐 Visual Consistency

- Hero icon containers standardized to **16×16** (was 14×14 in some screens)
- Step label positioning unified (top-right, above hero)
- Back button styling consistent across all screens

### 🧩 New Shared Component

```tsx
// src/components/calculator/shared/StepIndicator.tsx
<StepIndicator currentStep={1} totalSteps={4} labels={['Budget', 'Stack', 'Deal', 'Waterfall']} />
```

Available for future use in more complex progress visualization.

## Testing Checklist

- [ ] Budget: Back button returns to wiki from input
- [ ] Budget: Smart start skips wiki when budget entered
- [ ] Stack: Smart start shows summary when data exists
- [ ] Stack: Edit from summary navigates to correct step
- [ ] Deal: Back button returns to wiki from input
- [ ] Deal: Smart start skips wiki when revenue entered
- [ ] All step labels display correctly

## Phase Progress

| Phase | Scope | Status |
|-------|-------|--------|
| 1 | Stack Tab mini-app | ✅ Complete |
| 2 | Budget/Deal tabs | ✅ Complete |
| **3** | **Consistency pass** | ✅ **This PR** |

## Merge Strategy

This PR targets `feature/budget-mini-app` to stack changes. After review:
1. Merge this PR into `feature/budget-mini-app`
2. Merge `feature/budget-mini-app` into `main`