### PR TITLE
feat(wiki): Section 01 pillars → responsive 2×2 grid

### DIFF
--- a/src/pages/IntroView.tsx
+++ b/src/pages/IntroView.tsx
@@ -183,8 +183,8 @@ const IntroView = () => {
                 flows from acquisition to final profit splits.
               </p>
               
-              {/* The Four Pillars */}
-              <div className="space-y-4">
+              {/* The Four Pillars — 2×2 Grid on desktop, single column on mobile */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div 
                   className="p-4"
                   style={{ 


### PR DESCRIPTION
## Summary

Surgical CSS-only change to convert the four pillar cards in Section 01 from a vertical stack to a responsive 2×2 grid.

---

## Changes

| Before | After |
|--------|-------|
| `space-y-4` (vertical stack) | `grid grid-cols-1 md:grid-cols-2 gap-4` |

---

## Impact

- **Desktop**: ~50% reduction in vertical scroll for Section 01
- **Mobile**: Unchanged — single column maintained for accessibility
- **Zero logic changes** — pure layout optimization

---

## Visual

```
DESKTOP (md+)                    MOBILE
┌─────────────┬─────────────┐    ┌─────────────────────────┐
│  Budget     │  Capital    │    │  Budget                 │
├─────────────┼─────────────┤    ├─────────────────────────┤
│  Fees       │  Waterfall  │    │  Capital                │
└─────────────┴─────────────┘    ├─────────────────────────┤
                                 │  Fees                   │
                                 ├─────────────────────────┤
                                 │  Waterfall              │
                                 └─────────────────────────┘
```

---

## QA Checklist

- [ ] Desktop: 4 cards display in 2×2 grid
- [ ] Tablet: Grid maintains at `md` breakpoint (768px+)
- [ ] Mobile: Falls back to single column
- [ ] Card content readable at all sizes
- [ ] Gold left border accent intact on all cards

---

Ref: Product Bible v2.0 — Hybrid Layout Decision