### PR TITLE
fix: add elevated background to inputs for better contrast

### DIFF
--- a/src/components/calculator/StandardStepLayout.tsx
+++ b/src/components/calculator/StandardStepLayout.tsx
@@ -23,7 +23,7 @@ interface StandardStepLayoutProps {
  * Structure:
  * - ChapterCard Container
  *   - Header (Built-in to ChapterCard)
- *   - Body
+ *   - Body (NOW LIGHTER: bg-bg-elevated)
  *     - Subtitle (Optional)
  *     - Children (Input fields, etc)
  *     - Action Button (Continue)
@@ -44,7 +44,7 @@ const StandardStepLayout = ({
         chapter={chapter}
         title={title}
         isActive={true}
-        className="overflow-visible min-h-[500px]" // FIXED HEIGHT: Prevents layout jumping
+        className="overflow-visible min-h-[500px]" 
       >
         <div className="flex flex-col h-full justify-between space-y-6">
           {/* Top Content */}
@@ -56,8 +56,9 @@ const StandardStepLayout = ({
               </p>
             )}
 
-            {/* Main Content (Inputs) */}
-            <div className="space-y-6">
+            {/* Main Content (Inputs) - WRAPPED IN ELEVATED SURFACE */}
+            {/* This fixes the "too black" issue by giving inputs a defined surface to sit on */}
+            <div className="bg-bg-elevated border border-border-subtle rounded-lg p-5 space-y-6 shadow-sm">
               {children}
             </div>
           </div>


### PR DESCRIPTION
## 🖼️ Visual Fix: Too Black / Hard to Read

The feedback "it's too black everywhere" was addressed by updating the core layout component.

### The Solution:
I updated `StandardStepLayout.tsx` to wrap the input/content area in a distinct container:
- **`bg-bg-elevated`**: Instead of inputs floating in a black void, they now sit on a slightly lighter (elevated) dark gray surface.
- **`border-border-subtle`**: A subtle border defines the input area.
- **`rounded-lg` & `shadow-sm`**: Adds depth and separation.

### The Result:
The app still feels "dark mode premium," but the input sections are now clearly distinguished from the background. It is no longer an endless sea of black. The hierarchy is:
1.  **Black Background** (Global)
2.  **Card Background** (Chapter Container)
3.  **Elevated Surface** (Input Area - New!)

This creates visual "stepping stones" for the eye, making the forms much easier to parse.