### PR TITLE
feat: complete wiki architecture with educational content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import IntroView from "./pages/IntroView";
 import BudgetInfo from "./pages/BudgetInfo";
+import CapitalInfo from "./pages/CapitalInfo";
+import FeesInfo from "./pages/FeesInfo";
+import WaterfallInfo from "./pages/WaterfallInfo";
 import Auth from "./pages/Auth";
 import Calculator from "./pages/Calculator";
 import Store from "./pages/Store";
@@ -23,6 +26,9 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/intro" element={<IntroView />} />
           <Route path="/budget-info" element={<BudgetInfo />} />
+          <Route path="/capital-info" element={<CapitalInfo />} />
+          <Route path="/fees-info" element={<FeesInfo />} />
+          <Route path="/waterfall-info" element={<WaterfallInfo />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/calculator" element={<Calculator />} />
           <Route path="/store" element={<Store />} />

--- a/src/pages/CapitalInfo.tsx
+++ b/src/pages/CapitalInfo.tsx
@@ -1,0 +1,453 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import Header from "@/components/Header";
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MINI WIKI: CAPITAL STACK
+   Full educational deep-dive on how indie films are financed.
+   ═══════════════════════════════════════════════════════════════════════════ */
+const tokens = {
+  bgVoid: '#000000',
+  bgMatte: '#0D0D0D',
+  bgHeader: '#111111',
+  bgSurface: '#141414',
+  
+  gold: '#FFD700',
+  goldMuted: 'rgba(255, 215, 0, 0.45)',
+  goldSubtle: 'rgba(255, 215, 0, 0.08)',
+  goldGlow: 'rgba(255, 215, 0, 0.25)',
+  goldFill: 'rgba(255, 215, 0, 0.12)',
+  goldRadiant: 'rgba(255, 215, 0, 0.18)',
+  
+  borderMatte: '#1A1A1A',
+  borderSubtle: '#222222',
+  
+  textPrimary: '#FFFFFF',
+  textMid: '#B0B0B0',
+  textDim: '#6B6B6B',
+  
+  radiusMd: '12px',
+  radiusLg: '14px',
+};
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SECTION HEADER — Radiant Gold Left Border
+   ═══════════════════════════════════════════════════════════════════════════ */
+interface SectionHeaderProps {
+  number: string;
+  title: string;
+}
+
+const SectionHeader = ({ number, title }: SectionHeaderProps) => (
+  <div 
+    className="flex items-stretch"
+    style={{ 
+      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
+      borderBottom: `1px solid ${tokens.borderMatte}`,
+    }}
+  >
+    <div 
+      className="w-1 flex-shrink-0"
+      style={{ 
+        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
+        boxShadow: `0 0 12px ${tokens.goldGlow}`,
+      }}
+    />
+    
+    <div 
+      className="flex items-center justify-center px-4 py-4"
+      style={{ 
+        borderRight: `1px solid ${tokens.borderSubtle}`,
+        minWidth: '56px',
+        background: tokens.goldFill,
+      }}
+    >
+      <span 
+        className="font-bebas text-xl tracking-wide"
+        style={{ color: tokens.gold }}
+      >
+        {number}
+      </span>
+    </div>
+    
+    <div className="flex items-center px-4 py-4">
+      <h2 
+        className="font-bold text-xs uppercase tracking-widest"
+        style={{ color: tokens.textPrimary }}
+      >
+        {title}
+      </h2>
+    </div>
+  </div>
+);
+
+const CapitalInfo = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <Header />
+      
+      <div 
+        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
+        style={{ background: tokens.bgVoid }}
+      >
+        <div className="max-w-2xl mx-auto space-y-6">
+          
+          {/* PAGE HEADER */}
+          <div className="space-y-4 pt-6 animate-fade-in">
+            <button
+              onClick={() => navigate('/intro')}
+              className="flex items-center gap-2 text-sm transition-colors mb-4"
+              style={{ color: tokens.textDim }}
+              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span>Back to Overview</span>
+            </button>
+            
+            <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
+              Capital <span style={{ color: tokens.gold }}>Stack</span>
+            </h1>
+            
+            <p 
+              className="text-base leading-relaxed max-w-lg"
+              style={{ color: tokens.textMid }}
+            >
+              Understanding how independent films are financed—and who gets paid back first.
+            </p>
+            
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              }}
+            />
+          </div>
+
+          {/* SECTION: WHAT IS A CAPITAL STACK */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="01" title="What Is a Capital Stack?" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                The <strong style={{ color: tokens.textPrimary }}>capital stack</strong> is 
+                the combination of all funding sources used to finance your production. Like 
+                layers in a building, each capital source sits in a specific position—and that 
+                position determines when (and if) each investor gets repaid.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Most independent films can't be funded by a single source. Instead, producers 
+                piece together a stack from multiple sources: equity investors, senior lenders, 
+                gap financiers, tax incentives, and sometimes pre-sales or minimum guarantees. 
+                Each comes with different terms, risks, and recoupment positions.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: EQUITY */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="02" title="Equity Investors" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                <strong style={{ color: tokens.textPrimary }}>Equity</strong> is risk capital. 
+                Equity investors give you money in exchange for ownership—a percentage of the 
+                profits if the film succeeds. They don't get interest payments or guaranteed 
+                returns. If the film loses money, equity investors lose their investment.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Because equity is the riskiest capital, equity investors typically demand:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Priority recoupment</strong> — 
+                  they want their principal back before anyone else (except senior debt)</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Premium</strong> — 
+                  a percentage on top of their investment (typically 10-25%) before profits split</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Backend participation</strong> — 
+                  a share of profits after recoupment (often 50%)</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          {/* SECTION: SENIOR DEBT */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="03" title="Senior Debt" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                <strong style={{ color: tokens.textPrimary }}>Senior debt</strong> is the 
+                safest position in the stack. Senior lenders get repaid first, before anyone 
+                else sees a dollar. Because of this priority position, senior debt charges 
+                lower rates than equity demands—but it must be repaid regardless of the film's success.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Common sources of senior debt include:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Bank loans</strong> — 
+                  secured against pre-sales, tax credits, or minimum guarantees</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Tax credit advances</strong> — 
+                  lenders who front cash against confirmed incentive rebates</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Minimum guarantee loans</strong> — 
+                  discounted advances against contracted distribution deals</span>
+                </li>
+              </ul>
+              
+              <div 
+                className="p-4 mt-2"
+                style={{ 
+                  background: tokens.goldSubtle,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.goldMuted}`,
+                }}
+              >
+                <p 
+                  className="text-xs font-semibold uppercase tracking-wide mb-2"
+                  style={{ color: tokens.gold }}
+                >
+                  Key Point
+                </p>
+                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
+                  Senior debt sits at the top of the waterfall. Every dollar of revenue goes to 
+                  senior lenders first—including their interest and fees—before equity investors 
+                  or profit participants see anything.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* SECTION: GAP FINANCING */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="04" title="Gap Financing" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                <strong style={{ color: tokens.textPrimary }}>Gap financing</strong> fills the 
+                space between your secured capital (pre-sales, tax credits) and your total budget. 
+                It's called "gap" because it bridges the gap—typically 15-25% of budget.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Gap lenders take real risk. They're betting that your unsold territories will 
+                eventually sell for enough to cover their loan. Because of this risk, gap financing 
+                is more expensive than senior debt—expect interest rates of 12-18% plus fees.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Gap typically sits after senior debt but before equity in the recoupment waterfall. 
+                Some deals subordinate gap to equity recoupment—the terms vary significantly by lender 
+                and by the strength of your sales estimates.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: HOW IT ALL FITS */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="05" title="How It All Fits Together" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                A typical indie capital stack might look like this:
+              </p>
+              
+              <div 
+                className="p-4 font-mono text-xs space-y-1"
+                style={{ 
+                  background: tokens.bgSurface,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.borderSubtle}`,
+                  color: tokens.textMid,
+                }}
+              >
+                <div className="flex justify-between">
+                  <span>Tax Credit Advance (Senior)</span>
+                  <span style={{ color: tokens.textPrimary }}>25%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Pre-sale Loan (Senior)</span>
+                  <span style={{ color: tokens.textPrimary }}>15%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Gap Financing</span>
+                  <span style={{ color: tokens.textPrimary }}>20%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Equity Investment</span>
+                  <span style={{ color: tokens.textPrimary }}>40%</span>
+                </div>
+                <div 
+                  className="pt-2 mt-2 flex justify-between font-semibold"
+                  style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
+                >
+                  <span style={{ color: tokens.gold }}>Total</span>
+                  <span style={{ color: tokens.gold }}>100%</span>
+                </div>
+              </div>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                When revenues come in, they flow through the waterfall in order: distribution 
+                fees first, then senior debt gets repaid, then gap, then equity recovers their 
+                investment plus premium, and finally—if there's anything left—profits split 
+                according to the Operating Agreement.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: WHAT THIS MEANS FOR YOU */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="06" title="What This Means For You" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                As a producer, understanding the capital stack is essential because:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span>It determines how your waterfall is structured—you can't negotiate 
+                  recoupment positions without understanding who's providing what</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span>Each capital source has different cost implications—interest, 
+                  premiums, and backend participation all reduce what's available for profit</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span>Your personal backend (producer profit) only starts after everyone 
+                  else is satisfied—knowing the math helps you set realistic expectations</span>
+                </li>
+              </ul>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                The simulation in this tool lets you model different capital structures and see 
+                exactly how each scenario affects your waterfall. Small changes in the stack can 
+                have significant impacts on who actually gets paid.
+              </p>
+            </div>
+          </div>
+
+          {/* CTA SECTION */}
+          <div className="pt-6 flex flex-col items-center gap-6 animate-fade-in">
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              }}
+            />
+            
+            <Button 
+              onClick={() => navigate('/calculator')}
+              className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
+              style={{
+                background: `linear-gradient(135deg, ${tokens.gold} 0%, #E6C200 100%)`,
+                border: 'none',
+                borderRadius: tokens.radiusMd,
+                color: '#000000',
+                boxShadow: `0 8px 24px ${tokens.goldGlow}`,
+              }}
+            >
+              Run the Numbers
+              <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </Button>
+            
+            <div className="flex items-center gap-6">
+              <button
+                onClick={() => navigate('/intro')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <ArrowLeft className="w-4 h-4" />
+                <span>Back to Overview</span>
+              </button>
+              
+              <button
+                onClick={() => navigate('/fees-info')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <span>Distribution Fees</span>
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CapitalInfo;

--- a/src/pages/FeesInfo.tsx
+++ b/src/pages/FeesInfo.tsx
@@ -1,0 +1,473 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import Header from "@/components/Header";
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MINI WIKI: DISTRIBUTION FEES
+   Deep-dive on fees that come off the top before anyone gets paid.
+   ═══════════════════════════════════════════════════════════════════════════ */
+const tokens = {
+  bgVoid: '#000000',
+  bgMatte: '#0D0D0D',
+  bgHeader: '#111111',
+  bgSurface: '#141414',
+  
+  gold: '#FFD700',
+  goldMuted: 'rgba(255, 215, 0, 0.45)',
+  goldSubtle: 'rgba(255, 215, 0, 0.08)',
+  goldGlow: 'rgba(255, 215, 0, 0.25)',
+  goldFill: 'rgba(255, 215, 0, 0.12)',
+  goldRadiant: 'rgba(255, 215, 0, 0.18)',
+  
+  borderMatte: '#1A1A1A',
+  borderSubtle: '#222222',
+  
+  textPrimary: '#FFFFFF',
+  textMid: '#B0B0B0',
+  textDim: '#6B6B6B',
+  
+  radiusMd: '12px',
+  radiusLg: '14px',
+};
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SECTION HEADER — Radiant Gold Left Border
+   ═══════════════════════════════════════════════════════════════════════════ */
+interface SectionHeaderProps {
+  number: string;
+  title: string;
+}
+
+const SectionHeader = ({ number, title }: SectionHeaderProps) => (
+  <div 
+    className="flex items-stretch"
+    style={{ 
+      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
+      borderBottom: `1px solid ${tokens.borderMatte}`,
+    }}
+  >
+    <div 
+      className="w-1 flex-shrink-0"
+      style={{ 
+        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
+        boxShadow: `0 0 12px ${tokens.goldGlow}`,
+      }}
+    />
+    
+    <div 
+      className="flex items-center justify-center px-4 py-4"
+      style={{ 
+        borderRight: `1px solid ${tokens.borderSubtle}`,
+        minWidth: '56px',
+        background: tokens.goldFill,
+      }}
+    >
+      <span 
+        className="font-bebas text-xl tracking-wide"
+        style={{ color: tokens.gold }}
+      >
+        {number}
+      </span>
+    </div>
+    
+    <div className="flex items-center px-4 py-4">
+      <h2 
+        className="font-bold text-xs uppercase tracking-widest"
+        style={{ color: tokens.textPrimary }}
+      >
+        {title}
+      </h2>
+    </div>
+  </div>
+);
+
+const FeesInfo = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <Header />
+      
+      <div 
+        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
+        style={{ background: tokens.bgVoid }}
+      >
+        <div className="max-w-2xl mx-auto space-y-6">
+          
+          {/* PAGE HEADER */}
+          <div className="space-y-4 pt-6 animate-fade-in">
+            <button
+              onClick={() => navigate('/intro')}
+              className="flex items-center gap-2 text-sm transition-colors mb-4"
+              style={{ color: tokens.textDim }}
+              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span>Back to Overview</span>
+            </button>
+            
+            <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
+              Distribution <span style={{ color: tokens.gold }}>Fees</span>
+            </h1>
+            
+            <p 
+              className="text-base leading-relaxed max-w-lg"
+              style={{ color: tokens.textMid }}
+            >
+              The money that comes off the top before your waterfall even begins.
+            </p>
+            
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              }}
+            />
+          </div>
+
+          {/* SECTION: WHY FEES MATTER */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="01" title="Why Fees Matter" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                When a streamer or buyer acquires your film for $2 million, that $2 million 
+                doesn't flow directly into your waterfall. <strong style={{ color: tokens.textPrimary }}>
+                Distribution fees come off the top first</strong>—before senior debt, before 
+                equity recoupment, before anyone in your Operating Agreement sees a cent.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                These fees aren't optional. They're contractual obligations to the entities 
+                who sold, delivered, and collected on your film. Understanding them is 
+                critical because they directly reduce what's available for your waterfall.
+              </p>
+              
+              <div 
+                className="p-4 mt-2"
+                style={{ 
+                  background: tokens.goldSubtle,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.goldMuted}`,
+                }}
+              >
+                <p 
+                  className="text-xs font-semibold uppercase tracking-wide mb-2"
+                  style={{ color: tokens.gold }}
+                >
+                  Reality Check
+                </p>
+                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
+                  On a $2M acquisition, fees can easily total 20-30%. That means $400K-$600K 
+                  comes off before anyone in your waterfall gets paid.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* SECTION: SALES AGENT FEE */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="02" title="Sales Agent Fee" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                The <strong style={{ color: tokens.textPrimary }}>sales agent</strong> represents 
+                your film to international buyers and domestic distributors. They attend markets 
+                (Cannes, AFM, Berlin), pitch to acquisitions executives, negotiate deals, and 
+                sometimes advance marketing costs.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Sales agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
+                10-20%</strong> of gross revenues, depending on:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Territory</strong> — 
+                  domestic sales often command lower percentages than international</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Budget level</strong> — 
+                  larger films may negotiate better rates</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Cast/director</strong> — 
+                  star-driven packages may warrant lower fees</span>
+                </li>
+              </ul>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Some sales agents also charge <strong style={{ color: tokens.textPrimary }}>
+                market fees</strong> for attending festivals and markets, plus <strong style={{ color: tokens.textPrimary }}>
+                recoupable expenses</strong> for marketing materials, screeners, and travel.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: COLLECTION AGENT FEE */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="03" title="Collection Agent Fee" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                The <strong style={{ color: tokens.textPrimary }}>collection agent</strong> (also 
+                called a collection account manager or CAM) is a neutral third party who receives 
+                all revenues, applies the waterfall, and distributes payments to the correct parties.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Collection agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
+                1-5%</strong> of gross revenues. Common CAMs include Fintage House, Freeway, and 
+                Film Finances. While the percentage seems small, it comes off before anything else.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Why use a collection agent? They provide:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Investor confidence</strong> — 
+                  a neutral party ensures the waterfall is followed correctly</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Audit trail</strong> — 
+                  detailed accounting for every dollar that flows through</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Lender requirement</strong> — 
+                  most senior lenders require a CAM before funding</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          {/* SECTION: DELIVERY COSTS */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="04" title="Delivery Costs" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                When a buyer acquires your film, they don't just want the movie—they want a 
+                complete <strong style={{ color: tokens.textPrimary }}>delivery package</strong>. 
+                This includes specific technical masters, audio mixes, subtitles, closed captions, 
+                artwork, and legal documentation.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Delivery costs vary significantly but can range from $25,000 to $150,000+ depending 
+                on the buyer's requirements. Streamers like Netflix have particularly detailed 
+                technical specifications.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                In most deals, delivery costs are <strong style={{ color: tokens.textPrimary }}>
+                recoupable</strong>—meaning they come off the top of your revenues, just like 
+                distribution fees. Make sure your budget includes a realistic delivery allowance.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: THE REAL MATH */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="05" title="The Real Math" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Here's what happens to a $2,000,000 acquisition before it reaches your waterfall:
+              </p>
+              
+              <div 
+                className="p-4 font-mono text-xs space-y-1"
+                style={{ 
+                  background: tokens.bgSurface,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.borderSubtle}`,
+                  color: tokens.textMid,
+                }}
+              >
+                <div className="flex justify-between">
+                  <span>Gross Acquisition</span>
+                  <span style={{ color: tokens.textPrimary }}>$2,000,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Sales Agent (15%)</span>
+                  <span style={{ color: '#EF4444' }}>− $300,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Collection Agent (3%)</span>
+                  <span style={{ color: '#EF4444' }}>− $60,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Market Expenses</span>
+                  <span style={{ color: '#EF4444' }}>− $40,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Delivery Costs</span>
+                  <span style={{ color: '#EF4444' }}>− $75,000</span>
+                </div>
+                <div 
+                  className="pt-2 mt-2 flex justify-between font-semibold"
+                  style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
+                >
+                  <span style={{ color: tokens.gold }}>Net to Waterfall</span>
+                  <span style={{ color: tokens.gold }}>$1,525,000</span>
+                </div>
+              </div>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                That's nearly <strong style={{ color: tokens.textPrimary }}>24% gone</strong> before 
+                your senior debt, equity investors, or profit participants see anything. And this 
+                is just one territory—international sales may have additional layers of fees.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: NEGOTIATING FEES */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="06" title="Negotiating Fees" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                While fees are standard in the industry, they're not set in stone. Producers 
+                with leverage (strong packages, track records, or competing offers) can negotiate:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Caps on recoupable expenses</strong> — 
+                  limit how much a sales agent can charge back</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Sliding scale percentages</strong> — 
+                  lower rates as revenues increase</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Sunset clauses</strong> — 
+                  fees that reduce or expire after a certain period</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Territory carve-outs</strong> — 
+                  excluding territories where you have direct relationships</span>
+                </li>
+              </ul>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Always have an entertainment attorney review your sales representation and 
+                collection agreements before signing. Small percentage differences can translate 
+                to significant dollar amounts.
+              </p>
+            </div>
+          </div>
+
+          {/* CTA SECTION */}
+          <div className="pt-6 flex flex-col items-center gap-6 animate-fade-in">
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              }}
+            />
+            
+            <Button 
+              onClick={() => navigate('/calculator')}
+              className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
+              style={{
+                background: `linear-gradient(135deg, ${tokens.gold} 0%, #E6C200 100%)`,
+                border: 'none',
+                borderRadius: tokens.radiusMd,
+                color: '#000000',
+                boxShadow: `0 8px 24px ${tokens.goldGlow}`,
+              }}
+            >
+              Model Your Fees
+              <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </Button>
+            
+            <div className="flex items-center gap-6">
+              <button
+                onClick={() => navigate('/capital-info')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <ArrowLeft className="w-4 h-4" />
+                <span>Capital Stack</span>
+              </button>
+              
+              <button
+                onClick={() => navigate('/waterfall-info')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <span>Recoupment</span>
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FeesInfo;

--- a/src/pages/IntroView.tsx
+++ b/src/pages/IntroView.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight, ArrowLeft, ChevronDown, DollarSign, Layers, Percent, GitBranch } from 'lucide-react';
+import { ArrowRight, ArrowLeft, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
 import Header from "@/components/Header";
@@ -13,35 +13,27 @@ import { cn } from "@/lib/utils";
    - Apps: Gold left border accent, dark matte surfaces, premium sparse gold
    ═══════════════════════════════════════════════════════════════════════════ */
 const tokens = {
-  // Backgrounds - Matte surfaces
   bgVoid: '#000000',
-  bgMatte: '#0D0D0D',      // Primary card surface
-  bgHeader: '#111111',     // Header bars
-  bgSurface: '#141414',    // Elevated surfaces
-  bgElevated: '#1A1A1A',   // Even more elevated
+  bgMatte: '#0D0D0D',
+  bgHeader: '#111111',
+  bgSurface: '#141414',
   
-  // Gold System — Radiant but controlled
   gold: '#FFD700',
   goldMuted: 'rgba(255, 215, 0, 0.45)',
   goldSubtle: 'rgba(255, 215, 0, 0.08)',
   goldGlow: 'rgba(255, 215, 0, 0.25)',
   goldFill: 'rgba(255, 215, 0, 0.12)',
-  goldRadiant: 'rgba(255, 215, 0, 0.18)',  // For header glow effect
+  goldRadiant: 'rgba(255, 215, 0, 0.18)',
   
-  // Borders
   borderMatte: '#1A1A1A',
   borderSubtle: '#222222',
-  borderGold: 'rgba(255, 215, 0, 0.3)',
   
-  // Text
   textPrimary: '#FFFFFF',
   textMid: '#B0B0B0',
   textDim: '#6B6B6B',
   
-  // Radius
   radiusMd: '12px',
   radiusLg: '14px',
-  radiusSm: '8px',
 };
 
 interface FAQItem {
@@ -69,7 +61,7 @@ const faqItems: FAQItem[] = [
 ];
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER COMPONENT — Radiant Gold Left Border + Matte Gray Surface
+   SECTION HEADER — Radiant Gold Left Border + Matte Gray Surface
    ═══════════════════════════════════════════════════════════════════════════ */
 interface SectionHeaderProps {
   number: string;
@@ -84,7 +76,6 @@ const SectionHeader = ({ number, title }: SectionHeaderProps) => (
       borderBottom: `1px solid ${tokens.borderMatte}`,
     }}
   >
-    {/* Radiant Gold Left Border Accent */}
     <div 
       className="w-1 flex-shrink-0"
       style={{ 
@@ -93,7 +84,6 @@ const SectionHeader = ({ number, title }: SectionHeaderProps) => (
       }}
     />
     
-    {/* Chapter Number Box with Gold Fill */}
     <div 
       className="flex items-center justify-center px-4 py-4"
       style={{ 
@@ -110,7 +100,6 @@ const SectionHeader = ({ number, title }: SectionHeaderProps) => (
       </span>
     </div>
     
-    {/* Title */}
     <div className="flex items-center px-4 py-4">
       <h2 
         className="font-bold text-xs uppercase tracking-widest"
@@ -123,141 +112,44 @@ const SectionHeader = ({ number, title }: SectionHeaderProps) => (
 );
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   MINI-WIKI PREVIEW CARD — Shows actual content preview, clickable
+   PILLAR SECTION — Each pillar gets its own containment header
    ═══════════════════════════════════════════════════════════════════════════ */
-interface MiniWikiPreviewProps {
+interface PillarSectionProps {
   number: string;
   title: string;
-  icon: React.ReactNode;
-  previewContent: {
-    label: string;
-    value: string;
-  }[];
-  exampleNote?: string;
-  onClick: () => void;
+  children: React.ReactNode;
+  learnMorePath: string;
 }
 
-const MiniWikiPreview = ({ number, title, icon, previewContent, exampleNote, onClick }: MiniWikiPreviewProps) => (
-  <button
-    onClick={onClick}
-    className="w-full text-left group transition-all duration-200 hover:scale-[1.01]"
-    style={{ 
-      background: tokens.bgMatte,
-      border: `1px solid ${tokens.borderMatte}`,
-      borderRadius: tokens.radiusLg,
-      overflow: 'hidden',
-    }}
-  >
-    {/* Mini Header with Gold Accent */}
+const PillarSection = ({ number, title, children, learnMorePath }: PillarSectionProps) => {
+  const navigate = useNavigate();
+  
+  return (
     <div 
-      className="flex items-stretch"
+      className="overflow-hidden animate-fade-in"
       style={{ 
-        background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 20%, ${tokens.bgHeader} 100%)`,
-        borderBottom: `1px solid ${tokens.borderMatte}`,
+        background: tokens.bgMatte,
+        border: `1px solid ${tokens.borderMatte}`,
+        borderRadius: tokens.radiusLg,
       }}
     >
-      {/* Gold Left Border */}
-      <div 
-        className="w-1 flex-shrink-0"
-        style={{ 
-          background: tokens.gold,
-          boxShadow: `0 0 8px ${tokens.goldGlow}`,
-        }}
-      />
+      <SectionHeader number={number} title={title} />
       
-      {/* Number Box */}
-      <div 
-        className="flex items-center justify-center px-3 py-3"
-        style={{ 
-          borderRight: `1px solid ${tokens.borderSubtle}`,
-          minWidth: '44px',
-          background: tokens.goldFill,
-        }}
-      >
-        <span 
-          className="font-bebas text-base tracking-wide"
+      <div className="p-5 space-y-4">
+        {children}
+        
+        <button
+          onClick={() => navigate(learnMorePath)}
+          className="flex items-center gap-2 text-sm font-medium transition-all hover:gap-3"
           style={{ color: tokens.gold }}
         >
-          {number}
-        </span>
-      </div>
-      
-      {/* Icon + Title */}
-      <div className="flex items-center gap-2 px-3 py-3">
-        <span style={{ color: tokens.goldMuted }}>{icon}</span>
-        <h3 
-          className="font-bold text-xs uppercase tracking-widest"
-          style={{ color: tokens.textPrimary }}
-        >
-          {title}
-        </h3>
-      </div>
-      
-      {/* Arrow on hover */}
-      <div className="ml-auto flex items-center pr-3">
-        <ArrowRight 
-          className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity"
-          style={{ color: tokens.gold }}
-        />
+          <span>Deep dive</span>
+          <ArrowRight className="w-4 h-4" />
+        </button>
       </div>
     </div>
-    
-    {/* Preview Content — Example of what they'll see */}
-    <div className="p-4 space-y-3">
-      {/* Example Label */}
-      <div 
-        className="text-[10px] uppercase tracking-widest font-medium"
-        style={{ color: tokens.goldMuted }}
-      >
-        Preview
-      </div>
-      
-      {/* Preview Items */}
-      <div className="space-y-2">
-        {previewContent.map((item, idx) => (
-          <div 
-            key={idx}
-            className="flex justify-between items-center py-2 px-3"
-            style={{ 
-              background: tokens.bgSurface,
-              borderRadius: tokens.radiusSm,
-              border: `1px solid ${tokens.borderSubtle}`,
-            }}
-          >
-            <span className="text-xs" style={{ color: tokens.textMid }}>
-              {item.label}
-            </span>
-            <span 
-              className="text-xs font-mono font-semibold"
-              style={{ color: tokens.textPrimary }}
-            >
-              {item.value}
-            </span>
-          </div>
-        ))}
-      </div>
-      
-      {/* Example Note */}
-      {exampleNote && (
-        <p 
-          className="text-[11px] italic pt-1"
-          style={{ color: tokens.textDim }}
-        >
-          {exampleNote}
-        </p>
-      )}
-      
-      {/* Learn More Link */}
-      <div 
-        className="flex items-center gap-1 pt-2 text-xs font-medium group-hover:gap-2 transition-all"
-        style={{ color: tokens.gold }}
-      >
-        <span>Learn more</span>
-        <ArrowRight className="w-3 h-3" />
-      </div>
-    </div>
-  </button>
-);
+  );
+};
 
 const IntroView = () => {
   const navigate = useNavigate();
@@ -268,7 +160,7 @@ const IntroView = () => {
   };
 
   const handleStartSimulation = () => {
-    navigate('/budget-info');
+    navigate('/calculator');
   };
 
   return (
@@ -296,7 +188,6 @@ const IntroView = () => {
               How money moves through a film deal—from acquisition to your pocket.
             </p>
             
-            {/* Gold Gradient Divider */}
             <div 
               className="h-px w-full"
               style={{ 
@@ -306,93 +197,96 @@ const IntroView = () => {
           </div>
 
           {/* ═══════════════════════════════════════════════════════════════
-              SECTION 01 — WHAT'S YOUR MODEL? (Mini-Wiki Previews)
+              PILLAR 01 — PRODUCTION BUDGET
               ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
+          <PillarSection
+            number="01"
+            title="Production Budget"
+            learnMorePath="/budget-info"
           >
-            <SectionHeader number="01" title="What's Your Model?" />
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              Also called <strong style={{ color: tokens.textPrimary }}>Negative Cost</strong>—the 
+              total amount required to produce your film. This includes everything from script 
+              development through final delivery: above-the-line talent, crew, equipment, 
+              locations, post-production, and contingency.
+            </p>
             
-            <div className="p-5 space-y-5">
-              {/* Intro Context */}
-              <p 
-                className="text-sm leading-relaxed"
-                style={{ color: tokens.textMid }}
-              >
-                Here's an example of what you'll model. Each section below previews the actual 
-                content—click any to dive deeper before starting your simulation.
-              </p>
-              
-              {/* Mini-Wiki Previews — 2×2 Grid */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                
-                {/* PRODUCTION BUDGET Preview */}
-                <MiniWikiPreview
-                  number="01"
-                  title="Production Budget"
-                  icon={<DollarSign className="w-4 h-4" />}
-                  previewContent={[
-                    { label: "Negative Cost", value: "$850,000" },
-                    { label: "Above-the-Line", value: "$127,500" },
-                    { label: "Contingency", value: "$42,500" },
-                  ]}
-                  exampleNote="This is what it costs to make the film."
-                  onClick={() => navigate('/budget-info')}
-                />
-                
-                {/* CAPITAL STACK Preview */}
-                <MiniWikiPreview
-                  number="02"
-                  title="Capital Stack"
-                  icon={<Layers className="w-4 h-4" />}
-                  previewContent={[
-                    { label: "Senior Debt", value: "$340,000" },
-                    { label: "Equity", value: "$425,000" },
-                    { label: "Deferrals", value: "$85,000" },
-                  ]}
-                  exampleNote="How production is funded."
-                  onClick={() => navigate('/capital-info')}
-                />
-                
-                {/* DISTRIBUTION FEES Preview */}
-                <MiniWikiPreview
-                  number="03"
-                  title="Distribution Fees"
-                  icon={<Percent className="w-4 h-4" />}
-                  previewContent={[
-                    { label: "Sales Agent", value: "10%" },
-                    { label: "Collection Agent", value: "5%" },
-                    { label: "Net to Waterfall", value: "85%" },
-                  ]}
-                  exampleNote="What comes off the top first."
-                  onClick={() => navigate('/fees-info')}
-                />
-                
-                {/* RECOUPMENT WATERFALL Preview */}
-                <MiniWikiPreview
-                  number="04"
-                  title="Recoupment Waterfall"
-                  icon={<GitBranch className="w-4 h-4" />}
-                  previewContent={[
-                    { label: "Position 1", value: "Senior Debt" },
-                    { label: "Position 2", value: "Equity" },
-                    { label: "Position 3", value: "Profit Split" },
-                  ]}
-                  exampleNote="The order money flows out."
-                  onClick={() => navigate('/waterfall-info')}
-                />
-                
-              </div>
-            </div>
-          </div>
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              Your budget isn't just a number—it's the foundation of your entire deal structure. 
+              It determines how much capital you need to raise, what your realistic sales 
+              expectations should be, and ultimately how the waterfall will flow.
+            </p>
+          </PillarSection>
 
           {/* ═══════════════════════════════════════════════════════════════
-              SECTION 02 — WHY THIS MATTERS
+              PILLAR 02 — CAPITAL STACK
+              ═══════════════════════════════════════════════════════════════ */}
+          <PillarSection
+            number="02"
+            title="Capital Stack"
+            learnMorePath="/capital-info"
+          >
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              The <strong style={{ color: tokens.textPrimary }}>capital stack</strong> is how 
+              your production gets funded. Most independent films combine multiple sources: 
+              equity investors who own a piece of the upside, senior debt that gets repaid 
+              first, gap financing against unsold territories, and sometimes tax incentives 
+              or soft money.
+            </p>
+            
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              The structure of your capital stack directly determines your waterfall. Whoever 
+              provides the riskiest money typically demands the most favorable recoupment 
+              position. Understanding this relationship is essential before you sign anything.
+            </p>
+          </PillarSection>
+
+          {/* ═══════════════════════════════════════════════════════════════
+              PILLAR 03 — DISTRIBUTION FEES
+              ═══════════════════════════════════════════════════════════════ */}
+          <PillarSection
+            number="03"
+            title="Distribution Fees"
+            learnMorePath="/fees-info"
+          >
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              Before anyone in your waterfall sees a dollar, <strong style={{ color: tokens.textPrimary }}>
+              distribution fees come off the top</strong>. Sales agents typically take 10-20%, 
+              collection agents take 1-5%, and there may be additional market fees, delivery 
+              costs, and recoupable expenses.
+            </p>
+            
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              A $2M acquisition doesn't mean $2M flows to your waterfall. After fees, you 
+              might see $1.6M or less. This is why understanding the fee stack is critical 
+              before celebrating any sale.
+            </p>
+          </PillarSection>
+
+          {/* ═══════════════════════════════════════════════════════════════
+              PILLAR 04 — RECOUPMENT WATERFALL
+              ═══════════════════════════════════════════════════════════════ */}
+          <PillarSection
+            number="04"
+            title="Recoupment Waterfall"
+            learnMorePath="/waterfall-info"
+          >
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              The <strong style={{ color: tokens.textPrimary }}>waterfall</strong> is the 
+              contractual order in which revenues are distributed. Each position must be 
+              fully satisfied before the next position receives anything. Senior debt typically 
+              sits first, followed by equity recoupment, then profit participation.
+            </p>
+            
+            <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              Your position in the waterfall determines when—and if—you get paid. A producer 
+              with a 50% backend sounds great, but if that backend only triggers after $5M 
+              in prior positions are satisfied, the reality might be very different.
+            </p>
+          </PillarSection>
+
+          {/* ═══════════════════════════════════════════════════════════════
+              WHY THIS MATTERS
               ═══════════════════════════════════════════════════════════════ */}
           <div 
             className="overflow-hidden animate-fade-in"
@@ -402,7 +296,7 @@ const IntroView = () => {
               borderRadius: tokens.radiusLg,
             }}
           >
-            <SectionHeader number="02" title="Why This Matters" />
+            <SectionHeader number="05" title="Why This Matters" />
             
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -418,7 +312,7 @@ const IntroView = () => {
               </p>
               
               <div 
-                className="p-4 mt-4"
+                className="p-4 mt-2"
                 style={{ 
                   background: tokens.goldSubtle,
                   borderRadius: tokens.radiusMd,
@@ -441,7 +335,7 @@ const IntroView = () => {
           </div>
 
           {/* ═══════════════════════════════════════════════════════════════
-              SECTION 03 — FAQ
+              FAQ
               ═══════════════════════════════════════════════════════════════ */}
           <div 
             className="overflow-hidden animate-fade-in"
@@ -451,9 +345,8 @@ const IntroView = () => {
               borderRadius: tokens.radiusLg,
             }}
           >
-            <SectionHeader number="03" title="FAQ" />
+            <SectionHeader number="06" title="FAQ" />
             
-            {/* FAQ Accordion — Notion-style toggles */}
             <div>
               {faqItems.map((item, index) => (
                 <div 
@@ -505,7 +398,6 @@ const IntroView = () => {
               CTA SECTION
               ═══════════════════════════════════════════════════════════════ */}
           <div className="pt-6 flex flex-col items-center gap-6 animate-fade-in">
-            {/* Gold Gradient Divider */}
             <div 
               className="h-px w-full"
               style={{ 
@@ -513,7 +405,6 @@ const IntroView = () => {
               }}
             />
             
-            {/* CTA Button — Routes to /budget-info (first wiki page) */}
             <Button 
               onClick={handleStartSimulation}
               className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
@@ -529,7 +420,6 @@ const IntroView = () => {
               <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Button>
             
-            {/* Back Link */}
             <button
               onClick={() => navigate('/')}
               className="flex items-center gap-2 text-sm transition-colors"

--- a/src/pages/WaterfallInfo.tsx
+++ b/src/pages/WaterfallInfo.tsx
@@ -1,0 +1,533 @@
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import Header from "@/components/Header";
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MINI WIKI: RECOUPMENT WATERFALL
+   Deep-dive on how revenues are distributed in order of priority.
+   ═══════════════════════════════════════════════════════════════════════════ */
+const tokens = {
+  bgVoid: '#000000',
+  bgMatte: '#0D0D0D',
+  bgHeader: '#111111',
+  bgSurface: '#141414',
+  
+  gold: '#FFD700',
+  goldMuted: 'rgba(255, 215, 0, 0.45)',
+  goldSubtle: 'rgba(255, 215, 0, 0.08)',
+  goldGlow: 'rgba(255, 215, 0, 0.25)',
+  goldFill: 'rgba(255, 215, 0, 0.12)',
+  goldRadiant: 'rgba(255, 215, 0, 0.18)',
+  
+  borderMatte: '#1A1A1A',
+  borderSubtle: '#222222',
+  
+  textPrimary: '#FFFFFF',
+  textMid: '#B0B0B0',
+  textDim: '#6B6B6B',
+  
+  radiusMd: '12px',
+  radiusLg: '14px',
+};
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SECTION HEADER — Radiant Gold Left Border
+   ═══════════════════════════════════════════════════════════════════════════ */
+interface SectionHeaderProps {
+  number: string;
+  title: string;
+}
+
+const SectionHeader = ({ number, title }: SectionHeaderProps) => (
+  <div 
+    className="flex items-stretch"
+    style={{ 
+      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
+      borderBottom: `1px solid ${tokens.borderMatte}`,
+    }}
+  >
+    <div 
+      className="w-1 flex-shrink-0"
+      style={{ 
+        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
+        boxShadow: `0 0 12px ${tokens.goldGlow}`,
+      }}
+    />
+    
+    <div 
+      className="flex items-center justify-center px-4 py-4"
+      style={{ 
+        borderRight: `1px solid ${tokens.borderSubtle}`,
+        minWidth: '56px',
+        background: tokens.goldFill,
+      }}
+    >
+      <span 
+        className="font-bebas text-xl tracking-wide"
+        style={{ color: tokens.gold }}
+      >
+        {number}
+      </span>
+    </div>
+    
+    <div className="flex items-center px-4 py-4">
+      <h2 
+        className="font-bold text-xs uppercase tracking-widest"
+        style={{ color: tokens.textPrimary }}
+      >
+        {title}
+      </h2>
+    </div>
+  </div>
+);
+
+const WaterfallInfo = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <Header />
+      
+      <div 
+        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
+        style={{ background: tokens.bgVoid }}
+      >
+        <div className="max-w-2xl mx-auto space-y-6">
+          
+          {/* PAGE HEADER */}
+          <div className="space-y-4 pt-6 animate-fade-in">
+            <button
+              onClick={() => navigate('/intro')}
+              className="flex items-center gap-2 text-sm transition-colors mb-4"
+              style={{ color: tokens.textDim }}
+              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span>Back to Overview</span>
+            </button>
+            
+            <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
+              Recoupment <span style={{ color: tokens.gold }}>Waterfall</span>
+            </h1>
+            
+            <p 
+              className="text-base leading-relaxed max-w-lg"
+              style={{ color: tokens.textMid }}
+            >
+              The contractual order that determines who gets paid—and when.
+            </p>
+            
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              }}
+            />
+          </div>
+
+          {/* SECTION: WHAT IS A WATERFALL */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="01" title="What Is a Waterfall?" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                The <strong style={{ color: tokens.textPrimary }}>recoupment waterfall</strong> is 
+                the contractual hierarchy that determines how revenues flow through a film deal. 
+                Like water flowing down a series of pools, money fills each "position" completely 
+                before spilling over to the next.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                This isn't a metaphor—it's a legally binding document, typically defined in the 
+                <strong style={{ color: tokens.textPrimary }}> Operating Agreement</strong> or 
+                <strong style={{ color: tokens.textPrimary }}> Interparty Agreement</strong> that 
+                governs your production. Every dollar of revenue follows this exact path.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Understanding your waterfall isn't optional—it's the only way to know whether 
+                your "50% backend" actually means anything, or whether it triggers so late that 
+                it's essentially worthless.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: TYPICAL WATERFALL ORDER */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="02" title="Typical Waterfall Order" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                While every deal is different, a typical indie film waterfall follows this order:
+              </p>
+              
+              <div 
+                className="p-4 font-mono text-xs space-y-3"
+                style={{ 
+                  background: tokens.bgSurface,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.borderSubtle}`,
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    1
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Distribution Fees</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Sales agent, collection agent, market expenses</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    2
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Delivery Costs</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Technical masters, materials, recoupable expenses</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    3
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Senior Debt</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Bank loans, tax credit advances (principal + interest)</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    4
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Gap Financing</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Gap loans (principal + interest + fees)</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    5
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Equity Recoupment</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Investor principal + negotiated premium (10-25%)</p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start gap-3">
+                  <span 
+                    className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center"
+                    style={{ background: tokens.goldFill, color: tokens.gold }}
+                  >
+                    6
+                  </span>
+                  <div>
+                    <span style={{ color: tokens.textPrimary }}>Profit Participation</span>
+                    <p style={{ color: tokens.textDim }} className="mt-1">Producer backend, talent deferrals, investor backend</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* SECTION: RECOUPMENT POSITIONS */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="03" title="Recoupment Positions" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Your <strong style={{ color: tokens.textPrimary }}>recoupment position</strong> is 
+                where you sit in the waterfall. Earlier positions get paid first—which means 
+                they're safer but typically offer lower returns. Later positions take more risk 
+                but can be more lucrative if the film performs well.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Common position structures:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>First dollar</strong> — 
+                  the earliest position after fees; the safest for investors</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Pari passu</strong> — 
+                  multiple parties sharing the same position proportionally</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Subordinated</strong> — 
+                  a position that only triggers after higher positions are satisfied</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Last money in</strong> — 
+                  sometimes the final investor gets first recoupment as an incentive</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          {/* SECTION: PROFIT CORRIDORS */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="04" title="Profit Corridors" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                After everyone above the line recoups, the remaining money is 
+                <strong style={{ color: tokens.textPrimary }}> profit</strong>. But profit doesn't 
+                just pile up—it gets split according to the Operating Agreement.
+              </p>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                A typical split might look like:
+              </p>
+              
+              <div 
+                className="p-4 font-mono text-xs space-y-1"
+                style={{ 
+                  background: tokens.bgSurface,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.borderSubtle}`,
+                  color: tokens.textMid,
+                }}
+              >
+                <div className="flex justify-between">
+                  <span>Equity Investors (backend)</span>
+                  <span style={{ color: tokens.textPrimary }}>50%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Producers (combined)</span>
+                  <span style={{ color: tokens.textPrimary }}>25%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Talent Deferrals</span>
+                  <span style={{ color: tokens.textPrimary }}>15%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Director</span>
+                  <span style={{ color: tokens.textPrimary }}>5%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Writer</span>
+                  <span style={{ color: tokens.textPrimary }}>5%</span>
+                </div>
+                <div 
+                  className="pt-2 mt-2 flex justify-between font-semibold"
+                  style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
+                >
+                  <span style={{ color: tokens.gold }}>Total</span>
+                  <span style={{ color: tokens.gold }}>100%</span>
+                </div>
+              </div>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Some deals include <strong style={{ color: tokens.textPrimary }}>
+                multiple profit corridors</strong>—for example, after equity recoups 110%, 
+                the split might shift to favor producers more heavily.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: THE HARSH REALITY */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="05" title="The Harsh Reality" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Here's what nobody tells you: on most independent films, the waterfall never 
+                reaches profit participation. The combination of distribution fees, delivery 
+                costs, and capital recoupment often exceeds what the film earns.
+              </p>
+              
+              <div 
+                className="p-4 mt-2"
+                style={{ 
+                  background: tokens.goldSubtle,
+                  borderRadius: tokens.radiusMd,
+                  border: `1px solid ${tokens.goldMuted}`,
+                }}
+              >
+                <p 
+                  className="text-xs font-semibold uppercase tracking-wide mb-2"
+                  style={{ color: tokens.gold }}
+                >
+                  Industry Reality
+                </p>
+                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
+                  A $1M film that sells for $1.5M might look profitable on paper. But after 
+                  20% in fees ($300K), $50K in delivery, and $1M in capital recoupment, only 
+                  $150K reaches profit—and that still needs to be split among multiple parties.
+                </p>
+              </div>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                This is why understanding the waterfall before you sign is critical. A "generous" 
+                backend that triggers after $3M in prior positions might never pay out on a film 
+                that's realistic about its sales potential.
+              </p>
+            </div>
+          </div>
+
+          {/* SECTION: PROTECTING YOURSELF */}
+          <div 
+            className="overflow-hidden animate-fade-in"
+            style={{ 
+              background: tokens.bgMatte,
+              border: `1px solid ${tokens.borderMatte}`,
+              borderRadius: tokens.radiusLg,
+            }}
+          >
+            <SectionHeader number="06" title="Protecting Yourself" />
+            
+            <div className="p-5 space-y-4">
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                As a producer, there are several ways to improve your position:
+              </p>
+              
+              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Negotiate a producer fee</strong> — 
+                  a fixed amount in the budget that you receive regardless of performance</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>First position corridor</strong> — 
+                  a small percentage that comes off before investor recoupment</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Run the math</strong> — 
+                  model your waterfall against realistic sales to see what you'll actually receive</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <span style={{ color: tokens.gold }}>•</span>
+                  <span><strong style={{ color: tokens.textPrimary }}>Audit rights</strong> — 
+                  ensure you have the contractual right to audit the collection account</span>
+                </li>
+              </ul>
+              
+              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+                Most importantly: have an entertainment attorney review your Operating Agreement 
+                before signing. The waterfall is where your deal is won or lost.
+              </p>
+            </div>
+          </div>
+
+          {/* CTA SECTION */}
+          <div className="pt-6 flex flex-col items-center gap-6 animate-fade-in">
+            <div 
+              className="h-px w-full"
+              style={{ 
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              }}
+            />
+            
+            <Button 
+              onClick={() => navigate('/calculator')}
+              className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
+              style={{
+                background: `linear-gradient(135deg, ${tokens.gold} 0%, #E6C200 100%)`,
+                border: 'none',
+                borderRadius: tokens.radiusMd,
+                color: '#000000',
+                boxShadow: `0 8px 24px ${tokens.goldGlow}`,
+              }}
+            >
+              See Your Waterfall
+              <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </Button>
+            
+            <div className="flex items-center gap-6">
+              <button
+                onClick={() => navigate('/fees-info')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <ArrowLeft className="w-4 h-4" />
+                <span>Distribution Fees</span>
+              </button>
+              
+              <button
+                onClick={() => navigate('/intro')}
+                className="flex items-center gap-2 text-sm transition-colors"
+                style={{ color: tokens.textDim }}
+                onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
+                onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              >
+                <span>Overview</span>
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default WaterfallInfo;


### PR DESCRIPTION
## Summary

Rebuilds the wiki system with proper architecture: main wiki overview + 4 separate deep-dive mini wiki pages.

## Changes

### Main Wiki (`/intro` - IntroView.tsx)
- Each pillar gets its **own containment header** (not nested cards)
- Real educational content explaining each concept
- "Deep dive" links to detailed mini wiki pages
- FAQ section with toggle accordion
- No fake dashboard numbers

### New Mini Wiki Pages
| Route | Page | Content |
|-------|------|---------|
| `/capital-info` | CapitalInfo.tsx | Equity, senior debt, gap financing, capital stack structure |
| `/fees-info` | FeesInfo.tsx | Sales agent fees, CAM fees, delivery costs, real fee math |
| `/waterfall-info` | WaterfallInfo.tsx | Waterfall order, recoupment positions, profit corridors |

### Updated Routes
- Added all three new page imports and routes in App.tsx

## Architecture
```
/intro (Main Wiki)
├── Links to → /budget-info (Production Budget)
├── Links to → /capital-info (Capital Stack)
├── Links to → /fees-info (Distribution Fees)
└── Links to → /waterfall-info (Recoupment Waterfall)
```

## Design System Applied
- Containment headers with gold left border + radiant glow
- Chapter number boxes with gold fill background
- Matte dark card bodies with generous whitespace
- Sparse gold usage (accents only)
- Navigation between mini wikis

## Files Changed
- `src/pages/IntroView.tsx` - Rebuilt main wiki
- `src/pages/CapitalInfo.tsx` - New
- `src/pages/FeesInfo.tsx` - New  
- `src/pages/WaterfallInfo.tsx` - New
- `src/App.tsx` - Updated routes