### PR TITLE
feat: Wiki Architecture Refactor - Accordion Pattern + Pure Action Calculator

### DIFF
--- a/src/components/calculator/budget/index.ts
+++ b/src/components/calculator/budget/index.ts
@@ -1,11 +1,4 @@
 // Budget Mini-App Components
-// Step-based architecture matching Stack tab pattern
+// Pure action zone - no wiki screens
 
-// Reuse WikiScreen from stack for consistency
-export { WikiScreen } from '../stack';
-
-// Step 0: Overview
-export { default as BudgetOverviewWiki } from './BudgetOverviewWiki';
-
-// Step 1: Input
 export { default as BudgetInput } from './BudgetInput';

--- a/src/components/calculator/deal/index.ts
+++ b/src/components/calculator/deal/index.ts
@@ -1,11 +1,4 @@
 // Deal Mini-App Components
-// Step-based architecture matching Stack/Budget pattern
+// Pure action zone - no wiki screens
 
-// Reuse WikiScreen from stack for consistency
-export { WikiScreen } from '../stack';
-
-// Step 0: Overview
-export { default as DealOverviewWiki } from './DealOverviewWiki';
-
-// Step 1: Input
 export { default as DealInput } from './DealInput';

--- a/src/components/calculator/stack/index.ts
+++ b/src/components/calculator/stack/index.ts
@@ -1,31 +1,14 @@
 // Stack Mini-App Components
-// Step-based architecture: each step is an isolated mini-app
+// Pure action zone - no wiki screens
 
-export { default as WikiScreen } from './WikiScreen';
 export { default as StackInputCard } from './StackInputCard';
 
-// Step 0: Overview
-export { default as StackOverviewWiki } from './StackOverviewWiki';
-
-// Step 1-2: Tax Credits
-export { default as TaxCreditsWiki } from './TaxCreditsWiki';
+// Input Components
 export { default as TaxCreditsInput } from './TaxCreditsInput';
-
-// Step 3-4: Senior Debt
-export { default as SeniorDebtWiki } from './SeniorDebtWiki';
 export { default as SeniorDebtInput } from './SeniorDebtInput';
-
-// Step 5-6: Gap/Mezz
-export { default as GapMezzWiki } from './GapMezzWiki';
 export { default as GapMezzInput } from './GapMezzInput';
-
-// Step 7-8: Equity
-export { default as EquityWiki } from './EquityWiki';
 export { default as EquityInput } from './EquityInput';
-
-// Step 9-10: Deferments
-export { default as DefermentsWiki } from './DefermentsWiki';
 export { default as DefermentsInput } from './DefermentsInput';
 
-// Step 11: Summary
+// Summary
 export { default as StackSummary } from './StackSummary';

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -1,53 +1,28 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { WaterfallInputs, GuildState } from "@/lib/waterfall";
 import { useHaptics } from "@/hooks/use-haptics";
 
-// Import budget mini-app components
-import { BudgetOverviewWiki, BudgetInput } from "../budget";
+// Import budget input component
+import BudgetInput from "../budget/BudgetInput";
 
 interface BudgetTabProps {
   inputs: WaterfallInputs;
   guilds: GuildState;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
   onToggleGuild: (guild: keyof GuildState) => void;
-  onAdvance?: () => void; // Called when user completes Budget and wants to go to Stack
+  onAdvance?: () => void;
 }
 
 /**
- * BudgetTab - Step Router (Mini-App Architecture)
+ * BudgetTab - Pure Action Zone
  * 
- * This tab manages navigation between isolated mini-app screens.
- * Each screen has ONE job: educate (Wiki) or collect data (Input).
+ * No wiki screens - education lives in /intro.
+ * This tab goes straight to input collection.
  * 
- * Step Map:
- * 0 = BudgetOverviewWiki (intro to negative cost concept)
- * 1 = BudgetInput (enter budget + quick amounts)
- * 
- * Smart Start: Skips wiki if budget already entered.
  * On completion, advances to Stack tab.
  */
 const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
   const haptics = useHaptics();
-  
-  // Smart start: Skip wiki if budget already entered
-  const [currentStep, setCurrentStep] = useState(() => {
-    return inputs.budget > 0 ? 1 : 0;
-  });
-
-  // Navigation helpers
-  const goToStep = useCallback((step: number) => {
-    haptics.light();
-    setCurrentStep(step);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [haptics]);
-
-  const nextStep = useCallback(() => {
-    goToStep(currentStep + 1);
-  }, [currentStep, goToStep]);
-
-  const prevStep = useCallback(() => {
-    goToStep(Math.max(0, currentStep - 1));
-  }, [currentStep, goToStep]);
 
   // Handle completion - advance to Stack tab
   const handleComplete = useCallback(() => {
@@ -57,32 +32,13 @@ const BudgetTab = ({ inputs, onUpdateInput, onAdvance }: BudgetTabProps) => {
     }
   }, [haptics, onAdvance]);
 
-  // Render the current step
-  const renderStep = () => {
-    switch (currentStep) {
-      // Step 0: Overview Wiki
-      case 0:
-        return <BudgetOverviewWiki onContinue={nextStep} />;
-
-      // Step 1: Budget Input
-      case 1:
-        return (
-          <BudgetInput
-            inputs={inputs}
-            onUpdateInput={onUpdateInput}
-            onBack={prevStep}
-            onNext={handleComplete}
-          />
-        );
-
-      default:
-        return <BudgetOverviewWiki onContinue={nextStep} />;
-    }
-  };
-
   return (
     <div className="pb-8">
-      {renderStep()}
+      <BudgetInput
+        inputs={inputs}
+        onUpdateInput={onUpdateInput}
+        onNext={handleComplete}
+      />
     </div>
   );
 };

--- a/src/components/calculator/tabs/DealTab.tsx
+++ b/src/components/calculator/tabs/DealTab.tsx
@@ -1,54 +1,29 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { WaterfallInputs, GuildState } from "@/lib/waterfall";
 import { CapitalSelections } from "../steps/CapitalSelectStep";
 import { useHaptics } from "@/hooks/use-haptics";
 
-// Import deal mini-app components
-import { DealOverviewWiki, DealInput } from "../deal";
+// Import deal input component
+import DealInput from "../deal/DealInput";
 
 interface DealTabProps {
   inputs: WaterfallInputs;
   guilds: GuildState;
   selections: CapitalSelections;
   onUpdateInput: (key: keyof WaterfallInputs, value: number) => void;
-  onAdvance?: () => void; // Called when user completes Deal and wants to go to Waterfall
+  onAdvance?: () => void;
 }
 
 /**
- * DealTab - Step Router (Mini-App Architecture)
+ * DealTab - Pure Action Zone
  * 
- * This tab manages navigation between isolated mini-app screens.
- * Each screen has ONE job: educate (Wiki) or collect data (Input).
+ * No wiki screens - education lives in /intro.
+ * This tab goes straight to input collection.
  * 
- * Step Map:
- * 0 = DealOverviewWiki (intro to acquisition/breakeven concepts)
- * 1 = DealInput (enter revenue + see breakeven status)
- * 
- * Smart Start: Skips wiki if revenue already entered.
  * On completion, advances to Waterfall tab.
  */
 const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealTabProps) => {
   const haptics = useHaptics();
-  
-  // Smart start: Skip wiki if revenue already entered
-  const [currentStep, setCurrentStep] = useState(() => {
-    return inputs.revenue > 0 ? 1 : 0;
-  });
-
-  // Navigation helpers
-  const goToStep = useCallback((step: number) => {
-    haptics.light();
-    setCurrentStep(step);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [haptics]);
-
-  const nextStep = useCallback(() => {
-    goToStep(currentStep + 1);
-  }, [currentStep, goToStep]);
-
-  const prevStep = useCallback(() => {
-    goToStep(Math.max(0, currentStep - 1));
-  }, [currentStep, goToStep]);
 
   // Handle completion - advance to Waterfall tab
   const handleComplete = useCallback(() => {
@@ -58,34 +33,15 @@ const DealTab = ({ inputs, guilds, selections, onUpdateInput, onAdvance }: DealT
     }
   }, [haptics, onAdvance]);
 
-  // Render the current step
-  const renderStep = () => {
-    switch (currentStep) {
-      // Step 0: Overview Wiki
-      case 0:
-        return <DealOverviewWiki onContinue={nextStep} />;
-
-      // Step 1: Deal Input
-      case 1:
-        return (
-          <DealInput
-            inputs={inputs}
-            guilds={guilds}
-            selections={selections}
-            onUpdateInput={onUpdateInput}
-            onBack={prevStep}
-            onNext={handleComplete}
-          />
-        );
-
-      default:
-        return <DealOverviewWiki onContinue={nextStep} />;
-    }
-  };
-
   return (
     <div className="pb-8">
-      {renderStep()}
+      <DealInput
+        inputs={inputs}
+        guilds={guilds}
+        selections={selections}
+        onUpdateInput={onUpdateInput}
+        onNext={handleComplete}
+      />
     </div>
   );
 };


### PR DESCRIPTION
# 🎬 Wiki Architecture Refactor

## Summary
Implements the confirmed wiki architecture from Product Bible v2.0:
- **Wiki Zone** = Teach (IntroView with accordions + deep dive pages)
- **Calculator Zone** = Do (pure action, no wiki screens)

---

## Changes

### 1. IntroView.tsx - Accordion Pattern ✨
- All 4 pillars now **collapsed by default**
- On expand → condensed content + "Deep dive" link
- Maintains NOTION meets apps design language
- Gold accent border with radiant glow effect

### 2. Tab Components - Pure Action Zone 🎯
- **BudgetTab**: Goes straight to BudgetInput (no wiki step)
- **StackTab**: Navigates between inputs only (removed 6 wiki screens)
- **DealTab**: Goes straight to DealInput (no wiki step)

### 3. Index Files - Cleaned Exports 🧹
- Removed all wiki component exports
- Wiki files are now orphaned (see issue for cleanup)

---

## User Flow (After This PR)

```
/intro (Wiki Zone)
├── Accordion pillars (collapsed by default)
│   ├── 01 Production Budget → /budget-info
│   ├── 02 Capital Stack → /capital-info
│   ├── 03 Distribution Fees → /fees-info
│   └── 04 Recoupment Waterfall → /waterfall-info
├── Why This Matters (always visible)
├── FAQ (accordion)
└── [Start Simulation] → /calculator

/calculator (Action Zone)
├── Budget Tab → BudgetInput
├── Stack Tab → Inputs → Summary
├── Deal Tab → DealInput
└── Waterfall Tab → Results
```

---

## Testing Checklist
- [ ] Visit `/intro` - all 4 pillars collapsed by default
- [ ] Click pillar header - expands with condensed content + deep dive link
- [ ] Click "Deep dive" - navigates to mini wiki and scrolls to top
- [ ] Click "Start Simulation" - navigates to calculator
- [ ] Budget tab - goes straight to input (no wiki)
- [ ] Stack tab - flows through inputs without wiki screens
- [ ] Deal tab - goes straight to input (no wiki)
- [ ] Full flow works on mobile

---

## Follow-up Required
⚠️ **See Issue #X** - Delete orphaned wiki files after merge