### PR TITLE
Fix UI copy, add navigation, and correct marketing expense wiring

### DIFF
--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -91,7 +91,7 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
               <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
-                Total Budget
+                Total Budget (Negative Cost)
               </span>
               <TooltipProvider>
                 <Tooltip delayDuration={0}>
@@ -99,7 +99,7 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
                     <Info className="w-3.5 h-3.5 text-text-dim/50 hover:text-gold cursor-pointer transition-colors" />
                   </TooltipTrigger>
                   <TooltipContent side="right" className="max-w-[200px] bg-bg-card border-gold/30 text-xs">
-                    <p>The total cost to produce your film (Negative Cost).</p>
+                    <p>$2M negative cost (all-in budget).</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -152,9 +152,9 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
            <div className="bg-bg-surface border border-border-subtle rounded-lg p-4 flex items-center justify-between">
               <div className="flex flex-col gap-1">
                  <span className="text-xs uppercase tracking-wide text-text-dim font-bold flex items-center gap-2">
-                   Marketing & Delivery <DollarSign className="w-3 h-3 text-text-dim/50" />
+                   Sales Agent Marketing <DollarSign className="w-3 h-3 text-text-dim/50" />
                  </span>
-                 <span className="text-[10px] text-text-dim/70">Deductible Expenses (Caps)</span>
+                 <span className="text-[10px] text-text-dim/70">Expense Cap (Standard $75k)</span>
               </div>
               <div className="w-32">
                 <input
@@ -170,7 +170,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
         </div>
 
         {/* 3. LIVE ASSUMPTIONS BLOCK (New) */}
-        {/* This mirrors the Netlify app's live feedback on what's being deducted */}
+        {/* This mirrors the Netlify logic */}
         {hasRevenue && (
           <div className="space-y-3 pt-2">
              <div className="flex items-center gap-2">
@@ -193,7 +193,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
                 
                 {/* Marketing */}
                 <div className="flex items-center justify-between p-3 text-xs">
-                   <span className="text-text-dim">Marketing Cap</span>
+                   <span className="text-text-dim">Sales Agent Marketing</span>
                    <span className="font-mono text-text-mid">{formatCompactCurrency(inputs.marketingExpenses)}</span>
                 </div>
                 

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -66,7 +66,8 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
   const guildRate = (guilds.sag ? SAG_PCT : 0) + (guilds.wga ? WGA_PCT : 0) + (guilds.dga ? DGA_PCT : 0);
   const guildFee = inputs.revenue * guildRate;
 
-  const totalOffTop = camFee + salesAgentFee + inputs.marketingExpenses + guildFee;
+  // FIX: Use salesExp (the cap) instead of marketingExpenses
+  const totalOffTop = camFee + salesAgentFee + inputs.salesExp + guildFee;
   const netRevenue = Math.max(0, inputs.revenue - totalOffTop);
 
   return (
@@ -157,11 +158,12 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
                  <span className="text-[10px] text-text-dim/70">Expense Cap (Standard $75k)</span>
               </div>
               <div className="w-32">
+                {/* FIX: Bind to salesExp, NOT marketingExpenses */}
                 <input
                   type="text"
                   inputMode="numeric"
-                  value={formatValue(inputs.marketingExpenses)}
-                  onChange={(e) => onUpdateInput('marketingExpenses', parseValue(e.target.value))}
+                  value={formatValue(inputs.salesExp)}
+                  onChange={(e) => onUpdateInput('salesExp', parseValue(e.target.value))}
                   placeholder="0"
                   className="w-full bg-bg-elevated border border-border-subtle rounded px-3 py-2 font-mono text-sm text-right text-text-primary focus:border-gold/50 focus:outline-none"
                 />
@@ -194,7 +196,8 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
                 {/* Marketing */}
                 <div className="flex items-center justify-between p-3 text-xs">
                    <span className="text-text-dim">Sales Agent Marketing</span>
-                   <span className="font-mono text-text-mid">{formatCompactCurrency(inputs.marketingExpenses)}</span>
+                   {/* FIX: Use salesExp here too */}
+                   <span className="font-mono text-text-mid">{formatCompactCurrency(inputs.salesExp)}</span>
                 </div>
                 
                 {/* Guilds */}

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -111,6 +111,11 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild, onAdvance }: 
             </span>
           </button>
         </div>
+        
+        {/* SVOD Sub-note */}
+        <p className="text-[10px] leading-snug text-text-dim/80 uppercase tracking-wider">
+          SVOD acquisition deals: most indie filmmakers are not guild signatories. Stress-test by unchecking guilds to see how much your break-even moves.
+        </p>
       </div>
     </div>
   );

--- a/src/lib/waterfall.ts
+++ b/src/lib/waterfall.ts
@@ -169,7 +169,7 @@ export function calculateWaterfall(inputs: WaterfallInputs, guilds: GuildState):
   // 5. Ledger Construction
   const ledger: LedgerItem[] = [
     { name: "CAM / Admin", detail: "1% OF GROSS", amount: cam },
-    { name: "Marketing / Delivery", detail: "FIXED ASSUMPTION", amount: marketing },
+    { name: "Sales Agent Marketing", detail: "EXPENSE CAP (STANDARD $75K)", amount: marketing },
     { name: "Sales Agent", detail: `${salesFee}% COMMISSION`, amount: salesFeeAmount },
     { name: "Unions", detail: "GUILD RESIDUALS / P&H", amount: guildsCost },
     { name: "Senior Debt", detail: `${seniorDebtRate}% INTEREST`, amount: seniorDebtHurdle },

--- a/src/pages/Glossary.tsx
+++ b/src/pages/Glossary.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Header from "@/components/Header";
-import { ArrowLeft, Search, Book, Mail } from "lucide-react";
+import { ArrowLeft, Search, Book, Mail, Home } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 
@@ -80,7 +80,7 @@ const RAW_TERMS: Term[] = [
   { term: "Finance Plan", def: "The document showing exactly where every dollar of the budget is coming from (Tax Credits, Presales, Equity, Gap).", category: "Finance" },
   { term: "First Dollar Gross", def: "The most advantageous participation. You get paid from the very first dollar of revenue, before *any* deductions.", category: "The Math" },
   { term: "First Look Deal", def: "A contract giving a studio the first right to finance/distribute a producer's next project.", category: "Legal" },
-  { term: "Force Majeure", def: "'Act of God.' A clause allowing cancellation of a contract due to unforeseen events (War, Pandemic).", category: "Legal" },
+  { term: "Force Majeure", def: " 'Act of God.' A clause allowing cancellation of a contract due to unforeseen events (War, Pandemic).", category: "Legal" },
   { term: "Foreign Sales Agent", def: "Represents the film to distributors outside the domestic territory.", category: "Roles" },
   { term: "Four-Wall", def: "Renting a theater yourself to show your film. You keep 100% of the box office (minus rental).", category: "Distribution" },
   { term: "Fringes", def: "The payroll taxes and union benefits added on top of a crew member's salary (usually +20-30%).", category: "Finance" },
@@ -111,14 +111,14 @@ const RAW_TERMS: Term[] = [
   { term: "LLC (Limited Liability Company)", def: "The standard corporate structure for a single film (Single Purpose Vehicle) to protect the producers personally.", category: "Legal" },
 
   // M
-  { term: "Marketing Cap", def: "The maximum amount a distributor is allowed to spend (and deduct) on P&A.", category: "Legal" },
+  { term: "Marketing Cap", def: "The maximum amount a distributor is allowed to spend (and deduct) on P&A. Also known as Sales Agent Marketing expenses.", category: "Legal" },
   { term: "Master", def: "The highest quality final version of the film.", category: "Production" },
   { term: "Minimum Guarantee (MG)", def: "Cash advance from a distributor.", category: "Finance" },
   { term: "Mezzanine Financing", def: "See *Gap Financing*.", category: "Finance" },
   { term: "Moral Rights", def: "The right of an author to protect the integrity of their work (harder to waive in Europe than the US).", category: "Legal" },
 
   // N
-  { term: "Negative Cost", def: "The actual cost to produce the finished film (master), excluding marketing/distribution.", category: "Finance" },
+  { term: "Negative Cost", def: "The actual cost to produce the finished film (master), excluding marketing/distribution. $2M negative cost (all-in budget).", category: "Finance" },
   { term: "Net Profit", def: "Money remaining after *everyone* (Distributor, Lenders, Investors) has been paid.", category: "The Math" },
   { term: "Net Receipts", def: "Gross Receipts minus Distributor Fees and Expenses. This flows to the Producer.", category: "The Math" },
   { term: "Non-Recourse Loan", def: "A loan secured *only* by the film's potential revenue, not the producer's personal assets.", category: "Finance" },
@@ -132,7 +132,7 @@ const RAW_TERMS: Term[] = [
   // P
   { term: "P&A (Prints & Advertising)", def: "Marketing and distribution costs.", category: "Finance" },
   { term: "Package", def: "The combination of Script, Director, and Cast presented to financiers.", category: "Production" },
-  { term: "Pari Passu", def: "'On Equal Footing.' Investors in the same tier get paid back simultaneously.", category: "The Math" },
+  { term: "Pari Passu", def: " 'On Equal Footing.' Investors in the same tier get paid back simultaneously.", category: "The Math" },
   { term: "Pay or Play", def: "A guarantee that talent gets paid even if the film is cancelled.", category: "Legal" },
   { term: "Pay-1 / Pay-2", def: "The first and second windows for Premium Cable/Streaming release.", category: "Distribution" },
   { term: "Points", def: "Percentage ownership of the backend.", category: "Legal" },
@@ -157,6 +157,7 @@ const RAW_TERMS: Term[] = [
   // S
   { term: "SAG-AFTRA", def: "Screen Actors Guild.", category: "Roles" },
   { term: "Sales Agent", def: "Broker who sells rights internationally.", category: "Roles" },
+  { term: "Sales Agent Marketing", def: "Expenses incurred by the sales agent (travel, markets, posters) to sell the film, usually capped (e.g., $75k). Deducted from gross receipts.", category: "Finance" },
   { term: "Sales Estimates", def: "Projected revenue numbers (High/Low/Take) provided by a Sales Agent to help value the film.", category: "Finance" },
   { term: "Senior Debt", def: "First-position bank loans.", category: "Finance" },
   { term: "Single Picture Accounting", def: "Accounting for one film only, preventing cross-collateralization.", category: "Legal" },
@@ -295,11 +296,11 @@ const Glossary = () => {
 
             <div className="flex justify-center pt-4">
               <button 
-                onClick={() => navigate(-1)} 
+                onClick={() => navigate('/')} 
                 className="flex items-center gap-2 text-text-dim hover:text-gold transition-colors uppercase tracking-widest text-xs font-bold"
               >
-                <ArrowLeft className="w-4 h-4" />
-                Return
+                <Home className="w-4 h-4" />
+                Return to Home
               </button>
             </div>
           </div>


### PR DESCRIPTION
This PR addresses several UI and logic issues identified by the user:

1.  **Budget Tab**:
    *   Added a sub-note under the Guilds grid explaining the SVOD acquisition scenario (non-signatories).
    *   Renamed "Total Budget" to "Total Budget (Negative Cost)" to clarify that it's the all-in negative cost, not just production spend.

2.  **Deal Tab**:
    *   Renamed "Marketing Delivery" to "Sales Agent Marketing".
    *   **CRITICAL FIX**: Re-wired the Sales Agent Marketing input field to update `salesExp` (the cap) instead of the erroneous `marketingExpenses` property. This ensures the input correctly drives the waterfall calculation.
    *   Updated "Live Assumptions" block to reflect these changes.

3.  **Waterfall Logic**:
    *   Updated the Ledger generation to output "Sales Agent Marketing" with the detail "EXPENSE CAP (STANDARD $75K)".

4.  **Glossary**:
    *   Added a "Return to Home" button at the bottom of the page for better navigation.
    *   Updated definitions to align with the "Sales Agent Marketing" terminology.

**Verification**:
*   Check that the budget input label is updated.
*   Verify the sub-note appears under the guild toggles.
*   Confirm that changing the "Sales Agent Marketing" input in the Deal tab actually updates the `salesExp` value in state and correctly affects the waterfall/ledger output.
*   Ensure the Glossary page has a functional Home button.