### PR TITLE
🎨 Wiki Matte Polish — Gray cards, gold gradients, succinct copy

### DIFF
--- a/src/pages/IntroView.tsx
+++ b/src/pages/IntroView.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight, ArrowLeft, ShieldCheck, TrendingUp, Lightbulb, FileText, ChevronDown } from 'lucide-react';
+import { ArrowRight, ArrowLeft, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
 import Header from "@/components/Header";
@@ -9,74 +9,52 @@ import { cn } from "@/lib/utils";
    PRODUCT BIBLE v2.0 TOKENS
    ═══════════════════════════════════════════════════════════════════════════ */
 const tokens = {
-  // Backgrounds
+  // Backgrounds - More matte consistency
   bgVoid: '#000000',
-  bgCard: '#070707',
-  bgSurface: '#141414',
-  bgElevated: '#111111',
+  bgMatte: '#111111',      // Primary card surface
+  bgSurface: '#161616',    // Slightly elevated
   
   // Gold System
   gold: '#FFD700',
   goldMuted: 'rgba(255, 215, 0, 0.45)',
-  goldSubtle: 'rgba(255, 215, 0, 0.12)',
-  goldGlow: 'rgba(255, 215, 0, 0.3)',
+  goldSubtle: 'rgba(255, 215, 0, 0.10)',
+  goldGlow: 'rgba(255, 215, 0, 0.25)',
   
   // Borders
-  borderDefault: '#2A2A2A',
-  borderGold: 'rgba(255, 215, 0, 0.45)',
+  borderMatte: '#222222',
+  borderGold: 'rgba(255, 215, 0, 0.35)',
   
   // Text
   textPrimary: '#FFFFFF',
-  textMid: '#CFCFCF',
-  textDim: '#8A8A8A',
+  textMid: '#B0B0B0',
+  textDim: '#6B6B6B',
   
   // Radius
-  radiusSm: '8px',
   radiusMd: '12px',
-  radiusLg: '14px',
+  radiusLg: '16px',
 };
 
 interface FAQItem {
   question: string;
-  answer: React.ReactNode;
+  answer: string;
 }
 
 const faqItems: FAQItem[] = [
   {
     question: "Is this legal financial advice?",
-    answer: "No. This is a simulation tool for estimation and planning purposes only. Always consult with a qualified entertainment attorney or accountant for final deal structures."
-  },
-  {
-    question: "Can I save my results?",
-    answer: "Yes. At the end of the simulation, you'll have options to export or view a summary of your waterfall model."
+    answer: "No. This is a planning tool only. Consult an entertainment attorney for final deal structures."
   },
   {
     question: "Is this for theatrical releases?",
-    answer: (
-      <>
-        No. This calculator is built for <span className="text-white font-medium">streamer acquisition and direct sales</span>—the dominant path for indie films today. It models what happens when you sell your finished film to Netflix, Amazon, Hulu, Tubi, or an independent buyer.
-      </>
-    )
+    answer: "No. This models streamer acquisitions and direct sales—Netflix, Amazon, Tubi, or independent buyers."
   },
   {
-    question: "I don't understand all the terms yet. Should I wait?",
-    answer: (
-      <>
-        No. The best way to learn recoupment is to <span className="text-white font-medium">interact with a working model</span>. Start with a simple scenario and adjust as you go. If you get stuck, use the in-app definitions or reach out—we'll walk you through it.
-      </>
-    )
+    question: "How accurate is this?",
+    answer: "The waterfall logic matches real Operating Agreements. Specific percentages vary by deal, but the mechanics are universal."
   },
   {
-    question: "How accurate is this compared to real deals?",
-    answer: (
-      <>
-        This calculator uses the same waterfall logic found in actual Operating Agreements and distribution contracts. The math is <span className="text-white font-medium">institutional-grade</span>. What varies deal-to-deal are specific fee percentages, expense caps, and waterfall positions—but the structural mechanics are universal.
-      </>
-    )
-  },
-  {
-    question: "I'm new to this. Where do I start?",
-    answer: "Just follow the steps. The waterfall process is broken into 4 stages. If you get stuck, look for the quick tips inside the calculator."
+    question: "I'm new. Where do I start?",
+    answer: "Just follow the steps. Look for the info icons for quick definitions."
   }
 ];
 
@@ -100,302 +78,196 @@ const IntroView = () => {
         className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
         style={{ background: tokens.bgVoid }}
       >
-        <div className="max-w-3xl mx-auto space-y-6">
+        <div className="max-w-2xl mx-auto space-y-8">
           
-          {/* ═══════════════════════════════════════════════════════════════════
-              HEADER - Documentation Style
-              ═══════════════════════════════════════════════════════════════════ */}
-          <div className="space-y-4 pb-6 animate-fade-in">
-            {/* Breadcrumb */}
-            <div 
-              className="flex items-center space-x-2 text-xs font-mono uppercase tracking-widest"
-              style={{ color: tokens.gold }}
-            >
-              <FileText className="w-4 h-4" />
-              <span>Protocol / Overview</span>
-            </div>
-            
+          {/* ═══════════════════════════════════════════════════════════════
+              HEADER
+              ═══════════════════════════════════════════════════════════════ */}
+          <div className="space-y-4 pt-4 animate-fade-in">
             {/* Title */}
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
-              Filmmaker <span style={{ color: tokens.gold }}>Waterfall</span> Protocol
+              Waterfall <span style={{ color: tokens.gold }}>Protocol</span>
             </h1>
             
             {/* Subtitle */}
             <p 
-              className="text-base leading-relaxed max-w-2xl"
+              className="text-base leading-relaxed"
               style={{ color: tokens.textMid }}
             >
-              This is how money moves through a film deal—from acquisition to your pocket. 
-              Most producers don't see this math until they've already signed away their upside.
+              How money moves through a film deal—from acquisition to your pocket.
             </p>
             
-            {/* Divider */}
+            {/* Gold Gradient Divider */}
             <div 
-              className="h-px w-full mt-4"
+              className="h-px w-full"
               style={{ 
-                background: `linear-gradient(90deg, ${tokens.goldMuted}, transparent 60%)` 
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
               }}
             />
           </div>
 
-          {/* ═══════════════════════════════════════════════════════════════════
-              MAIN CONTENT CARD - Chapter Style
-              ═══════════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════
+              WHAT YOU'LL MODEL — Matte Card
+              ═══════════════════════════════════════════════════════════════ */}
           <div 
             className="overflow-hidden animate-fade-in"
             style={{ 
-              background: tokens.bgCard,
-              border: `1px solid ${tokens.borderDefault}`,
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
               borderRadius: tokens.radiusLg,
             }}
           >
-            {/* Card Header - Elevated */}
+            {/* Card Header with Gold Gradient Top Border */}
             <div 
-              className="flex items-center gap-4 px-5 py-4"
+              className="px-5 py-4"
               style={{ 
-                background: tokens.bgElevated,
-                borderBottom: `1px solid ${tokens.borderDefault}`,
+                borderBottom: `1px solid ${tokens.borderMatte}`,
+                background: `linear-gradient(180deg, rgba(255,215,0,0.06) 0%, transparent 100%)`,
               }}
             >
-              {/* Chapter Number */}
-              <div 
-                className="w-10 h-10 flex items-center justify-center font-bebas text-lg"
-                style={{
-                  background: tokens.goldSubtle,
-                  border: `1px solid ${tokens.goldMuted}`,
-                  borderRadius: tokens.radiusMd,
-                  color: tokens.gold,
-                }}
-              >
-                01
-              </div>
-              <div>
+              <div className="flex items-center gap-3">
+                <span 
+                  className="font-bebas text-lg"
+                  style={{ color: tokens.gold }}
+                >
+                  01
+                </span>
                 <h2 
                   className="font-bold text-sm uppercase tracking-wide"
                   style={{ color: tokens.textPrimary }}
                 >
-                  Before You Begin
+                  What You'll Model
                 </h2>
-                <p 
-                  className="text-xs"
-                  style={{ color: tokens.textDim }}
-                >
-                  Understanding the waterfall
-                </p>
               </div>
             </div>
             
             {/* Card Body */}
-            <div className="p-5 space-y-5">
-              
-              {/* Section 1 */}
-              <div className="flex items-start gap-4">
-                <div 
-                  className="p-2.5 flex-shrink-0"
-                  style={{
-                    background: tokens.goldSubtle,
-                    border: `1px solid ${tokens.goldMuted}`,
-                    borderRadius: tokens.radiusMd,
-                  }}
-                >
-                  <ShieldCheck className="w-5 h-5" style={{ color: tokens.gold }} />
-                </div>
-                <div>
-                  <h3 
-                    className="text-sm font-bold mb-1.5"
-                    style={{ color: tokens.textPrimary }}
-                  >
-                    Why this exists
-                  </h3>
-                  <p 
-                    className="text-sm leading-relaxed"
-                    style={{ color: tokens.textDim }}
-                  >
-                    Most filmmakers guess their numbers. You won't. This calculator models the flow of money from acquisition sale to your pocket—accounting for sales agent fees, distributor commissions, and investor recoupment. Whether you're selling to Netflix, Amazon, Tubi, or an independent buyer, you need to know where the money goes before you promise anyone a return.
+            <div className="p-5 space-y-4">
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <p className="text-sm" style={{ color: tokens.textMid }}>
+                    <span className="text-white font-medium">Production Budget</span> — Your total cost to make the film
                   </p>
                 </div>
-              </div>
-
-              {/* Divider */}
-              <div style={{ borderTop: `1px solid ${tokens.borderDefault}` }} />
-
-              {/* Section 2 */}
-              <div className="flex items-start gap-4">
-                <div 
-                  className="p-2.5 flex-shrink-0"
-                  style={{
-                    background: tokens.goldSubtle,
-                    border: `1px solid ${tokens.goldMuted}`,
-                    borderRadius: tokens.radiusMd,
-                  }}
-                >
-                  <TrendingUp className="w-5 h-5" style={{ color: tokens.gold }} />
-                </div>
-                <div>
-                  <h3 
-                    className="text-sm font-bold mb-1.5"
-                    style={{ color: tokens.textPrimary }}
-                  >
-                    The Investor Advantage
-                  </h3>
-                  <p 
-                    className="text-sm leading-relaxed"
-                    style={{ color: tokens.textDim }}
-                  >
-                    Investors back producers who understand the risks. When you can walk someone through off-the-tops, collection fees, and recoupment positions, you're speaking their language. A clear waterfall demonstrates competence—and competence closes deals.
+                <div className="flex items-start gap-3">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <p className="text-sm" style={{ color: tokens.textMid }}>
+                    <span className="text-white font-medium">Capital Stack</span> — How you're funding it (equity, debt, deferrals)
                   </p>
                 </div>
-              </div>
-
-              {/* Divider */}
-              <div style={{ borderTop: `1px solid ${tokens.borderDefault}` }} />
-
-              {/* Section 3 */}
-              <div className="flex items-start gap-4">
-                <div 
-                  className="p-2.5 flex-shrink-0"
-                  style={{
-                    background: tokens.goldSubtle,
-                    border: `1px solid ${tokens.goldMuted}`,
-                    borderRadius: tokens.radiusMd,
-                  }}
-                >
-                  <Lightbulb className="w-5 h-5" style={{ color: tokens.gold }} />
+                <div className="flex items-start gap-3">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <p className="text-sm" style={{ color: tokens.textMid }}>
+                    <span className="text-white font-medium">Distribution Fees</span> — What comes off the top before anyone gets paid
+                  </p>
                 </div>
-                <div>
-                  <h3 
-                    className="text-sm font-bold mb-1.5"
-                    style={{ color: tokens.textPrimary }}
-                  >
-                    The Learning Curve Is The Point
-                  </h3>
-                  <p 
-                    className="text-sm leading-relaxed"
-                    style={{ color: tokens.textDim }}
-                  >
-                    If parts of this feel unfamiliar, that's expected. Film finance is deliberately complex—it protects the people who understand it. The terminology exists for a reason, and learning it is how you stop leaving money on the table.
+                <div className="flex items-start gap-3">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <p className="text-sm" style={{ color: tokens.textMid }}>
+                    <span className="text-white font-medium">Recoupment</span> — Who gets paid back, and in what order
                   </p>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* ═══════════════════════════════════════════════════════════════════
-              PRO TIP CALLOUT
-              ═══════════════════════════════════════════════════════════════════ */}
-          <div 
-            className="flex items-start gap-3 p-4 animate-fade-in"
-            style={{ 
-              background: tokens.goldSubtle,
-              borderLeft: `3px solid ${tokens.gold}`,
-              borderRadius: `0 ${tokens.radiusMd} ${tokens.radiusMd} 0`,
-            }}
-          >
-            <span 
-              className="text-xs font-bold uppercase tracking-wide flex-shrink-0"
-              style={{ color: tokens.gold }}
-            >
-              Tip
-            </span>
-            <p 
-              className="text-sm leading-relaxed"
-              style={{ color: tokens.textMid }}
-            >
-              Don't let unfamiliar terminology stop you. Look for the 
-              <span 
-                className="inline-flex items-center justify-center w-5 h-5 mx-1 text-xs font-bold rounded-full"
-                style={{ 
-                  color: tokens.gold, 
-                  border: `1px solid ${tokens.goldMuted}`,
-                  background: tokens.goldSubtle,
-                }}
-              >i</span>
-              icons throughout the calculator for quick definitions.
-            </p>
-          </div>
-
-          {/* ═══════════════════════════════════════════════════════════════════
-              FAQ CARD - Chapter Style
-              ═══════════════════════════════════════════════════════════════════ */}
+          {/* ═══════════════════════════════════════════════════════════════
+              WHY THIS MATTERS — Matte Card
+              ═══════════════════════════════════════════════════════════════ */}
           <div 
             className="overflow-hidden animate-fade-in"
             style={{ 
-              background: tokens.bgCard,
-              border: `1px solid ${tokens.borderDefault}`,
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
               borderRadius: tokens.radiusLg,
             }}
           >
-            {/* Card Header */}
             <div 
-              className="flex items-center gap-4 px-5 py-4"
+              className="px-5 py-4"
               style={{ 
-                background: tokens.bgElevated,
-                borderBottom: `1px solid ${tokens.borderDefault}`,
+                borderBottom: `1px solid ${tokens.borderMatte}`,
+                background: `linear-gradient(180deg, rgba(255,215,0,0.06) 0%, transparent 100%)`,
               }}
             >
-              <div 
-                className="w-10 h-10 flex items-center justify-center font-bebas text-lg"
-                style={{
-                  background: tokens.goldSubtle,
-                  border: `1px solid ${tokens.goldMuted}`,
-                  borderRadius: tokens.radiusMd,
-                  color: tokens.gold,
-                }}
-              >
-                02
-              </div>
-              <div>
+              <div className="flex items-center gap-3">
+                <span 
+                  className="font-bebas text-lg"
+                  style={{ color: tokens.gold }}
+                >
+                  02
+                </span>
                 <h2 
                   className="font-bold text-sm uppercase tracking-wide"
                   style={{ color: tokens.textPrimary }}
                 >
-                  Common Questions
+                  Why This Matters
                 </h2>
-                <p 
-                  className="text-xs"
-                  style={{ color: tokens.textDim }}
+              </div>
+            </div>
+            
+            <div className="p-5">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Most filmmakers don't see this math until they've already signed. Investors back producers who understand the risks. When you can walk through collection fees and recoupment positions, you're speaking their language.
+              </p>
+            </div>
+          </div>
+
+          {/* ═══════════════════════════════════════════════════════════════
+              FAQ — Matte Card
+              ═══════════════════════════════════════════════════════════════ */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <div 
+              className="px-5 py-4"
+              style={{ 
+                borderBottom: `1px solid ${tokens.borderMatte}`,
+                background: `linear-gradient(180deg, rgba(255,215,0,0.06) 0%, transparent 100%)`,
+              }}
+            >
+              <div className="flex items-center gap-3">
+                <span 
+                  className="font-bebas text-lg"
+                  style={{ color: tokens.gold }}
                 >
-                  Quick answers before you start
-                </p>
+                  03
+                </span>
+                <h2 
+                  className="font-bold text-sm uppercase tracking-wide"
+                  style={{ color: tokens.textPrimary }}
+                >
+                  Quick Answers
+                </h2>
               </div>
             </div>
             
             {/* FAQ Accordion */}
-            <div className="divide-y" style={{ borderColor: tokens.borderDefault }}>
+            <div>
               {faqItems.map((item, index) => (
                 <div 
                   key={index}
-                  style={{ borderColor: tokens.borderDefault }}
+                  style={{ borderTop: index > 0 ? `1px solid ${tokens.borderMatte}` : 'none' }}
                 >
                   <button
                     onClick={() => toggleFAQ(index)}
-                    className="w-full flex items-center gap-4 p-4 text-left transition-all duration-150"
+                    className="w-full flex items-center justify-between p-4 text-left transition-all duration-150"
                     style={{
                       background: openFAQ === index ? tokens.goldSubtle : 'transparent',
                     }}
                   >
-                    {/* Number Badge */}
-                    <div 
-                      className="w-7 h-7 flex items-center justify-center flex-shrink-0 font-mono text-xs font-bold"
-                      style={{
-                        background: openFAQ === index ? tokens.goldSubtle : tokens.bgSurface,
-                        border: `1px solid ${openFAQ === index ? tokens.goldMuted : tokens.borderDefault}`,
-                        borderRadius: tokens.radiusSm,
-                        color: openFAQ === index ? tokens.gold : tokens.textDim,
-                      }}
-                    >
-                      {String(index + 1).padStart(2, '0')}
-                    </div>
-                    
-                    {/* Question */}
                     <span 
-                      className="flex-1 text-sm font-medium"
+                      className="text-sm font-medium pr-4"
                       style={{ color: openFAQ === index ? tokens.textPrimary : tokens.textMid }}
                     >
                       {item.question}
                     </span>
                     
-                    {/* Chevron */}
                     <ChevronDown 
                       className={cn(
                         "w-4 h-4 flex-shrink-0 transition-transform duration-200",
@@ -405,21 +277,15 @@ const IntroView = () => {
                     />
                   </button>
                   
-                  {/* Answer */}
                   <div
                     className={cn(
                       "overflow-hidden transition-all duration-200",
-                      openFAQ === index ? "max-h-48 opacity-100" : "max-h-0 opacity-0"
+                      openFAQ === index ? "max-h-32 opacity-100" : "max-h-0 opacity-0"
                     )}
                   >
                     <div 
                       className="px-4 pb-4 text-sm leading-relaxed"
-                      style={{ 
-                        color: tokens.textDim,
-                        marginLeft: '44px',
-                        borderLeft: `2px solid ${tokens.goldMuted}`,
-                        paddingLeft: '16px',
-                      }}
+                      style={{ color: tokens.textDim }}
                     >
                       {item.answer}
                     </div>
@@ -429,45 +295,35 @@ const IntroView = () => {
             </div>
           </div>
 
-          {/* ═══════════════════════════════════════════════════════════════════
+          {/* ═══════════════════════════════════════════════════════════════
               CTA SECTION
-              ═══════════════════════════════════════════════════════════════════ */}
-          <div className="pt-6 flex flex-col items-center gap-5 animate-fade-in">
-            {/* Divider */}
+              ═══════════════════════════════════════════════════════════════ */}
+          <div className="pt-4 flex flex-col items-center gap-6 animate-fade-in">
+            {/* Gold Gradient Divider */}
             <div 
               className="h-px w-full"
               style={{ 
-                background: `linear-gradient(90deg, transparent, ${tokens.goldMuted}, transparent)` 
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
               }}
             />
             
-            {/* CTA Button - Product Bible Style */}
+            {/* CTA Button - Solid Gold */}
             <Button 
               onClick={handleInitialize}
-              className="group px-8 py-6 text-xs font-black uppercase tracking-widest transition-all duration-200"
+              className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
               style={{
-                background: tokens.goldSubtle,
-                border: `1px solid ${tokens.goldMuted}`,
+                background: `linear-gradient(135deg, ${tokens.gold} 0%, #E6C200 100%)`,
+                border: 'none',
                 borderRadius: tokens.radiusMd,
-                color: tokens.gold,
-                boxShadow: `0 10px 26px rgba(255, 215, 0, 0.18)`,
+                color: '#000000',
+                boxShadow: `0 8px 24px ${tokens.goldGlow}`,
               }}
             >
-              Initialize Simulation
+              Start Simulation
               <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Button>
             
-            {/* Version */}
-            <div 
-              className="text-xs font-mono tracking-wider"
-              style={{ color: tokens.textDim }}
-            >
-              v2.0.5-stable
-            </div>
-          </div>
-
-          {/* Back Link */}
-          <div className="pt-2 flex justify-center animate-fade-in">
+            {/* Back Link */}
             <button
               onClick={() => navigate('/')}
               className="flex items-center gap-2 text-sm transition-colors"


### PR DESCRIPTION
## Summary
Redesigns the wiki intro page with consistent matte gray aesthetic, gold gradients, and tightened copy.

---

## Changes

| Before | After |
|--------|-------|
| Card bg `#070707` | Card bg `#111111` (matte gray) |
| Verbose paragraphs | Succinct, scannable copy |
| Flat dividers | **Gold gradient dividers** |
| 3 verbose sections | 3 tight cards: What You'll Model, Why This Matters, Quick Answers |
| Icon-heavy sections | Clean bullet points with gold accents |
| 6 FAQ items | 4 essential FAQs |

---

## Design Tokens

```js
bgMatte: '#111111'       // Primary card surface
borderMatte: '#222222'   // Subtle borders
gold gradient header: linear-gradient(180deg, rgba(255,215,0,0.06) 0%, transparent 100%)
```

---

## Capital Stack

Kept simple — just mentions "equity, debt, deferrals" without granular breakdown of tax credits, incentives, etc.

---

## Preview Route
`/intro`