### PR TITLE
Unify color system and typography across calculator UI

### DIFF
--- a/src/components/calculator/DisclaimerFooter.tsx
+++ b/src/components/calculator/DisclaimerFooter.tsx
@@ -5,8 +5,8 @@ const DisclaimerFooter = () => {
     <div className="mt-8 py-4 border-t border-[#1A1A1A]">
       <div className="flex items-start gap-3">
         <AlertTriangle className="w-4 h-4 text-gold/40 flex-shrink-0 mt-0.5" />
-        <p className="text-[10px] text-white/30 leading-relaxed">
-          <span className="text-gold/50 font-medium">Educational model only.</span>{" "}
+        <p className="text-[10px] text-text-dim leading-relaxed">
+          <span className="text-gold font-medium">Educational model only.</span>{" "}
           Not financial, legal, or investment advice. Consult qualified entertainment 
           counsel and financial advisor before making deal decisions.
         </p>

--- a/src/components/calculator/StandardSectionHeader.tsx
+++ b/src/components/calculator/StandardSectionHeader.tsx
@@ -21,7 +21,7 @@ export const StandardSectionHeader = ({
     <div className="matte-section-header px-5 py-3 flex items-center justify-between">
       <div className="flex items-center gap-3">
         <Icon className="w-4 h-4 text-gold/60" />
-        <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+        <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
           {label}
         </span>
       </div>

--- a/src/components/calculator/StandardStepIcon.tsx
+++ b/src/components/calculator/StandardStepIcon.tsx
@@ -15,7 +15,7 @@ export const StandardStepIcon = ({ icon: Icon, label }: StandardStepIconProps) =
         <Icon className="w-5 h-5 text-gold" />
       </div>
       {label && (
-        <p className="text-white/30 text-[10px] mt-2 uppercase tracking-widest text-center">
+        <p className="text-text-dim text-[10px] mt-2 uppercase tracking-widest text-center">
           {label}
         </p>
       )}

--- a/src/components/calculator/StandardStepLayout.tsx
+++ b/src/components/calculator/StandardStepLayout.tsx
@@ -73,7 +73,7 @@ const StandardStepLayout = ({
           <span className="text-gold">{titleHighlight}</span>
         </h2>
 
-        <p className="text-white/50 text-sm max-w-xs mx-auto leading-relaxed">
+        <p className="text-text-dim text-sm max-w-xs mx-auto leading-relaxed">
           {subtitle}
         </p>
       </div>
@@ -91,7 +91,7 @@ const StandardStepLayout = ({
         <div className="matte-section-header px-5 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             {SectionIcon && <SectionIcon className="w-4 h-4 text-gold/60" />}
-            <span className="text-xs uppercase tracking-wider text-white/40">
+            <span className="text-xs uppercase tracking-wider text-text-dim">
               {sectionLabel}
             </span>
           </div>

--- a/src/components/calculator/WaterfallVisual.tsx
+++ b/src/components/calculator/WaterfallVisual.tsx
@@ -131,7 +131,7 @@ const WaterfallVisual = ({
         )}
       >
         <div>
-          <p className="text-[9px] uppercase tracking-wider text-white/40 mb-1">
+          <p className="text-[9px] uppercase tracking-wider text-text-dim mb-1">
             GROSS REVENUE
           </p>
           <p className="text-sm text-white">Acquisition Price</p>
@@ -179,7 +179,7 @@ const WaterfallVisual = ({
                       "w-7 h-7 flex items-center justify-center text-[9px] font-mono font-medium",
                       tier.status === "filled" && "bg-white text-black",
                       tier.status === "partial" && "bg-white/20 text-white border border-white/20",
-                      tier.status === "empty" && "bg-bg-header text-white/30 border border-border-subtle"
+                      tier.status === "empty" && "bg-bg-header text-text-dim border border-border-subtle"
                     )}
                   >
                     {index + 1}
@@ -187,15 +187,15 @@ const WaterfallVisual = ({
 
                   {/* Labels */}
                   <div>
-                    <p className="text-[9px] uppercase tracking-wider text-white/40 mb-0.5">
+                    <p className="text-[9px] uppercase tracking-wider text-text-dim mb-0.5">
                       {tier.phase}
                     </p>
                     <p
                       className={cn(
                         "text-sm font-medium",
                         tier.status === "filled" && "text-white",
-                        tier.status === "partial" && "text-white/80",
-                        tier.status === "empty" && "text-white/50"
+                        tier.status === "partial" && "text-text-mid",
+                        tier.status === "empty" && "text-text-dim"
                       )}
                     >
                       {tier.label}
@@ -210,14 +210,14 @@ const WaterfallVisual = ({
                       "font-mono text-base font-medium tabular-nums",
                       isProfit && tier.paid > 0 && "text-gold",
                       !isProfit && tier.status === "filled" && "text-white",
-                      !isProfit && tier.status === "partial" && "text-white/70",
-                      tier.status === "empty" && "text-white/30"
+                      !isProfit && tier.status === "partial" && "text-text-mid",
+                      tier.status === "empty" && "text-text-dim"
                     )}
                   >
                     {isProfit ? "+" : "-"}{formatCompactCurrency(tier.paid)}
                   </p>
                   {tier.status === "partial" && (
-                    <p className="text-[9px] text-white/30 font-mono">
+                    <p className="text-[9px] text-text-dim font-mono">
                       of {formatCompactCurrency(tier.amount)}
                     </p>
                   )}
@@ -248,17 +248,17 @@ const WaterfallVisual = ({
       >
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-[9px] uppercase tracking-wider text-white/40 mb-1">
+            <p className="text-[9px] uppercase tracking-wider text-text-dim mb-1">
               REMAINING FOR SPLIT
             </p>
-            <p className="text-xs text-white/40">
+            <p className="text-xs text-text-dim">
               50% Producer / 50% Investor
             </p>
           </div>
           <p
             className={cn(
               "font-mono text-2xl font-medium tabular-nums",
-              profitPool > 0 ? "text-gold" : "text-white/30"
+              profitPool > 0 ? "text-gold" : "text-text-dim"
             )}
           >
             {profitPool >= 0 ? "+" : ""}{formatCompactCurrency(profitPool)}

--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -106,17 +106,17 @@ const BudgetInput = ({ inputs, onUpdateInput, onBack, onNext }: BudgetInputProps
             }}
           />
           <div 
-            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center"
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <DollarSign className="w-8 h-8 text-gold" />
+            <DollarSign className="w-7 h-7 text-gold" />
           </div>
         </div>
 
-        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+        <h2 className="font-bebas text-3xl tracking-[0.08em] text-white mb-1">
           Production Budget
         </h2>
-        <p className="text-white/50 text-xs max-w-xs mx-auto">
+        <p className="text-text-dim text-xs max-w-xs mx-auto">
           Enter your total negative cost
         </p>
       </div>
@@ -125,7 +125,7 @@ const BudgetInput = ({ inputs, onUpdateInput, onBack, onNext }: BudgetInputProps
       <div className="matte-section overflow-hidden">
         {/* Section header */}
         <div className="matte-section-header px-5 py-3 flex items-center justify-between">
-          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+          <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
             Total Budget
           </span>
           {isCompleted && (

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -106,17 +106,17 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }
             }}
           />
           <div 
-            className="relative w-16 h-16 border border-gold/30 bg-gold/5 flex items-center justify-center" 
+            className="relative w-14 h-14 border border-gold/30 bg-gold/5 flex items-center justify-center"
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <Handshake className="w-8 h-8 text-gold" />
+            <Handshake className="w-7 h-7 text-gold" />
           </div>
         </div>
 
-        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+        <h2 className="font-bebas text-3xl tracking-[0.08em] text-white mb-1">
           Acquisition Price
         </h2>
-        <p className="text-white/50 text-xs max-w-xs mx-auto">
+        <p className="text-text-dim text-xs max-w-xs mx-auto">
           What the distributor pays for your film
         </p>
       </div>
@@ -147,7 +147,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }
       <div ref={mobileRef} className="matte-section overflow-hidden">
         {/* Section header */}
         <div className="matte-section-header px-5 py-3 flex items-center justify-between">
-          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+          <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
             Acquisition Amount
           </span>
           {hasRevenue && (
@@ -198,21 +198,21 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }
             className={cn(
               "mx-5 mb-5 p-4 border flex items-center justify-between",
               isAboveBreakeven
-                ? "border-status-success bg-[rgba(0,255,100,0.08)]"
-                : "border-status-danger bg-[rgba(255,82,82,0.08)]"
+                ? "border-gold/50 bg-gold/[0.08]"
+                : "border-gold/30 bg-gold/[0.04]"
             )}
             style={{ borderRadius: 'var(--radius-md)' }}
           >
             <div className="flex items-center gap-3">
               {isAboveBreakeven ? (
-                <TrendingUp className="w-5 h-5 text-status-success" />
+                <TrendingUp className="w-5 h-5 text-gold" />
               ) : (
-                <TrendingDown className="w-5 h-5 text-status-danger" />
+                <TrendingDown className="w-5 h-5 text-text-dim" />
               )}
               <div>
                 <p className={cn(
                   "text-xs font-bold uppercase tracking-wider mb-0.5",
-                  isAboveBreakeven ? "text-status-success" : "text-status-danger"
+                  isAboveBreakeven ? "text-gold" : "text-text-dim"
                 )}>
                   {isAboveBreakeven ? 'Above Breakeven' : 'Below Breakeven'}
                 </p>
@@ -224,7 +224,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onBack, onNext }
               </div>
             </div>
             {isAboveBreakeven && percentAbove > 0 && (
-              <span className="text-2xl font-mono text-status-success">
+              <span className="text-2xl font-mono text-gold">
                 +{percentAbove.toFixed(0)}%
               </span>
             )}

--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -119,7 +119,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
           </div>
         </div>
 
-        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+        <h2 className="font-bebas text-3xl tracking-[0.08em] text-white mb-1">
           Capital Stack
         </h2>
         <p className="text-text-dim text-xs max-w-xs mx-auto">
@@ -130,7 +130,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
       {/* Selection cards */}
       <div className="matte-section overflow-hidden">
         <div className="matte-section-header px-5 py-3 flex items-center justify-between">
-          <span className="text-xs uppercase tracking-[0.2em] text-text-dim font-medium">
+          <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
             Select all that apply
           </span>
           {selectedCount > 0 && (

--- a/src/components/calculator/stack/StackInputCard.tsx
+++ b/src/components/calculator/stack/StackInputCard.tsx
@@ -105,10 +105,10 @@ const StackInputCard = ({
           </div>
         </div>
 
-        <h2 className="font-bebas text-2xl tracking-[0.08em] text-white mb-1">
+        <h2 className="font-bebas text-3xl tracking-[0.08em] text-white mb-1">
           {title}
         </h2>
-        <p className="text-white/50 text-xs max-w-xs mx-auto">
+        <p className="text-text-dim text-xs max-w-xs mx-auto">
           {subtitle}
         </p>
       </div>
@@ -117,7 +117,7 @@ const StackInputCard = ({
       <div className="matte-section overflow-hidden">
         {/* Section header */}
         <div className="matte-section-header px-5 py-3 flex items-center justify-between">
-          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+          <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
             {amountLabel}
           </span>
           {hasAmount && (
@@ -151,7 +151,7 @@ const StackInputCard = ({
               <div className="w-6 h-6 flex items-center justify-center text-xs font-mono font-bold bg-gold text-black">
                 2
               </div>
-              <span className="text-xs uppercase tracking-[0.2em] text-gold/80 font-semibold">
+              <span className="text-xs uppercase tracking-widest text-gold font-bold">
                 {rateConfig.label}
               </span>
             </div>
@@ -175,16 +175,16 @@ const StackInputCard = ({
             <div className="p-5">
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-white/40">Principal</span>
-                  <span className="font-mono text-white/60">{formatCompactCurrency(amount)}</span>
+                  <span className="text-text-dim">Principal</span>
+                  <span className="font-mono text-text-mid">{formatCompactCurrency(amount)}</span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-white/40">+ {rateConfig.label} ({rateValue}%)</span>
-                  <span className="font-mono text-white/60">{formatCompactCurrency(interestAmount)}</span>
+                  <span className="text-text-dim">+ {rateConfig.label} ({rateValue}%)</span>
+                  <span className="font-mono text-text-mid">{formatCompactCurrency(interestAmount)}</span>
                 </div>
                 <div className="h-px bg-gold/20" />
                 <div className="flex items-center justify-between">
-                  <span className="text-xs uppercase tracking-wider text-gold/70 font-semibold">Total Repayment</span>
+                  <span className="text-xs uppercase tracking-wider text-gold font-semibold">Total Repayment</span>
                   <span className="font-mono text-xl text-gold font-semibold">{formatCompactCurrency(totalRepayment)}</span>
                 </div>
               </div>
@@ -196,8 +196,8 @@ const StackInputCard = ({
         {typicalRangeLabel && (
           <div className="px-5 pb-5">
             <div className="flex items-center justify-between py-3 border-t border-border-subtle">
-              <span className="text-xs text-white/30">Typical range</span>
-              <span className="text-xs font-mono text-white/50">{typicalRangeLabel}</span>
+              <span className="text-xs text-text-dim">Typical range</span>
+              <span className="text-xs font-mono text-text-mid">{typicalRangeLabel}</span>
             </div>
           </div>
         )}
@@ -205,7 +205,7 @@ const StackInputCard = ({
 
       {/* Help Text */}
       {helpText && (
-        <p className="text-xs text-white/40 leading-relaxed text-center px-4">
+        <p className="text-xs text-text-dim leading-relaxed text-center px-4">
           {helpText}
         </p>
       )}
@@ -217,7 +217,7 @@ const StackInputCard = ({
           onClick={onBack}
           className={cn(
             "flex-1 py-3 flex items-center justify-center gap-2",
-            "border border-border-subtle text-white/60",
+            "border border-border-subtle text-text-mid",
             "hover:border-white/30 hover:text-white transition-all",
             "active:scale-[0.98]"
           )}
@@ -247,8 +247,8 @@ const StackInputCard = ({
             onClick={onSkip}
             className={cn(
               "flex-[2] py-3 flex items-center justify-center gap-2",
-              "border border-border-subtle text-white/40",
-              "hover:border-white/20 hover:text-white/60 transition-all",
+              "border border-border-subtle text-text-dim",
+              "hover:border-white/20 hover:text-text-mid transition-all",
               "active:scale-[0.98]"
             )}
             style={{ borderRadius: 'var(--radius-md)' }}

--- a/src/components/calculator/stack/StackSummary.tsx
+++ b/src/components/calculator/stack/StackSummary.tsx
@@ -50,7 +50,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             style={{
               background: isFullyFunded
                 ? 'radial-gradient(circle, rgba(212, 175, 55, 0.25) 0%, transparent 70%)'
-                : 'radial-gradient(circle, rgba(255, 150, 50, 0.15) 0%, transparent 70%)',
+                : 'radial-gradient(circle, rgba(212, 175, 55, 0.15) 0%, transparent 70%)',
               filter: 'blur(15px)',
               transform: 'scale(2)',
             }}
@@ -59,15 +59,15 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             className={cn(
               "relative w-16 h-16 flex items-center justify-center",
               isFullyFunded 
-                ? "border-2 border-gold bg-gold/10" 
-                : "border-2 border-orange-500/50 bg-orange-500/10"
+                ? "border-2 border-gold bg-gold/10"
+                : "border-2 border-gold/30 bg-gold/5"
             )}
             style={{ borderRadius: 'var(--radius-md)' }}
           >
             {isFullyFunded ? (
               <Check className="w-8 h-8 text-gold" />
             ) : (
-              <Layers className="w-8 h-8 text-orange-400" />
+              <Layers className="w-8 h-8 text-gold" />
             )}
           </div>
         </div>
@@ -75,7 +75,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
         <h2 className="font-bebas text-3xl tracking-[0.08em] text-white mb-1">
           {isFullyFunded ? 'Stack Complete' : 'Review Your Stack'}
         </h2>
-        <p className="text-white/50 text-sm max-w-xs mx-auto">
+        <p className="text-text-dim text-sm max-w-xs mx-auto">
           {isFullyFunded 
             ? 'Your capital stack covers the budget. Ready to proceed.'
             : `You're ${formatCompactCurrency(fundingGap)} short of your ${formatCompactCurrency(inputs.budget)} budget.`
@@ -105,7 +105,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             <span className="text-xs text-text-dim">Budget: {formatCompactCurrency(inputs.budget)}</span>
             <span className={cn(
               "font-mono text-xs font-bold",
-              gapPercent >= 100 ? "text-gold" : "text-orange-400"
+              gapPercent >= 100 ? "text-gold" : "text-gold/60"
             )}>
               {gapPercent.toFixed(0)}% Funded
             </span>
@@ -116,12 +116,12 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
       {/* Stack Breakdown */}
       <div className="matte-section overflow-hidden">
         <div className="matte-section-header px-5 py-3">
-          <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+          <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
             Capital Sources
           </span>
         </div>
 
-        <div className="divide-y divide-[#1A1A1A]">
+        <div className="divide-y divide-border-subtle">
           {stackItems.length > 0 ? (
             stackItems.map((item) => {
               const Icon = item.icon;
@@ -132,11 +132,11 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
                 >
                   <div className="flex items-center gap-3">
                     <div className={cn("w-1 h-8 rounded-full", item.color)} />
-                    <Icon className="w-4 h-4 text-white/40" />
+                    <Icon className="w-4 h-4 text-text-dim" />
                     <div>
                       <span className="text-sm text-white font-medium">{item.label}</span>
                       {item.rate !== undefined && (
-                        <span className="text-xs text-white/40 ml-2">@ {item.rate}% {item.rateLabel}</span>
+                        <span className="text-xs text-text-dim ml-2">@ {item.rate}% {item.rateLabel}</span>
                       )}
                     </div>
                   </div>
@@ -144,7 +144,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
                     <span className="font-mono text-gold">{formatCompactCurrency(item.amount)}</span>
                     <button
                       onClick={() => onEdit(item.sourceKey)}
-                      className="p-1.5 text-white/30 hover:text-white/60 transition-colors"
+                      className="p-1.5 text-text-dim hover:text-text-mid transition-colors"
                     >
                       <Edit2 className="w-3.5 h-3.5" />
                     </button>
@@ -154,8 +154,8 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             })
           ) : (
             <div className="px-5 py-8 text-center">
-              <p className="text-white/40 text-sm">No capital sources added yet.</p>
-              <p className="text-white/30 text-xs mt-1">Go back to add funding sources.</p>
+              <p className="text-text-dim text-sm">No capital sources added yet.</p>
+              <p className="text-text-dim text-xs mt-1">Go back to add funding sources.</p>
             </div>
           )}
         </div>
@@ -164,11 +164,11 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
       {/* Warning if underfunded */}
       {!isFullyFunded && inputs.budget > 0 && totalCapital > 0 && (
         <div 
-          className="bg-orange-900/10 border-l-4 border-orange-500/50 p-4"
+          className="bg-gold/[0.06] border-l-4 border-gold/40 p-4"
           style={{ borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}
         >
-          <p className="text-xs text-orange-200/80 leading-relaxed">
-            <span className="font-bold text-orange-200">Note:</span> Your stack doesn't fully cover the budget. 
+          <p className="text-xs text-text-mid leading-relaxed">
+            <span className="font-bold text-gold">Note:</span> Your stack doesn't fully cover the budget. 
             You can still proceed, but you may need additional financing.
           </p>
         </div>

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -56,7 +56,7 @@ const WaterfallTab = ({ result, inputs }: WaterfallTabProps) => {
       <div className="space-y-4 animate-fade-in">
         {/* Header */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2 text-gold/80 text-xs font-mono uppercase tracking-widest">
+          <div className="flex items-center space-x-2 text-gold text-xs font-mono uppercase tracking-widest">
             <FileText className="w-3 h-3" />
             <span>Waterfall Results</span>
           </div>
@@ -71,7 +71,7 @@ const WaterfallTab = ({ result, inputs }: WaterfallTabProps) => {
         {/* Main Guide Card - Collapsible */}
         {showGuide && (
           <div
-            className="bg-bg-surface border border-border-default p-5 space-y-5"
+            className="bg-bg-card border border-border-default p-5 space-y-5"
             style={{ borderRadius: 'var(--radius-lg)' }}
           >
             {/* Section 1: What This Shows */}
@@ -135,10 +135,10 @@ const WaterfallTab = ({ result, inputs }: WaterfallTabProps) => {
 
         {/* Pro Tip Callout */}
         {showGuide && (
-          <div className="bg-gold/[0.06] border-l-4 border-gold/40 p-4 flex items-start space-x-3" style={{ borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}>
-            <Info className="w-4 h-4 text-gold/70 mt-0.5 flex-shrink-0" />
-            <div className="text-xs text-white/60 leading-relaxed">
-              <span className="font-bold text-gold/90">Pro Tip:</span> This is how agencies and studios model every deal. If you can walk an investor through a 4-tier waterfall with preferred returns, you're speaking their language—and that closes deals.
+          <div className="p-4 flex items-start space-x-3" style={{ borderRadius: 'var(--radius-md)', background: 'rgba(255, 215, 0, 0.06)', border: '1px solid rgba(255, 215, 0, 0.25)' }}>
+            <Info className="w-4 h-4 text-gold mt-0.5 flex-shrink-0" />
+            <div className="text-xs text-text-mid leading-relaxed">
+              <span className="font-bold text-gold">Pro Tip:</span> This is how agencies and studios model every deal. If you can walk an investor through a 4-tier waterfall with preferred returns, you're speaking their language—and that closes deals.
             </div>
           </div>
         )}
@@ -166,7 +166,7 @@ const WaterfallTab = ({ result, inputs }: WaterfallTabProps) => {
             </div>
             <p className={cn(
               "font-mono text-base font-medium",
-              isProfitable ? "text-status-success" : "text-text-dim"
+              isProfitable ? "text-gold" : "text-text-dim"
             )}>
               {formatCompactCurrency(result.profitPool)}
             </p>
@@ -204,10 +204,10 @@ const WaterfallTab = ({ result, inputs }: WaterfallTabProps) => {
         {/* Warning Banner */}
         {isUnderperforming && (
           <div
-            className="mb-6 p-4 flex items-start gap-3 border border-status-warning bg-[rgba(255,215,0,0.08)]"
+            className="mb-6 p-4 flex items-start gap-3 border border-gold/30 bg-gold/[0.06]"
             style={{ borderRadius: 'var(--radius-md)' }}
           >
-            <div className="w-5 h-5 flex items-center justify-center flex-shrink-0 mt-0.5 text-status-warning font-bold">!</div>
+            <div className="w-5 h-5 flex items-center justify-center flex-shrink-0 mt-0.5 text-gold font-bold">!</div>
             <div>
               <p className="text-sm text-text-primary font-medium">
                 Multiple is {formatMultiple(result.multiple)}

--- a/src/components/shared/WikiCallout.tsx
+++ b/src/components/shared/WikiCallout.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from "react";
+import { colors, radius } from "@/lib/design-system";
+
+/**
+ * WIKI CALLOUT — Gold-accented callout box
+ *
+ * Used for key insights, rules of thumb, pro tips, and warnings.
+ * Gold-only - NO red/green/orange variants. Severity is communicated
+ * through label text, not color.
+ */
+
+interface WikiCalloutProps {
+  label: string;
+  children: ReactNode;
+  icon?: ReactNode;
+}
+
+const WikiCallout = ({ label, children, icon }: WikiCalloutProps) => (
+  <div
+    className="p-4"
+    style={{
+      background: colors.goldSubtle,
+      borderRadius: radius.md,
+      border: `1px solid ${colors.goldMuted}`,
+    }}
+  >
+    <div className="flex gap-3">
+      {icon && (
+        <div className="flex-shrink-0 mt-0.5">{icon}</div>
+      )}
+      <div className="flex-1 min-w-0">
+        <p
+          className="text-xs font-semibold uppercase tracking-wide mb-2"
+          style={{ color: colors.gold }}
+        >
+          {label}
+        </p>
+        <div className="text-sm leading-relaxed" style={{ color: colors.textPrimary }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default WikiCallout;

--- a/src/components/shared/WikiCard.tsx
+++ b/src/components/shared/WikiCard.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { colors, radius } from "@/lib/design-system";
+
+/**
+ * WIKI CARD — Single source of truth for content containers
+ *
+ * The matte card with subtle gold border used across ALL pages.
+ * Always pair with WikiSectionHeader for the header.
+ */
+
+interface WikiCardProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const WikiCard = ({ children, className }: WikiCardProps) => (
+  <div
+    className={`overflow-hidden animate-fade-in ${className || ""}`}
+    style={{
+      background: colors.card,
+      border: `1px solid ${colors.borderSubtle}`,
+      borderRadius: radius.lg,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export default WikiCard;

--- a/src/components/shared/WikiSectionHeader.tsx
+++ b/src/components/shared/WikiSectionHeader.tsx
@@ -1,0 +1,102 @@
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { colors, radius } from "@/lib/design-system";
+
+/**
+ * WIKI SECTION HEADER — Single source of truth
+ *
+ * The gold-accented section header used across ALL pages.
+ * Features: Radiant gold left bar, gradient background, section number + title.
+ *
+ * This replaces the 5 separate SectionHeader implementations that existed
+ * in IntroView, BudgetInfo, CapitalInfo, FeesInfo, and WaterfallInfo.
+ */
+
+const tokens = {
+  gold: colors.gold,
+  goldMuted: colors.goldMuted,
+  goldGlow: colors.goldGlow,
+  goldFill: colors.goldSubtle,
+  goldRadiant: colors.goldGlow,
+  bgHeader: colors.elevated,
+  borderMatte: colors.borderSubtle,
+  borderSubtle: colors.borderSubtle,
+  textPrimary: colors.textPrimary,
+  textDim: colors.textDim,
+};
+
+interface WikiSectionHeaderProps {
+  number: string;
+  title: string;
+  isClickable?: boolean;
+  isExpanded?: boolean;
+  onClick?: () => void;
+}
+
+const WikiSectionHeader = ({
+  number,
+  title,
+  isClickable = false,
+  isExpanded,
+  onClick,
+}: WikiSectionHeaderProps) => (
+  <div
+    className={cn(
+      "flex items-stretch",
+      isClickable && "cursor-pointer hover:bg-white/[0.02] transition-colors"
+    )}
+    style={{
+      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
+      borderBottom: isExpanded !== false ? `1px solid ${tokens.borderMatte}` : "none",
+    }}
+    onClick={onClick}
+  >
+    {/* Gold Left Bar — THE signature element */}
+    <div
+      className="w-1 flex-shrink-0"
+      style={{
+        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
+        boxShadow: `0 0 12px ${tokens.goldGlow}`,
+      }}
+    />
+
+    {/* Section Number */}
+    <div
+      className="flex items-center justify-center px-4 py-4"
+      style={{
+        borderRight: `1px solid ${tokens.borderSubtle}`,
+        minWidth: "56px",
+        background: tokens.goldFill,
+      }}
+    >
+      <span
+        className="font-bebas text-xl tracking-wide"
+        style={{ color: tokens.gold }}
+      >
+        {number}
+      </span>
+    </div>
+
+    {/* Title + Chevron */}
+    <div className="flex items-center flex-1 px-4 py-4 justify-between">
+      <h2
+        className="font-bold text-xs uppercase tracking-widest"
+        style={{ color: tokens.textPrimary }}
+      >
+        {title}
+      </h2>
+
+      {isClickable && (
+        <ChevronDown
+          className={cn(
+            "w-4 h-4 flex-shrink-0 transition-transform duration-200",
+            isExpanded && "rotate-180"
+          )}
+          style={{ color: isExpanded ? tokens.gold : tokens.textDim }}
+        />
+      )}
+    </div>
+  </div>
+);
+
+export default WikiSectionHeader;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,0 +1,3 @@
+export { default as WikiSectionHeader } from "./WikiSectionHeader";
+export { default as WikiCard } from "./WikiCard";
+export { default as WikiCallout } from "./WikiCallout";

--- a/src/components/ui/matte-card.tsx
+++ b/src/components/ui/matte-card.tsx
@@ -49,7 +49,7 @@ export const MatteCardHeader = ({
         className
       )}
     >
-      <span className="text-xs uppercase tracking-[0.2em] text-white/40 font-medium">
+      <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
         {children}
       </span>
       {rightElement}
@@ -107,10 +107,10 @@ export const StatusBadge = ({
   className,
 }: StatusBadgeProps) => {
   const statusStyles = {
-    excellent: "bg-emerald-500/15 border-emerald-500/50 text-emerald-400",
-    good: "bg-gold/15 border-gold/50 text-gold",
-    marginal: "bg-amber-500/15 border-amber-500/50 text-amber-400",
-    underwater: "bg-red-500/15 border-red-500/50 text-red-400",
+    excellent: "bg-gold/15 border-gold/50 text-gold",
+    good: "bg-gold/10 border-gold/40 text-gold",
+    marginal: "bg-gold/[0.06] border-gold/30 text-gold/80",
+    underwater: "bg-gold/[0.04] border-gold/20 text-text-dim",
   };
 
   return (
@@ -146,17 +146,17 @@ export const VerdictCard = ({
   className,
 }: VerdictCardProps) => {
   const statusColors = {
-    excellent: "#10B981",
+    excellent: "#FFD700",
     good: "#FFD700",
-    marginal: "#F59E0B",
-    underwater: "#EF4444",
+    marginal: "rgba(255, 215, 0, 0.6)",
+    underwater: "rgba(255, 215, 0, 0.3)",
   };
 
   const glowColors = {
-    excellent: "rgba(16, 185, 129, 0.4)",
+    excellent: "rgba(255, 215, 0, 0.4)",
     good: "rgba(255, 215, 0, 0.4)",
-    marginal: "rgba(245, 158, 11, 0.3)",
-    underwater: "rgba(239, 68, 68, 0.3)",
+    marginal: "rgba(255, 215, 0, 0.25)",
+    underwater: "rgba(255, 215, 0, 0.15)",
   };
 
   return (
@@ -172,7 +172,7 @@ export const VerdictCard = ({
       />
 
       {/* Label */}
-      <p className="text-[11px] uppercase tracking-[0.4em] text-white/50 font-semibold mb-4 relative z-10">
+      <p className="text-[11px] uppercase tracking-[0.4em] text-text-dim font-semibold mb-4 relative z-10">
         {title}
       </p>
 
@@ -189,7 +189,7 @@ export const VerdictCard = ({
 
       {/* Subtitle */}
       {subtitle && (
-        <p className="text-xs text-white/40 mt-3 relative z-10">{subtitle}</p>
+        <p className="text-xs text-text-dim mt-3 relative z-10">{subtitle}</p>
       )}
     </div>
   );
@@ -227,7 +227,7 @@ export const LedgerRow = ({
         <span
           className={cn(
             "text-sm",
-            isTotal ? "text-white font-semibold" : "text-white/60"
+            isTotal ? "text-white font-semibold" : "text-text-mid"
           )}
         >
           {label}
@@ -235,7 +235,7 @@ export const LedgerRow = ({
         <span
           className={cn(
             "font-mono",
-            isTotal ? "text-xl text-gold font-bold" : "text-base text-white/80"
+            isTotal ? "text-xl text-gold font-bold" : "text-base text-text-mid"
           )}
         >
           {value}
@@ -319,7 +319,7 @@ export const CtaCard = ({
           >
             {title}
           </h4>
-          <p className="text-xs text-white/50 mb-3 leading-relaxed">
+          <p className="text-xs text-text-dim mb-3 leading-relaxed">
             {description}
           </p>
           <span
@@ -327,7 +327,7 @@ export const CtaCard = ({
               "text-xs font-semibold uppercase tracking-wider transition-colors",
               isPrimary
                 ? "text-gold group-hover:text-gold-highlight"
-                : "text-white/60 group-hover:text-white"
+                : "text-text-mid group-hover:text-white"
             )}
           >
             {ctaText} &rarr;

--- a/src/components/ui/step-container.tsx
+++ b/src/components/ui/step-container.tsx
@@ -90,12 +90,12 @@ const StepContainer = React.forwardRef<HTMLDivElement, StepContainerProps>(
                 {/* Title area */}
                 <div className="flex-1">
                   {title && (
-                    <h2 className="font-bebas text-lg tracking-[0.15em] text-white/90">
+                    <h2 className="font-bebas text-lg tracking-[0.15em] text-text-primary">
                       {title}
                     </h2>
                   )}
                   {subtitle && (
-                    <p className="text-xs text-white/40 mt-0.5 tracking-wide">
+                    <p className="text-xs text-text-dim mt-0.5 tracking-wide">
                       {subtitle}
                     </p>
                   )}
@@ -111,7 +111,7 @@ const StepContainer = React.forwardRef<HTMLDivElement, StepContainerProps>(
                       <span className="font-mono text-sm text-gold font-semibold">
                         {stepNumber}
                       </span>
-                      <span className="font-mono text-xs text-white/30">
+                      <span className="font-mono text-xs text-text-dim">
                         /{totalSteps}
                       </span>
                     </div>

--- a/src/pages/BudgetInfo.tsx
+++ b/src/pages/BudgetInfo.tsx
@@ -1,19 +1,17 @@
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, DollarSign, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, AlertTriangle } from 'lucide-react';
 import Header from "@/components/Header";
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   PRODUCT BIBLE v2.0 — NOTION MEETS APPS
-   
-   Design DNA:
-   - Notion: Clean hierarchy, toggle sections, database-level organization
-   - Apps: Gold left border accent, dark matte surfaces, premium sparse gold
-   
+   MINI WIKI: PRODUCTION BUDGET
+   Full educational deep-dive on budget ranges, composition, and pitfalls.
+
    WIKI CONTAINMENT: This mini wiki can ONLY link back to /intro
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
 // Sourced from design-system.ts (aligned to index.css)
 import { colors, radius } from "@/lib/design-system";
+import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 const tokens = {
   bgVoid: colors.void,
@@ -24,70 +22,24 @@ const tokens = {
   goldMuted: colors.goldMuted,
   goldSubtle: colors.goldSubtle,
   goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
   borderMatte: colors.borderSubtle,
   borderSubtle: colors.borderSubtle,
   textPrimary: colors.textPrimary,
   textMid: colors.textMid,
   textDim: colors.textDim,
-  // Accent colors for budget tiers
-  tierLow: '#4ADE80',
-  tierMid: '#FBBF24',
-  tierHigh: '#F87171',
   radiusMd: radius.md,
   radiusLg: radius.lg,
 };
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER COMPONENT — Gold Left Border Accent (Signature Element)
+   GOLD INTENSITY TIERS — Budget tier accent colors
+   Full gold -> muted gold -> subtle gold (replacing green/yellow/red)
    ═══════════════════════════════════════════════════════════════════════════ */
-interface SectionHeaderProps {
-  number: string;
-  title: string;
-}
-
-const SectionHeader = ({ number, title }: SectionHeaderProps) => (
-  <div 
-    className="flex items-stretch"
-    style={{ 
-      background: tokens.bgHeader,
-      borderBottom: `1px solid ${tokens.borderMatte}`,
-    }}
-  >
-    {/* Gold Left Border Accent — THE signature element */}
-    <div 
-      className="w-1 flex-shrink-0"
-      style={{ background: tokens.gold }}
-    />
-    
-    {/* Chapter Number Box — Now with gold fill background */}
-    <div 
-      className="flex items-center justify-center px-4 py-4"
-      style={{ 
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: '56px',
-        background: tokens.goldFill,
-      }}
-    >
-      <span 
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
-        {number}
-      </span>
-    </div>
-    
-    {/* Title */}
-    <div className="flex items-center px-4 py-4">
-      <h2 
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
-        {title}
-      </h2>
-    </div>
-  </div>
-);
+const tierAccents = {
+  low: '#FFD700',                // 100% gold
+  mid: 'rgba(255, 215, 0, 0.6)', // 60% gold
+  high: 'rgba(255, 215, 0, 0.3)', // 30% gold
+};
 
 /* ═══════════════════════════════════════════════════════════════════════════
    BUDGET TIER CARD — Visual benchmarks for budget ranges
@@ -100,21 +52,21 @@ interface BudgetTierCardProps {
 }
 
 const BudgetTierCard = ({ tier, range, description, accentColor }: BudgetTierCardProps) => (
-  <div 
+  <div
     className="p-4 flex-1"
-    style={{ 
+    style={{
       background: tokens.bgSurface,
       borderRadius: tokens.radiusMd,
       borderTop: `3px solid ${accentColor}`,
     }}
   >
-    <span 
+    <span
       className="font-bebas text-xs tracking-wide uppercase"
       style={{ color: accentColor }}
     >
       {tier}
     </span>
-    <p 
+    <p
       className="text-lg font-bold text-white mt-1 mb-2"
       style={{ fontFamily: 'Roboto Mono, monospace' }}
     >
@@ -136,9 +88,9 @@ interface BudgetComponentProps {
 }
 
 const BudgetComponent = ({ category, percentage, items }: BudgetComponentProps) => (
-  <div 
+  <div
     className="p-4"
-    style={{ 
+    style={{
       background: tokens.bgSurface,
       borderRadius: tokens.radiusMd,
       borderLeft: `2px solid ${tokens.goldMuted}`,
@@ -146,10 +98,10 @@ const BudgetComponent = ({ category, percentage, items }: BudgetComponentProps) 
   >
     <div className="flex items-center justify-between mb-2">
       <span className="text-sm font-semibold text-white">{category}</span>
-      <span 
+      <span
         className="text-xs font-mono px-2 py-1 rounded"
-        style={{ 
-          background: tokens.goldFill,
+        style={{
+          background: tokens.goldSubtle,
           color: tokens.gold,
         }}
       >
@@ -163,7 +115,7 @@ const BudgetComponent = ({ category, percentage, items }: BudgetComponentProps) 
 );
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   MISTAKE CARD — Common pitfalls with warning styling
+   MISTAKE CARD — Common pitfalls with gold warning styling
    ═══════════════════════════════════════════════════════════════════════════ */
 interface MistakeCardProps {
   title: string;
@@ -171,17 +123,17 @@ interface MistakeCardProps {
 }
 
 const MistakeCard = ({ title, description }: MistakeCardProps) => (
-  <div 
+  <div
     className="p-4 flex gap-3"
-    style={{ 
-      background: 'rgba(248, 113, 113, 0.08)',
+    style={{
+      background: tokens.goldSubtle,
       borderRadius: tokens.radiusMd,
-      border: '1px solid rgba(248, 113, 113, 0.25)',
+      border: `1px solid ${tokens.goldMuted}`,
     }}
   >
-    <AlertTriangle 
-      className="w-5 h-5 flex-shrink-0 mt-0.5" 
-      style={{ color: tokens.tierHigh }}
+    <AlertTriangle
+      className="w-5 h-5 flex-shrink-0 mt-0.5"
+      style={{ color: tokens.gold }}
     />
     <div>
       <p className="text-sm font-semibold text-white mb-1">{title}</p>
@@ -208,15 +160,15 @@ const BudgetInfo = () => {
   return (
     <>
       <Header />
-      
-      <div 
+
+      <div
         className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
         style={{ background: tokens.bgVoid }}
       >
         <div className="max-w-2xl mx-auto space-y-6">
-          
+
           {/* ═══════════════════════════════════════════════════════════════
-              PAGE HEADER
+              PAGE HEADER — Matches CapitalInfo/FeesInfo style
               ═══════════════════════════════════════════════════════════════ */}
           <div className="space-y-4 pt-6 animate-fade-in">
             {/* Back to Overview — ONLY navigation link allowed */}
@@ -230,40 +182,24 @@ const BudgetInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
-            <div className="flex items-center gap-3">
-              <div 
-                className="p-2 rounded-lg"
-                style={{ background: tokens.goldFill }}
-              >
-                <DollarSign className="w-6 h-6" style={{ color: tokens.gold }} />
-              </div>
-              <div>
-                <p 
-                  className="text-xs font-semibold uppercase tracking-widest"
-                  style={{ color: tokens.goldMuted }}
-                >
-                  Chapter 01
-                </p>
-                <h1 className="text-3xl md:text-4xl font-bebas tracking-wide leading-tight">
-                  Production <span style={{ color: tokens.gold }}>Budget</span>
-                </h1>
-              </div>
-            </div>
-            
-            <p 
+
+            <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
+              Production <span style={{ color: tokens.gold }}>Budget</span>
+            </h1>
+
+            <p
               className="text-base leading-relaxed max-w-lg"
               style={{ color: tokens.textMid }}
             >
               Your budget isn't just a number—it's the foundation of your entire deal structure.
               Everything flows from here: capital requirements, investor returns, and your ultimate profit position.
             </p>
-            
+
             {/* Gold Gradient Divider */}
-            <div 
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              style={{
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
               }}
             />
           </div>
@@ -271,166 +207,130 @@ const BudgetInfo = () => {
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 01 — BUDGET RANGE BENCHMARKS
               ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="01" title="Budget Range Benchmarks" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="01" title="Budget Range Benchmarks" />
+
             <div className="p-5 space-y-5">
-              <p 
+              <p
                 className="text-sm leading-relaxed"
                 style={{ color: tokens.textMid }}
               >
-                Independent films operate across a wide spectrum. Where you land determines 
+                Independent films operate across a wide spectrum. Where you land determines
                 your financing options, crew expectations, and realistic sales projections.
               </p>
-              
-              {/* Three-tier budget cards */}
+
+              {/* Three-tier budget cards — gold intensity variations */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <BudgetTierCard 
+                <BudgetTierCard
                   tier="Micro/Low"
                   range="$100K – $1M"
                   description="Lean crews, deferred pay, limited locations. Often self-financed or angel-backed. Streamers pay $250K–$800K."
-                  accentColor={tokens.tierLow}
+                  accentColor={tierAccents.low}
                 />
-                
-                <BudgetTierCard 
+
+                <BudgetTierCard
                   tier="Mid-Budget"
                   range="$1M – $5M"
                   description="Union or hybrid crews, modest talent attachments. Typical equity + gap financing. Sales potential $1M–$3M."
-                  accentColor={tokens.tierMid}
+                  accentColor={tierAccents.mid}
                 />
-                
-                <BudgetTierCard 
+
+                <BudgetTierCard
                   tier="Elevated Indie"
                   range="$5M – $15M"
                   description="Name cast required, full union, complex financing. Presales often mandatory. Territory-by-territory deals common."
-                  accentColor={tokens.tierHigh}
+                  accentColor={tierAccents.high}
                 />
               </div>
-              
-              <div 
-                className="p-4"
-                style={{ 
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
-              >
-                <p 
-                  className="text-xs font-semibold uppercase tracking-wide mb-2"
-                  style={{ color: tokens.gold }}
-                >
-                  Rule of Thumb
-                </p>
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  Your realistic acquisition price is typically 0.8x – 1.5x your production budget 
-                  for first-time filmmakers. Established track records can push this to 2x–3x.
-                </p>
-              </div>
+
+              <WikiCallout label="Rule of Thumb">
+                Your realistic acquisition price is typically 0.8x – 1.5x your production budget
+                for first-time filmmakers. Established track records can push this to 2x–3x.
+              </WikiCallout>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 02 — BUDGET COMPOSITION
               ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="02" title="Budget Composition" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="02" title="Budget Composition" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                A professional budget breaks into predictable categories. Understanding these 
+                A professional budget breaks into predictable categories. Understanding these
                 helps you identify where costs can flex—and where they can't.
               </p>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <BudgetComponent 
+                <BudgetComponent
                   category="Above-the-Line"
                   percentage="20-35%"
                   items={['Writer', 'Director', 'Producers', 'Lead Cast']}
                 />
-                
-                <BudgetComponent 
+
+                <BudgetComponent
                   category="Below-the-Line"
                   percentage="45-60%"
                   items={['Crew', 'Equipment', 'Locations', 'Art/Wardrobe']}
                 />
-                
-                <BudgetComponent 
+
+                <BudgetComponent
                   category="Post-Production"
                   percentage="10-15%"
                   items={['Edit', 'VFX', 'Sound Mix', 'Color/DCP']}
                 />
-                
-                <BudgetComponent 
+
+                <BudgetComponent
                   category="Contingency + Insurance"
                   percentage="10-12%"
                   items={['Overages', 'E&O', 'Production Insurance', 'Bonds']}
                 />
               </div>
-              
+
               <p className="text-xs leading-relaxed pt-2" style={{ color: tokens.textDim }}>
-                These percentages shift based on genre and approach. VFX-heavy films push post 
+                These percentages shift based on genre and approach. VFX-heavy films push post
                 to 25%+. Star-driven projects can see ATL exceed 40%.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 03 — COMMON MISTAKES
               ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="03" title="Common Mistakes" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="03" title="Common Mistakes" />
+
             <div className="p-5 space-y-3">
-              <MistakeCard 
+              <MistakeCard
                 title="Underestimating Post"
                 description="First-time producers routinely budget 5% for post and discover they need 15%. Sound design and color alone can exceed expectations by 2x."
               />
-              
-              <MistakeCard 
+
+              <MistakeCard
                 title="No Contingency Buffer"
                 description="Things go wrong. Weather, talent issues, equipment failures. A 10% contingency isn't padding—it's survival. Investors expect to see it."
               />
-              
-              <MistakeCard 
+
+              <MistakeCard
                 title="Ignoring Delivery Requirements"
                 description="Distributors require specific deliverables: M&E tracks, DCP, closed captions, marketing materials. Budget $30K–$75K for delivery alone."
               />
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               FOOTER — Back to Overview + subtle Start Simulation link
               ═══════════════════════════════════════════════════════════════ */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">
             {/* Gold Gradient Divider */}
-            <div 
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              style={{
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
               }}
             />
-            
+
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
@@ -442,7 +342,7 @@ const BudgetInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
+
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}

--- a/src/pages/CapitalInfo.tsx
+++ b/src/pages/CapitalInfo.tsx
@@ -2,27 +2,22 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import Header from "@/components/Header";
 import { colors, radius } from "@/lib/design-system";
+import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 /* ═══════════════════════════════════════════════════════════════════════════
    MINI WIKI: CAPITAL STACK
    Full educational deep-dive on how indie films are financed.
-   
+
    WIKI CONTAINMENT: This mini wiki can ONLY link back to /intro
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
 // Sourced from design-system.ts (aligned to index.css)
 const tokens = {
   bgVoid: colors.void,
-  bgMatte: colors.card,
-  bgHeader: colors.elevated,
   bgSurface: colors.surface,
   gold: colors.gold,
   goldMuted: colors.goldMuted,
   goldSubtle: colors.goldSubtle,
-  goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
-  goldRadiant: colors.goldGlow,
-  borderMatte: colors.borderSubtle,
   borderSubtle: colors.borderSubtle,
   textPrimary: colors.textPrimary,
   textMid: colors.textMid,
@@ -30,57 +25,6 @@ const tokens = {
   radiusMd: radius.md,
   radiusLg: radius.lg,
 };
-
-/* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER — Radiant Gold Left Border
-   ═══════════════════════════════════════════════════════════════════════════ */
-interface SectionHeaderProps {
-  number: string;
-  title: string;
-}
-
-const SectionHeader = ({ number, title }: SectionHeaderProps) => (
-  <div 
-    className="flex items-stretch"
-    style={{ 
-      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
-      borderBottom: `1px solid ${tokens.borderMatte}`,
-    }}
-  >
-    <div 
-      className="w-1 flex-shrink-0"
-      style={{ 
-        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
-        boxShadow: `0 0 12px ${tokens.goldGlow}`,
-      }}
-    />
-    
-    <div 
-      className="flex items-center justify-center px-4 py-4"
-      style={{ 
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: '56px',
-        background: tokens.goldFill,
-      }}
-    >
-      <span 
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
-        {number}
-      </span>
-    </div>
-    
-    <div className="flex items-center px-4 py-4">
-      <h2 
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
-        {title}
-      </h2>
-    </div>
-  </div>
-);
 
 const CapitalInfo = () => {
   const navigate = useNavigate();
@@ -98,13 +42,13 @@ const CapitalInfo = () => {
   return (
     <>
       <Header />
-      
-      <div 
+
+      <div
         className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
         style={{ background: tokens.bgVoid }}
       >
         <div className="max-w-2xl mx-auto space-y-6">
-          
+
           {/* PAGE HEADER */}
           <div className="space-y-4 pt-6 animate-fade-in">
             <button
@@ -117,212 +61,162 @@ const CapitalInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
+
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
               Capital <span style={{ color: tokens.gold }}>Stack</span>
             </h1>
-            
-            <p 
+
+            <p
               className="text-base leading-relaxed max-w-lg"
               style={{ color: tokens.textMid }}
             >
               Understanding how independent films are financed—and who gets paid back first.
             </p>
-            
-            <div 
+
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              style={{
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
               }}
             />
           </div>
 
           {/* SECTION: WHAT IS A CAPITAL STACK */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="01" title="What Is a Capital Stack?" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="01" title="What Is a Capital Stack?" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>capital stack</strong> is 
-                the combination of all funding sources used to finance your production. Like 
-                layers in a building, each capital source sits in a specific position—and that 
+                The <strong style={{ color: tokens.textPrimary }}>capital stack</strong> is
+                the combination of all funding sources used to finance your production. Like
+                layers in a building, each capital source sits in a specific position—and that
                 position determines when (and if) each investor gets repaid.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Most independent films can't be funded by a single source. Instead, producers 
-                piece together a stack from multiple sources: equity investors, senior lenders, 
-                gap financiers, tax incentives, and sometimes pre-sales or minimum guarantees. 
+                Most independent films can't be funded by a single source. Instead, producers
+                piece together a stack from multiple sources: equity investors, senior lenders,
+                gap financiers, tax incentives, and sometimes pre-sales or minimum guarantees.
                 Each comes with different terms, risks, and recoupment positions.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: EQUITY */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="02" title="Equity Investors" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="02" title="Equity Investors" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Equity</strong> is risk capital. 
-                Equity investors give you money in exchange for ownership—a percentage of the 
-                profits if the film succeeds. They don't get interest payments or guaranteed 
+                <strong style={{ color: tokens.textPrimary }}>Equity</strong> is risk capital.
+                Equity investors give you money in exchange for ownership—a percentage of the
+                profits if the film succeeds. They don't get interest payments or guaranteed
                 returns. If the film loses money, equity investors lose their investment.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Because equity is the riskiest capital, equity investors typically demand:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Priority recoupment</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Priority recoupment</strong> —
                   they want their principal back before anyone else (except senior debt)</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Premium</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Premium</strong> —
                   a percentage on top of their investment (typically 10-25%) before profits split</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Backend participation</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Backend participation</strong> —
                   a share of profits after recoupment (often 50%)</span>
                 </li>
               </ul>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: SENIOR DEBT */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="03" title="Senior Debt" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="03" title="Senior Debt" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Senior debt</strong> is the 
-                safest position in the stack. Senior lenders get repaid first, before anyone 
-                else sees a dollar. Because of this priority position, senior debt charges 
+                <strong style={{ color: tokens.textPrimary }}>Senior debt</strong> is the
+                safest position in the stack. Senior lenders get repaid first, before anyone
+                else sees a dollar. Because of this priority position, senior debt charges
                 lower rates than equity demands—but it must be repaid regardless of the film's success.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Common sources of senior debt include:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Bank loans</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Bank loans</strong> —
                   secured against pre-sales, tax credits, or minimum guarantees</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Tax credit advances</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Tax credit advances</strong> —
                   lenders who front cash against confirmed incentive rebates</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Minimum guarantee loans</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Minimum guarantee loans</strong> —
                   discounted advances against contracted distribution deals</span>
                 </li>
               </ul>
-              
-              <div 
-                className="p-4 mt-2"
-                style={{ 
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
-              >
-                <p 
-                  className="text-xs font-semibold uppercase tracking-wide mb-2"
-                  style={{ color: tokens.gold }}
-                >
-                  Key Point
-                </p>
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  Senior debt sits at the top of the waterfall. Every dollar of revenue goes to 
-                  senior lenders first—including their interest and fees—before equity investors 
-                  or profit participants see anything.
-                </p>
-              </div>
+
+              <WikiCallout label="Key Point">
+                Senior debt sits at the top of the waterfall. Every dollar of revenue goes to
+                senior lenders first—including their interest and fees—before equity investors
+                or profit participants see anything.
+              </WikiCallout>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: GAP FINANCING */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="04" title="Gap Financing" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="04" title="Gap Financing" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Gap financing</strong> fills the 
-                space between your secured capital (pre-sales, tax credits) and your total budget. 
+                <strong style={{ color: tokens.textPrimary }}>Gap financing</strong> fills the
+                space between your secured capital (pre-sales, tax credits) and your total budget.
                 It's called "gap" because it bridges the gap—typically 15-25% of budget.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Gap lenders take real risk. They're betting that your unsold territories will 
-                eventually sell for enough to cover their loan. Because of this risk, gap financing 
+                Gap lenders take real risk. They're betting that your unsold territories will
+                eventually sell for enough to cover their loan. Because of this risk, gap financing
                 is more expensive than senior debt—expect interest rates of 12-18% plus fees.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Gap typically sits after senior debt but before equity in the recoupment waterfall. 
-                Some deals subordinate gap to equity recoupment—the terms vary significantly by lender 
+                Gap typically sits after senior debt but before equity in the recoupment waterfall.
+                Some deals subordinate gap to equity recoupment—the terms vary significantly by lender
                 and by the strength of your sales estimates.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: HOW IT ALL FITS */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="05" title="How It All Fits Together" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="05" title="How It All Fits Together" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 A typical indie capital stack might look like this:
               </p>
-              
-              <div 
+
+              <div
                 className="p-4 font-mono text-xs space-y-1"
-                style={{ 
+                style={{
                   background: tokens.bgSurface,
                   borderRadius: tokens.radiusMd,
                   border: `1px solid ${tokens.borderSubtle}`,
@@ -345,7 +239,7 @@ const CapitalInfo = () => {
                   <span>Equity Investment</span>
                   <span style={{ color: tokens.textPrimary }}>40%</span>
                 </div>
-                <div 
+                <div
                   className="pt-2 mt-2 flex justify-between font-semibold"
                   style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
                 >
@@ -353,67 +247,60 @@ const CapitalInfo = () => {
                   <span style={{ color: tokens.gold }}>100%</span>
                 </div>
               </div>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                When revenues come in, they flow through the waterfall in order: distribution 
-                fees first, then senior debt gets repaid, then gap, then equity recovers their 
-                investment plus premium, and finally—if there's anything left—profits split 
+                When revenues come in, they flow through the waterfall in order: distribution
+                fees first, then senior debt gets repaid, then gap, then equity recovers their
+                investment plus premium, and finally—if there's anything left—profits split
                 according to the Operating Agreement.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: WHAT THIS MEANS FOR YOU */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="06" title="What This Means For You" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="06" title="What This Means For You" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 As a producer, understanding the capital stack is essential because:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span>It determines how your waterfall is structured—you can't negotiate 
+                  <span>It determines how your waterfall is structured—you can't negotiate
                   recoupment positions without understanding who's providing what</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span>Each capital source has different cost implications—interest, 
+                  <span>Each capital source has different cost implications—interest,
                   premiums, and backend participation all reduce what's available for profit</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span>Your personal backend (producer profit) only starts after everyone 
+                  <span>Your personal backend (producer profit) only starts after everyone
                   else is satisfied—knowing the math helps you set realistic expectations</span>
                 </li>
               </ul>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The simulation in this tool lets you model different capital structures and see 
-                exactly how each scenario affects your waterfall. Small changes in the stack can 
+                The simulation in this tool lets you model different capital structures and see
+                exactly how each scenario affects your waterfall. Small changes in the stack can
                 have significant impacts on who actually gets paid.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* FOOTER — Back to Overview + subtle Start Simulation link */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">
-            <div 
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              style={{
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
               }}
             />
-            
+
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
@@ -425,7 +312,7 @@ const CapitalInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
+
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}

--- a/src/pages/FeesInfo.tsx
+++ b/src/pages/FeesInfo.tsx
@@ -2,27 +2,22 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import Header from "@/components/Header";
 import { colors, radius } from "@/lib/design-system";
+import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 /* ═══════════════════════════════════════════════════════════════════════════
    MINI WIKI: DISTRIBUTION FEES
    Deep-dive on fees that come off the top before anyone gets paid.
-   
+
    WIKI CONTAINMENT: This mini wiki can ONLY link back to /intro
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
-// Sourced from design-system.ts (aligned to index.css)
+
 const tokens = {
   bgVoid: colors.void,
-  bgMatte: colors.card,
-  bgHeader: colors.elevated,
   bgSurface: colors.surface,
   gold: colors.gold,
   goldMuted: colors.goldMuted,
   goldSubtle: colors.goldSubtle,
-  goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
-  goldRadiant: colors.goldGlow,
-  borderMatte: colors.borderSubtle,
   borderSubtle: colors.borderSubtle,
   textPrimary: colors.textPrimary,
   textMid: colors.textMid,
@@ -30,57 +25,6 @@ const tokens = {
   radiusMd: radius.md,
   radiusLg: radius.lg,
 };
-
-/* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER — Radiant Gold Left Border
-   ═══════════════════════════════════════════════════════════════════════════ */
-interface SectionHeaderProps {
-  number: string;
-  title: string;
-}
-
-const SectionHeader = ({ number, title }: SectionHeaderProps) => (
-  <div 
-    className="flex items-stretch"
-    style={{ 
-      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
-      borderBottom: `1px solid ${tokens.borderMatte}`,
-    }}
-  >
-    <div 
-      className="w-1 flex-shrink-0"
-      style={{ 
-        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
-        boxShadow: `0 0 12px ${tokens.goldGlow}`,
-      }}
-    />
-    
-    <div 
-      className="flex items-center justify-center px-4 py-4"
-      style={{ 
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: '56px',
-        background: tokens.goldFill,
-      }}
-    >
-      <span 
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
-        {number}
-      </span>
-    </div>
-    
-    <div className="flex items-center px-4 py-4">
-      <h2 
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
-        {title}
-      </h2>
-    </div>
-  </div>
-);
 
 const FeesInfo = () => {
   const navigate = useNavigate();
@@ -98,13 +42,13 @@ const FeesInfo = () => {
   return (
     <>
       <Header />
-      
-      <div 
+
+      <div
         className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
         style={{ background: tokens.bgVoid }}
       >
         <div className="max-w-2xl mx-auto space-y-6">
-          
+
           {/* PAGE HEADER */}
           <div className="space-y-4 pt-6 animate-fade-in">
             <button
@@ -117,223 +61,173 @@ const FeesInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
+
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
               Distribution <span style={{ color: tokens.gold }}>Fees</span>
             </h1>
-            
-            <p 
+
+            <p
               className="text-base leading-relaxed max-w-lg"
               style={{ color: tokens.textMid }}
             >
               The money that comes off the top before your waterfall even begins.
             </p>
-            
-            <div 
+
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              style={{
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
               }}
             />
           </div>
 
           {/* SECTION: WHY FEES MATTER */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="01" title="Why Fees Matter" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="01" title="Why Fees Matter" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                When a streamer or buyer acquires your film for $2 million, that $2 million 
+                When a streamer or buyer acquires your film for $2 million, that $2 million
                 doesn't flow directly into your waterfall. <strong style={{ color: tokens.textPrimary }}>
-                Distribution fees come off the top first</strong>—before senior debt, before 
+                Distribution fees come off the top first</strong>—before senior debt, before
                 equity recoupment, before anyone in your Operating Agreement sees a cent.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                These fees aren't optional. They're contractual obligations to the entities 
-                who sold, delivered, and collected on your film. Understanding them is 
+                These fees aren't optional. They're contractual obligations to the entities
+                who sold, delivered, and collected on your film. Understanding them is
                 critical because they directly reduce what's available for your waterfall.
               </p>
-              
-              <div 
-                className="p-4 mt-2"
-                style={{ 
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
-              >
-                <p 
-                  className="text-xs font-semibold uppercase tracking-wide mb-2"
-                  style={{ color: tokens.gold }}
-                >
-                  Reality Check
-                </p>
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  On a $2M acquisition, fees can easily total 20-30%. That means $400K-$600K 
-                  comes off before anyone in your waterfall gets paid.
-                </p>
-              </div>
+
+              <WikiCallout label="Reality Check">
+                On a $2M acquisition, fees can easily total 20-30%. That means $400K-$600K
+                comes off before anyone in your waterfall gets paid.
+              </WikiCallout>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: SALES AGENT FEE */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="02" title="Sales Agent Fee" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="02" title="Sales Agent Fee" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>sales agent</strong> represents 
-                your film to international buyers and domestic distributors. They attend markets 
-                (Cannes, AFM, Berlin), pitch to acquisitions executives, negotiate deals, and 
+                The <strong style={{ color: tokens.textPrimary }}>sales agent</strong> represents
+                your film to international buyers and domestic distributors. They attend markets
+                (Cannes, AFM, Berlin), pitch to acquisitions executives, negotiate deals, and
                 sometimes advance marketing costs.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Sales agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
                 10-20%</strong> of gross revenues, depending on:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Territory</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Territory</strong> —
                   domestic sales often command lower percentages than international</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Budget level</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Budget level</strong> —
                   larger films may negotiate better rates</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Cast/director</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Cast/director</strong> —
                   star-driven packages may warrant lower fees</span>
                 </li>
               </ul>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Some sales agents also charge <strong style={{ color: tokens.textPrimary }}>
                 market fees</strong> for attending festivals and markets, plus <strong style={{ color: tokens.textPrimary }}>
                 recoupable expenses</strong> for marketing materials, screeners, and travel.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: COLLECTION AGENT FEE */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="03" title="Collection Agent Fee" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="03" title="Collection Agent Fee" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>collection agent</strong> (also 
-                called a collection account manager or CAM) is a neutral third party who receives 
+                The <strong style={{ color: tokens.textPrimary }}>collection agent</strong> (also
+                called a collection account manager or CAM) is a neutral third party who receives
                 all revenues, applies the waterfall, and distributes payments to the correct parties.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Collection agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
-                1-5%</strong> of gross revenues. Common CAMs include Fintage House, Freeway, and 
+                1-5%</strong> of gross revenues. Common CAMs include Fintage House, Freeway, and
                 Film Finances. While the percentage seems small, it comes off before anything else.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Why use a collection agent? They provide:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Investor confidence</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Investor confidence</strong> —
                   a neutral party ensures the waterfall is followed correctly</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Audit trail</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Audit trail</strong> —
                   detailed accounting for every dollar that flows through</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Lender requirement</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Lender requirement</strong> —
                   most senior lenders require a CAM before funding</span>
                 </li>
               </ul>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: DELIVERY COSTS */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="04" title="Delivery Costs" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="04" title="Delivery Costs" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                When a buyer acquires your film, they don't just want the movie—they want a 
-                complete <strong style={{ color: tokens.textPrimary }}>delivery package</strong>. 
-                This includes specific technical masters, audio mixes, subtitles, closed captions, 
+                When a buyer acquires your film, they don't just want the movie—they want a
+                complete <strong style={{ color: tokens.textPrimary }}>delivery package</strong>.
+                This includes specific technical masters, audio mixes, subtitles, closed captions,
                 artwork, and legal documentation.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Delivery costs vary significantly but can range from $25,000 to $150,000+ depending 
-                on the buyer's requirements. Streamers like Netflix have particularly detailed 
+                Delivery costs vary significantly but can range from $25,000 to $150,000+ depending
+                on the buyer's requirements. Streamers like Netflix have particularly detailed
                 technical specifications.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 In most deals, delivery costs are <strong style={{ color: tokens.textPrimary }}>
-                recoupable</strong>—meaning they come off the top of your revenues, just like 
+                recoupable</strong>—meaning they come off the top of your revenues, just like
                 distribution fees. Make sure your budget includes a realistic delivery allowance.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: THE REAL MATH */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="05" title="The Real Math" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="05" title="The Real Math" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
                 Here's what happens to a $2,000,000 acquisition before it reaches your waterfall:
               </p>
-              
-              <div 
+
+              <div
                 className="p-4 font-mono text-xs space-y-1"
-                style={{ 
+                style={{
                   background: tokens.bgSurface,
                   borderRadius: tokens.radiusMd,
                   border: `1px solid ${tokens.borderSubtle}`,
@@ -346,21 +240,21 @@ const FeesInfo = () => {
                 </div>
                 <div className="flex justify-between">
                   <span>Sales Agent (15%)</span>
-                  <span style={{ color: '#EF4444' }}>− $300,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $300,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Collection Agent (3%)</span>
-                  <span style={{ color: '#EF4444' }}>− $60,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $60,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Market Expenses</span>
-                  <span style={{ color: '#EF4444' }}>− $40,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $40,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Delivery Costs</span>
-                  <span style={{ color: '#EF4444' }}>− $75,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $75,000</span>
                 </div>
-                <div 
+                <div
                   className="pt-2 mt-2 flex justify-between font-semibold"
                   style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
                 >
@@ -368,72 +262,65 @@ const FeesInfo = () => {
                   <span style={{ color: tokens.gold }}>$1,525,000</span>
                 </div>
               </div>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                That's nearly <strong style={{ color: tokens.textPrimary }}>24% gone</strong> before 
-                your senior debt, equity investors, or profit participants see anything. And this 
+                That's nearly <strong style={{ color: tokens.textPrimary }}>24% gone</strong> before
+                your senior debt, equity investors, or profit participants see anything. And this
                 is just one territory—international sales may have additional layers of fees.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* SECTION: NEGOTIATING FEES */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="06" title="Negotiating Fees" />
-            
+          <WikiCard>
+            <WikiSectionHeader number="06" title="Negotiating Fees" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                While fees are standard in the industry, they're not set in stone. Producers 
+                While fees are standard in the industry, they're not set in stone. Producers
                 with leverage (strong packages, track records, or competing offers) can negotiate:
               </p>
-              
+
               <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Caps on recoupable expenses</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Caps on recoupable expenses</strong> —
                   limit how much a sales agent can charge back</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Sliding scale percentages</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Sliding scale percentages</strong> —
                   lower rates as revenues increase</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Sunset clauses</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Sunset clauses</strong> —
                   fees that reduce or expire after a certain period</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Territory carve-outs</strong> — 
+                  <span><strong style={{ color: tokens.textPrimary }}>Territory carve-outs</strong> —
                   excluding territories where you have direct relationships</span>
                 </li>
               </ul>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Always have an entertainment attorney review your sales representation and 
-                collection agreements before signing. Small percentage differences can translate 
+                Always have an entertainment attorney review your sales representation and
+                collection agreements before signing. Small percentage differences can translate
                 to significant dollar amounts.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* FOOTER — Back to Overview + subtle Start Simulation link */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">
-            <div 
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              style={{
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
               }}
             />
-            
+
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
@@ -445,7 +332,7 @@ const FeesInfo = () => {
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
-            
+
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}

--- a/src/pages/IntroView.tsx
+++ b/src/pages/IntroView.tsx
@@ -5,33 +5,16 @@ import { useState } from 'react';
 import Header from "@/components/Header";
 import { cn } from "@/lib/utils";
 import { colors, radius } from "@/lib/design-system";
+import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
-/* ═══════════════════════════════════════════════════════════════════════════
-   PRODUCT BIBLE v2.0 — NOTION MEETS APPS
-   
-   Design DNA:
-   - Notion: Clean hierarchy, toggle sections, database-level organization
-   - Apps: Gold left border accent, dark matte surfaces, premium sparse gold
-   
-   WIKI ARCHITECTURE:
-   - Main Wiki (/intro) with collapsible pillar sections + deep dive links
-   - Mini wikis can ONLY link back to /intro (no cross-wiki navigation)
-   - Only "Start Simulation" exits to calculator
-   ═══════════════════════════════════════════════════════════════════════════ */
-// Sourced from design-system.ts (aligned to index.css)
 const tokens = {
   bgVoid: colors.void,
   bgMatte: colors.card,
-  bgHeader: colors.elevated,
-  bgSurface: colors.surface,
   gold: colors.gold,
   goldMuted: colors.goldMuted,
   goldSubtle: colors.goldSubtle,
   goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
-  goldRadiant: colors.goldGlow,
   borderMatte: colors.borderSubtle,
-  borderSubtle: colors.borderSubtle,
   textPrimary: colors.textPrimary,
   textMid: colors.textMid,
   textDim: colors.textDim,
@@ -63,77 +46,6 @@ const faqItems: FAQItem[] = [
   }
 ];
 
-/* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER — Radiant Gold Left Border + Matte Gray Surface
-   ═══════════════════════════════════════════════════════════════════════════ */
-interface SectionHeaderProps {
-  number: string;
-  title: string;
-  isExpanded?: boolean;
-  onClick?: () => void;
-  isClickable?: boolean;
-}
-
-const SectionHeader = ({ number, title, isExpanded, onClick, isClickable = false }: SectionHeaderProps) => (
-  <div 
-    className={cn(
-      "flex items-stretch",
-      isClickable && "cursor-pointer hover:bg-white/[0.02] transition-colors"
-    )}
-    style={{ 
-      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
-      borderBottom: isExpanded ? `1px solid ${tokens.borderMatte}` : 'none',
-    }}
-    onClick={onClick}
-  >
-    <div 
-      className="w-1 flex-shrink-0"
-      style={{ 
-        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
-        boxShadow: `0 0 12px ${tokens.goldGlow}`,
-      }}
-    />
-    
-    <div 
-      className="flex items-center justify-center px-4 py-4"
-      style={{ 
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: '56px',
-        background: tokens.goldFill,
-      }}
-    >
-      <span 
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
-        {number}
-      </span>
-    </div>
-    
-    <div className="flex items-center flex-1 px-4 py-4 justify-between">
-      <h2 
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
-        {title}
-      </h2>
-      
-      {isClickable && (
-        <ChevronDown 
-          className={cn(
-            "w-4 h-4 flex-shrink-0 transition-transform duration-200",
-            isExpanded && "rotate-180"
-          )}
-          style={{ color: isExpanded ? tokens.gold : tokens.textDim }}
-        />
-      )}
-    </div>
-  </div>
-);
-
-/* ═══════════════════════════════════════════════════════════════════════════
-   PILLAR DATA — Content for each accordion section
-   ═══════════════════════════════════════════════════════════════════════════ */
 interface PillarData {
   number: string;
   title: string;
@@ -168,9 +80,6 @@ const pillars: PillarData[] = [
   },
 ];
 
-/* ═══════════════════════════════════════════════════════════════════════════
-   PILLAR ACCORDION — Collapsed by default, condensed on expand
-   ═══════════════════════════════════════════════════════════════════════════ */
 interface PillarAccordionProps {
   pillar: PillarData;
   isExpanded: boolean;
@@ -179,30 +88,23 @@ interface PillarAccordionProps {
 
 const PillarAccordion = ({ pillar, isExpanded, onToggle }: PillarAccordionProps) => {
   const navigate = useNavigate();
-  
+
   const handleDeepDive = (e: React.MouseEvent) => {
     e.stopPropagation();
     navigate(pillar.learnMorePath);
     window.scrollTo(0, 0);
   };
-  
+
   return (
-    <div 
-      className="overflow-hidden animate-fade-in"
-      style={{ 
-        background: tokens.bgMatte,
-        border: `1px solid ${tokens.borderMatte}`,
-        borderRadius: tokens.radiusLg,
-      }}
-    >
-      <SectionHeader 
-        number={pillar.number} 
-        title={pillar.title} 
+    <WikiCard>
+      <WikiSectionHeader
+        number={pillar.number}
+        title={pillar.title}
         isExpanded={isExpanded}
         onClick={onToggle}
         isClickable={true}
       />
-      
+
       <div
         className={cn(
           "overflow-hidden transition-all duration-300 ease-out",
@@ -213,7 +115,7 @@ const PillarAccordion = ({ pillar, isExpanded, onToggle }: PillarAccordionProps)
           <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
             {pillar.summary}
           </p>
-          
+
           <button
             onClick={handleDeepDive}
             className="flex items-center gap-2 text-sm font-medium transition-all hover:gap-3"
@@ -224,7 +126,7 @@ const PillarAccordion = ({ pillar, isExpanded, onToggle }: PillarAccordionProps)
           </button>
         </div>
       </div>
-    </div>
+    </WikiCard>
   );
 };
 
@@ -248,39 +150,35 @@ const IntroView = () => {
   return (
     <>
       <Header />
-      
-      <div 
+
+      <div
         className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
         style={{ background: tokens.bgVoid }}
       >
         <div className="max-w-2xl mx-auto space-y-6">
-          
-          {/* ═══════════════════════════════════════════════════════════════
-              PAGE HEADER
-              ═══════════════════════════════════════════════════════════════ */}
+
+          {/* PAGE HEADER */}
           <div className="space-y-4 pt-6 animate-fade-in">
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
               Waterfall <span style={{ color: tokens.gold }}>Protocol</span>
             </h1>
-            
-            <p 
+
+            <p
               className="text-base leading-relaxed max-w-lg"
               style={{ color: tokens.textMid }}
             >
               How money moves through a film deal—from acquisition to your pocket.
             </p>
-            
-            <div 
+
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)` 
+              style={{
+                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
               }}
             />
           </div>
 
-          {/* ═══════════════════════════════════════════════════════════════
-              PILLARS 01-04 — Accordion Pattern (All collapsed by default)
-              ═══════════════════════════════════════════════════════════════ */}
+          {/* PILLARS 01-04 */}
           {pillars.map((pillar, index) => (
             <PillarAccordion
               key={pillar.number}
@@ -290,71 +188,38 @@ const IntroView = () => {
             />
           ))}
 
-          {/* ═══════════════════════════════════════════════════════════════
-              WHY THIS MATTERS
-              ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="05" title="Why This Matters" />
-            
+          {/* WHY THIS MATTERS */}
+          <WikiCard>
+            <WikiSectionHeader number="05" title="Why This Matters" />
+
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Most filmmakers don't see this math until they've already signed. 
+                Most filmmakers don't see this math until they've already signed.
                 By then, the deal terms are locked—and the surprises aren't pleasant.
               </p>
-              
+
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Understanding the waterfall before you negotiate changes the conversation. 
-                Investors back producers who can walk through collection fees, recoupment 
-                positions, and profit corridors with confidence. You're not just pitching 
+                Understanding the waterfall before you negotiate changes the conversation.
+                Investors back producers who can walk through collection fees, recoupment
+                positions, and profit corridors with confidence. You're not just pitching
                 a film—you're demonstrating you understand the business.
               </p>
-              
-              <div 
-                className="p-4 mt-2"
-                style={{ 
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
-              >
-                <p 
-                  className="text-xs font-semibold uppercase tracking-wide mb-2"
-                  style={{ color: tokens.gold }}
-                >
-                  Key Insight
-                </p>
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  A $2M acquisition doesn't mean $2M in your pocket. After fees and recoupment, 
-                  that number can shrink dramatically. This tool shows you exactly where the 
-                  money goes—before you sign anything.
-                </p>
-              </div>
-            </div>
-          </div>
 
-          {/* ═══════════════════════════════════════════════════════════════
-              FAQ
-              ═══════════════════════════════════════════════════════════════ */}
-          <div 
-            className="overflow-hidden animate-fade-in"
-            style={{ 
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="06" title="FAQ" />
-            
+              <WikiCallout label="Key Insight">
+                A $2M acquisition doesn't mean $2M in your pocket. After fees and recoupment,
+                that number can shrink dramatically. This tool shows you exactly where the
+                money goes—before you sign anything.
+              </WikiCallout>
+            </div>
+          </WikiCard>
+
+          {/* FAQ */}
+          <WikiCard>
+            <WikiSectionHeader number="06" title="FAQ" />
+
             <div>
               {faqItems.map((item, index) => (
-                <div 
+                <div
                   key={index}
                   style={{ borderTop: index > 0 ? `1px solid ${tokens.borderMatte}` : 'none' }}
                 >
@@ -365,14 +230,14 @@ const IntroView = () => {
                       background: openFAQ === index ? tokens.goldSubtle : 'transparent',
                     }}
                   >
-                    <span 
+                    <span
                       className="text-sm font-medium pr-4"
                       style={{ color: openFAQ === index ? tokens.textPrimary : tokens.textMid }}
                     >
                       {item.question}
                     </span>
-                    
-                    <ChevronDown 
+
+                    <ChevronDown
                       className={cn(
                         "w-4 h-4 flex-shrink-0 transition-transform duration-200",
                         openFAQ === index && "rotate-180"
@@ -380,14 +245,14 @@ const IntroView = () => {
                       style={{ color: openFAQ === index ? tokens.gold : tokens.textDim }}
                     />
                   </button>
-                  
+
                   <div
                     className={cn(
                       "overflow-hidden transition-all duration-200",
                       openFAQ === index ? "max-h-40 opacity-100" : "max-h-0 opacity-0"
                     )}
                   >
-                    <div 
+                    <div
                       className="px-4 pb-4 text-sm leading-relaxed"
                       style={{ color: tokens.textDim }}
                     >
@@ -397,20 +262,18 @@ const IntroView = () => {
                 </div>
               ))}
             </div>
-          </div>
+          </WikiCard>
 
-          {/* ═══════════════════════════════════════════════════════════════
-              CTA SECTION
-              ═══════════════════════════════════════════════════════════════ */}
+          {/* CTA */}
           <div className="pt-6 flex flex-col items-center gap-6 animate-fade-in">
-            <div 
+            <div
               className="h-px w-full"
-              style={{ 
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)` 
+              style={{
+                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
               }}
             />
-            
-            <Button 
+
+            <Button
               onClick={handleStartSimulation}
               className="group px-10 py-6 text-sm font-black uppercase tracking-widest transition-all duration-200 hover:scale-[1.02]"
               style={{
@@ -424,7 +287,7 @@ const IntroView = () => {
               Start Simulation
               <ArrowRight className="ml-3 w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Button>
-            
+
             <button
               onClick={() => navigate('/')}
               className="flex items-center gap-2 text-sm transition-colors"

--- a/src/pages/WaterfallInfo.tsx
+++ b/src/pages/WaterfallInfo.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Droplets, ChevronDown, Shield, Target, Calculator, FileCheck } from 'lucide-react';
 import Header from "@/components/Header";
 import { colors, radius } from "@/lib/design-system";
+import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 /* ═══════════════════════════════════════════════════════════════════════════
    MINI WIKI: RECOUPMENT WATERFALL
@@ -16,16 +17,11 @@ import { colors, radius } from "@/lib/design-system";
 // Sourced from design-system.ts (aligned to index.css)
 const tokens = {
   bgVoid: colors.void,
-  bgMatte: colors.card,
-  bgHeader: colors.elevated,
   bgSurface: colors.surface,
   gold: colors.gold,
   goldMuted: colors.goldMuted,
   goldSubtle: colors.goldSubtle,
   goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
-  goldRadiant: colors.goldGlow,
-  borderMatte: colors.borderSubtle,
   borderSubtle: colors.borderSubtle,
   textPrimary: colors.textPrimary,
   textMid: colors.textMid,
@@ -35,58 +31,8 @@ const tokens = {
 };
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   SECTION HEADER — Radiant Gold Left Border
-   ═══════════════════════════════════════════════════════════════════════════ */
-interface SectionHeaderProps {
-  number: string;
-  title: string;
-}
-
-const SectionHeader = ({ number, title }: SectionHeaderProps) => (
-  <div
-    className="flex items-stretch"
-    style={{
-      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
-      borderBottom: `1px solid ${tokens.borderMatte}`,
-    }}
-  >
-    <div
-      className="w-1 flex-shrink-0"
-      style={{
-        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
-        boxShadow: `0 0 12px ${tokens.goldGlow}`,
-      }}
-    />
-
-    <div
-      className="flex items-center justify-center px-4 py-4"
-      style={{
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: '56px',
-        background: tokens.goldFill,
-      }}
-    >
-      <span
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
-        {number}
-      </span>
-    </div>
-
-    <div className="flex items-center px-4 py-4">
-      <h2
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
-        {title}
-      </h2>
-    </div>
-  </div>
-);
-
-/* ═══════════════════════════════════════════════════════════════════════════
    FLOW TIER — Vertical pipeline step for Section 02
+   All accent colors are gold intensity variations (no rainbow).
    ═══════════════════════════════════════════════════════════════════════════ */
 interface FlowTierProps {
   position: number;
@@ -127,22 +73,22 @@ const FlowTier = ({ position, label, sublabel, accentColor, isLast }: FlowTierPr
 );
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   POSITION CARD — Risk-colored card for Section 03
+   POSITION CARD — Gold-accented card for Section 03
+   All cards use gold borderTop; risk labels use goldSubtle/goldMuted/gold.
    ═══════════════════════════════════════════════════════════════════════════ */
 interface PositionCardProps {
   title: string;
   riskLabel: string;
   description: string;
-  accentColor: string;
 }
 
-const PositionCard = ({ title, riskLabel, description, accentColor }: PositionCardProps) => (
+const PositionCard = ({ title, riskLabel, description }: PositionCardProps) => (
   <div
     className="p-4 flex-1"
     style={{
       background: tokens.bgSurface,
       borderRadius: tokens.radiusMd,
-      borderTop: `3px solid ${accentColor}`,
+      borderTop: `3px solid ${tokens.gold}`,
     }}
   >
     <div className="flex items-center justify-between mb-2">
@@ -152,9 +98,9 @@ const PositionCard = ({ title, riskLabel, description, accentColor }: PositionCa
       <span
         className="text-[10px] font-mono uppercase tracking-wider px-2 py-0.5 rounded-full"
         style={{
-          background: `${accentColor}18`,
-          color: accentColor,
-          border: `1px solid ${accentColor}40`,
+          background: tokens.goldSubtle,
+          color: tokens.gold,
+          border: `1px solid ${tokens.goldMuted}`,
         }}
       >
         {riskLabel}
@@ -168,6 +114,7 @@ const PositionCard = ({ title, riskLabel, description, accentColor }: PositionCa
 
 /* ═══════════════════════════════════════════════════════════════════════════
    SPLIT BAR — Visual proportional bar for Section 04
+   Segments use gold at varying opacities (no rainbow).
    ═══════════════════════════════════════════════════════════════════════════ */
 interface SplitSegment {
   label: string;
@@ -311,41 +258,19 @@ const WaterfallInfo = () => {
               SECTION 01 — WHAT IS A WATERFALL?
               Layout: Definition callout aside + supporting context
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="01" title="What Is a Waterfall?" />
+          <WikiCard>
+            <WikiSectionHeader number="01" title="What Is a Waterfall?" />
 
             <div className="p-5 space-y-4">
               {/* Key definition callout */}
-              <div
-                className="flex gap-3 p-4"
-                style={{
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
+              <WikiCallout
+                label="Key Concept"
+                icon={<Droplets className="w-5 h-5" style={{ color: tokens.gold }} />}
               >
-                <Droplets className="w-5 h-5 flex-shrink-0 mt-0.5" style={{ color: tokens.gold }} />
-                <div>
-                  <p
-                    className="text-xs font-semibold uppercase tracking-wide mb-1.5"
-                    style={{ color: tokens.gold }}
-                  >
-                    Key Concept
-                  </p>
-                  <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                    The <strong>recoupment waterfall</strong> is the contractual hierarchy that determines
-                    how revenues flow through a film deal. Like water flowing down a series of pools,
-                    money fills each "position" completely before spilling over to the next.
-                  </p>
-                </div>
-              </div>
+                The <strong>recoupment waterfall</strong> is the contractual hierarchy that determines
+                how revenues flow through a film deal. Like water flowing down a series of pools,
+                money fills each "position" completely before spilling over to the next.
+              </WikiCallout>
 
               {/* Supporting context — visually distinct from the callout */}
               <div
@@ -366,21 +291,14 @@ const WaterfallInfo = () => {
                 </p>
               </div>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 02 — TYPICAL WATERFALL ORDER
-              Layout: Vertical connected pipeline with colored phase nodes
+              Layout: Vertical connected pipeline with gold phase nodes
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="02" title="Typical Waterfall Order" />
+          <WikiCard>
+            <WikiSectionHeader number="02" title="Typical Waterfall Order" />
 
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -400,31 +318,31 @@ const WaterfallInfo = () => {
                   position={1}
                   label="Distribution Fees"
                   sublabel="Sales agent, collection agent, market expenses"
-                  accentColor="#EF4444"
+                  accentColor={tokens.gold}
                 />
                 <FlowTier
                   position={2}
                   label="Delivery Costs"
                   sublabel="Technical masters, materials, recoupable expenses"
-                  accentColor="#F97316"
+                  accentColor={tokens.goldMuted}
                 />
                 <FlowTier
                   position={3}
                   label="Senior Debt"
                   sublabel="Bank loans, tax credit advances (principal + interest)"
-                  accentColor="#EAB308"
+                  accentColor={tokens.gold}
                 />
                 <FlowTier
                   position={4}
                   label="Gap Financing"
                   sublabel="Gap loans (principal + interest + fees)"
-                  accentColor="#A3E635"
+                  accentColor={tokens.goldMuted}
                 />
                 <FlowTier
                   position={5}
                   label="Equity Recoupment"
                   sublabel="Investor principal + negotiated premium (10-25%)"
-                  accentColor="#22D3EE"
+                  accentColor={tokens.gold}
                 />
                 <FlowTier
                   position={6}
@@ -442,21 +360,14 @@ const WaterfallInfo = () => {
                 </p>
               </div>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 03 — RECOUPMENT POSITIONS
-              Layout: Grid of risk-colored position cards
+              Layout: Grid of gold-accented position cards
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="03" title="Recoupment Positions" />
+          <WikiCard>
+            <WikiSectionHeader number="03" title="Recoupment Positions" />
 
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -470,43 +381,32 @@ const WaterfallInfo = () => {
                   title="First Dollar"
                   riskLabel="Lowest Risk"
                   description="The earliest position after fees. Safest for investors — you get paid before almost everyone else."
-                  accentColor="#4ADE80"
                 />
                 <PositionCard
                   title="Pari Passu"
                   riskLabel="Shared Risk"
                   description="Multiple parties sharing the same position proportionally. Common when two equity sources co-invest."
-                  accentColor="#22D3EE"
                 />
                 <PositionCard
                   title="Subordinated"
                   riskLabel="Higher Risk"
                   description="Only triggers after higher positions are fully satisfied. More upside potential, less certainty."
-                  accentColor="#FBBF24"
                 />
                 <PositionCard
                   title="Last Money In"
                   riskLabel="Negotiated"
                   description="Sometimes the final investor gets first recoupment as an incentive to close the financing gap."
-                  accentColor="#C084FC"
                 />
               </div>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 04 — PROFIT CORRIDORS
               Layout: Visual split bar + monospace table
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="04" title="Profit Corridors" />
+          <WikiCard>
+            <WikiSectionHeader number="04" title="Profit Corridors" />
 
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -515,14 +415,14 @@ const WaterfallInfo = () => {
                 just pile up—it gets split according to the Operating Agreement.
               </p>
 
-              {/* Visual proportional bar */}
+              {/* Visual proportional bar — gold opacity gradient */}
               <SplitBar
                 segments={[
-                  { label: 'Equity Investors', percentage: 50, color: '#22D3EE' },
-                  { label: 'Producers', percentage: 25, color: tokens.gold },
-                  { label: 'Talent Deferrals', percentage: 15, color: '#C084FC' },
-                  { label: 'Director', percentage: 5, color: '#4ADE80' },
-                  { label: 'Writer', percentage: 5, color: '#F97316' },
+                  { label: 'Equity Investors', percentage: 50, color: tokens.gold },
+                  { label: 'Producers', percentage: 25, color: 'rgba(255,215,0,0.7)' },
+                  { label: 'Talent Deferrals', percentage: 15, color: 'rgba(255,215,0,0.5)' },
+                  { label: 'Director', percentage: 5, color: 'rgba(255,215,0,0.3)' },
+                  { label: 'Writer', percentage: 5, color: 'rgba(255,215,0,0.15)' },
                 ]}
               />
 
@@ -571,21 +471,14 @@ const WaterfallInfo = () => {
                 the split might shift to favor producers more heavily.
               </p>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 05 — THE HARSH REALITY
               Layout: Step-down draindown ledger showing money disappearing
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="05" title="The Harsh Reality" />
+          <WikiCard>
+            <WikiSectionHeader number="05" title="The Harsh Reality" />
 
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -593,7 +486,7 @@ const WaterfallInfo = () => {
                 reaches profit participation. Here's what a $1M film selling for $1.5M actually looks like:
               </p>
 
-              {/* Draindown ledger — like FeesInfo "The Real Math" */}
+              {/* Draindown ledger — negative numbers use goldMuted instead of red */}
               <div
                 className="p-4 font-mono text-xs space-y-1"
                 style={{
@@ -609,15 +502,15 @@ const WaterfallInfo = () => {
                 </div>
                 <div className="flex justify-between">
                   <span>Distribution Fees (20%)</span>
-                  <span style={{ color: '#EF4444' }}>− $300,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $300,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Delivery Costs</span>
-                  <span style={{ color: '#EF4444' }}>− $50,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $50,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Capital Recoupment</span>
-                  <span style={{ color: '#EF4444' }}>− $1,000,000</span>
+                  <span style={{ color: tokens.goldMuted }}>− $1,000,000</span>
                 </div>
                 <div
                   className="pt-2 mt-2 flex justify-between font-semibold"
@@ -628,7 +521,7 @@ const WaterfallInfo = () => {
                 </div>
               </div>
 
-              {/* Visual progress: how much survives */}
+              {/* Visual progress: how much survives — already gold, kept as-is */}
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <span className="text-xs" style={{ color: tokens.textDim }}>Revenue survival rate</span>
@@ -656,41 +549,20 @@ const WaterfallInfo = () => {
                 </p>
               </div>
 
-              <div
-                className="p-4"
-                style={{
-                  background: 'rgba(239, 68, 68, 0.08)',
-                  borderRadius: tokens.radiusMd,
-                  border: '1px solid rgba(239, 68, 68, 0.25)',
-                }}
-              >
-                <p
-                  className="text-xs font-semibold uppercase tracking-wide mb-1.5"
-                  style={{ color: '#EF4444' }}
-                >
-                  Bottom Line
-                </p>
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  A "generous" backend that triggers after $3M in prior positions might never pay out
-                  on a film that's realistic about its sales potential. Understand the math before you sign.
-                </p>
-              </div>
+              {/* "Bottom Line" warning — gold style instead of red */}
+              <WikiCallout label="Bottom Line">
+                A "generous" backend that triggers after $3M in prior positions might never pay out
+                on a film that's realistic about its sales potential. Understand the math before you sign.
+              </WikiCallout>
             </div>
-          </div>
+          </WikiCard>
 
           {/* ═══════════════════════════════════════════════════════════════
               SECTION 06 — PROTECTING YOURSELF
               Layout: 2x2 grid of icon-accented strategy cards
               ═══════════════════════════════════════════════════════════════ */}
-          <div
-            className="overflow-hidden animate-fade-in"
-            style={{
-              background: tokens.bgMatte,
-              border: `1px solid ${tokens.borderMatte}`,
-              borderRadius: tokens.radiusLg,
-            }}
-          >
-            <SectionHeader number="06" title="Protecting Yourself" />
+          <WikiCard>
+            <WikiSectionHeader number="06" title="Protecting Yourself" />
 
             <div className="p-5 space-y-4">
               <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
@@ -720,21 +592,12 @@ const WaterfallInfo = () => {
                 />
               </div>
 
-              <div
-                className="p-4"
-                style={{
-                  background: tokens.goldSubtle,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.goldMuted}`,
-                }}
-              >
-                <p className="text-sm leading-relaxed" style={{ color: tokens.textPrimary }}>
-                  Most importantly: have an entertainment attorney review your Operating Agreement
-                  before signing. The waterfall is where your deal is won or lost.
-                </p>
-              </div>
+              <WikiCallout label="Remember">
+                Most importantly: have an entertainment attorney review your Operating Agreement
+                before signing. The waterfall is where your deal is won or lost.
+              </WikiCallout>
             </div>
-          </div>
+          </WikiCard>
 
           {/* FOOTER — Back to Overview + subtle Start Simulation link */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">


### PR DESCRIPTION
## Summary
Standardized the color palette and typography throughout the calculator interface by replacing ad-hoc color values with a cohesive design system. This improves visual consistency, maintainability, and establishes a single source of truth for styling.

## Key Changes

### Color System Unification
- Replaced scattered `text-white/30`, `text-white/40`, `text-white/50`, `text-white/60` with semantic tokens:
  - `text-text-dim` for secondary/disabled text
  - `text-text-mid` for tertiary text
  - `text-text-primary` for primary text
- Removed status colors (red/green/orange) in favor of gold-only palette:
  - Changed `status-success` (green) → `text-gold`
  - Changed `status-danger` (red) → `text-text-dim`
  - Changed `status-warning` (orange) → `text-gold`
- Updated all callout boxes and alerts to use gold accents instead of multi-color variants

### Typography Standardization
- Unified section header letter-spacing: `tracking-[0.2em]` → `tracking-widest`
- Increased heading sizes for better hierarchy:
  - Step titles: `text-2xl` → `text-3xl` (BudgetInput, DealInput, CapitalSelect, StackInputCard)
- Adjusted font weights for consistency: `font-medium` → `font-bold` on section headers
- Reduced icon sizes in header badges: `w-8 h-8` → `w-7 h-7`

### Component Improvements
- Created three new shared components for reusability:
  - `WikiSectionHeader` — Gold-accented section headers with gradient background
  - `WikiCard` — Matte card container with subtle gold border
  - `WikiCallout` — Gold-only callout box for insights and warnings
- Updated `StatusBadge` and `VerdictCard` to use gold-only color scheme
- Refined border colors: `border-[#1A1A1A]` → `border-border-subtle`
- Improved visual hierarchy in waterfall and stack components

### Specific Component Updates
- **DisclaimerFooter**: Updated text colors and emphasis styling
- **WaterfallVisual**: Unified tier status colors, replaced orange with gold
- **StackSummary**: Changed underfunded state from orange to gold, improved consistency
- **DealInput**: Updated breakeven indicator colors to gold-only
- **StackInputCard**: Standardized all text colors and button states
- **WaterfallTab**: Replaced multi-color alerts with gold-accented callouts

## Implementation Details
- All changes maintain backward compatibility with existing component APIs
- Color tokens sourced from design system (`@/lib/design-system`)
- Semantic color naming improves code readability and future maintenance
- Gold-only palette creates a more cohesive, premium visual identity
- New shared components reduce duplication across feature pages

https://claude.ai/code/session_01U29yss7vqfRgy4inKvhtce