### PR TITLE
Fix navigation flow, remove email gate, normalize design system to go…

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -54,7 +54,7 @@ const MobileMenu = () => {
               className="w-full flex items-center gap-3 p-3 rounded-lg text-text-primary hover:bg-bg-elevated transition-colors text-left group"
             >
               <Briefcase className="w-5 h-5 text-gold group-hover:text-gold" />
-              <span className="font-bebas text-base tracking-wide text-gold">Producer's Services</span>
+              <span className="font-bebas text-base tracking-wide text-gold">Packages</span>
             </button>
 
             <button

--- a/src/components/calculator/TabBar.tsx
+++ b/src/components/calculator/TabBar.tsx
@@ -42,11 +42,17 @@ const TabBar = ({ activeTab, onTabChange, completedTabs = [], disabledTabs = [] 
               isDisabled && "opacity-30 cursor-not-allowed"
             )}
           >
-            <span className={cn(
-              "tab-icon transition-colors",
-              isActive ? "text-gold" : isCompleted ? "text-text-mid" : "text-text-dim"
-            )}>
-              {tab.icon}
+            <span className="relative">
+              <span className={cn(
+                "tab-icon transition-colors",
+                isActive ? "text-gold" : isCompleted ? "text-text-mid" : "text-text-dim"
+              )}>
+                {tab.icon}
+              </span>
+              {/* Gold completion dot */}
+              {isCompleted && !isActive && (
+                <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-gold rounded-full" />
+              )}
             </span>
             <span>{tab.label}</span>
           </button>

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -1,7 +1,7 @@
 import { WaterfallResult, WaterfallInputs, calculateWaterfall, formatCompactCurrency, formatMultiple } from "@/lib/waterfall";
 import { getVerdictStatus } from "@/lib/design-system";
-import { Lock, AlertTriangle, ChevronDown, ChevronUp, Play, X } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Lock, AlertTriangle, ChevronDown, ChevronUp, Play, X, FileSpreadsheet, Sparkles } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
 import StandardStepLayout from "../StandardStepLayout";
 import { useEffect, useState } from "react";
 import { useHaptics } from "@/hooks/use-haptics";
@@ -31,6 +31,7 @@ const DEMO_INPUTS: WaterfallInputs = {
 
 const WaterfallTab = ({ result: initialResult, inputs: initialInputs }: WaterfallTabProps) => {
   const haptics = useHaptics();
+  const navigate = useNavigate();
 
   // State for Demo Mode (if real inputs are empty)
   const isEmpty = initialInputs.budget === 0 || initialInputs.revenue === 0;
@@ -196,6 +197,29 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs }: Waterfal
               );
             })()}
 
+            {/* ═══ EXPORT CTA — The bridge to the store ═══ */}
+            {!isDemoMode && (
+              <div className="border border-gold/30 bg-gold/[0.04] rounded-lg p-5 space-y-4">
+                <div className="flex items-center gap-2">
+                  <Sparkles className="w-4 h-4 text-gold" />
+                  <span className="text-[10px] uppercase tracking-[0.2em] text-gold font-bold">
+                    Ready to Share?
+                  </span>
+                </div>
+                <p className="text-sm text-text-mid leading-relaxed">
+                  Turn these numbers into a professional investor package.
+                  Beautifully designed. Presentation-grade. Starting at $197.
+                </p>
+                <button
+                  onClick={() => navigate('/store')}
+                  className="btn-vault w-full"
+                >
+                  <FileSpreadsheet className="w-4 h-4 mr-2" />
+                  EXPORT YOUR FINANCIAL SNAPSHOT
+                </button>
+              </div>
+            )}
+
             {/* Disclaimer */}
             <Collapsible open={showDisclaimer} onOpenChange={setShowDisclaimer} className="border border-border-subtle rounded-lg bg-bg-surface overflow-hidden">
                <CollapsibleTrigger className="flex items-center justify-between w-full p-4 hover:bg-bg-elevated transition-colors">
@@ -206,13 +230,13 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs }: Waterfal
                   {showDisclaimer ? <ChevronUp className="w-4 h-4 text-text-dim" /> : <ChevronDown className="w-4 h-4 text-text-dim" />}
                </CollapsibleTrigger>
                <CollapsibleContent className="p-4 pt-0 text-xs text-text-dim space-y-2 border-t border-border-subtle bg-bg-void/50">
-                  <p className="mt-4">This calculator is for educational purposes only.</p>
-                  <p className="font-bold text-red-400 mt-2">Consult a qualified entertainment attorney.</p>
+                  <p className="mt-4">This calculator is for educational purposes only.
+                  Consult a qualified entertainment attorney before making any financing decisions.</p>
                </CollapsibleContent>
             </Collapsible>
 
             {/* Back to Wiki */}
-            <Link 
+            <Link
               to="/waterfall-info"
               className="block p-4 text-center text-xs text-gold/70 hover:text-gold hover:underline"
             >

--- a/src/components/shared/WikiCallout.tsx
+++ b/src/components/shared/WikiCallout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import { colors, radius } from "@/lib/design-system";
 
 /**
  * WIKI CALLOUT — Gold-accented callout box
@@ -16,26 +15,16 @@ interface WikiCalloutProps {
 }
 
 const WikiCallout = ({ label, children, icon }: WikiCalloutProps) => (
-  <div
-    className="p-4"
-    style={{
-      background: colors.goldSubtle,
-      borderRadius: radius.md,
-      border: `1px solid ${colors.goldMuted}`,
-    }}
-  >
+  <div className="p-4 bg-gold-subtle rounded-[--radius-md] border border-gold-muted">
     <div className="flex gap-3">
       {icon && (
         <div className="flex-shrink-0 mt-0.5">{icon}</div>
       )}
       <div className="flex-1 min-w-0">
-        <p
-          className="text-xs font-semibold uppercase tracking-wide mb-2"
-          style={{ color: colors.gold }}
-        >
+        <p className="text-xs font-semibold uppercase tracking-wide mb-2 text-gold">
           {label}
         </p>
-        <div className="text-sm leading-relaxed" style={{ color: colors.textPrimary }}>
+        <div className="text-sm leading-relaxed text-text-primary">
           {children}
         </div>
       </div>

--- a/src/components/shared/WikiCard.tsx
+++ b/src/components/shared/WikiCard.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from "react";
-import { colors, radius } from "@/lib/design-system";
+import { cn } from "@/lib/utils";
 
 /**
  * WIKI CARD — Single source of truth for content containers
  *
- * The matte card with subtle gold border used across ALL pages.
+ * The matte card with subtle border used across ALL pages.
  * Always pair with WikiSectionHeader for the header.
  */
 
@@ -15,12 +15,10 @@ interface WikiCardProps {
 
 const WikiCard = ({ children, className }: WikiCardProps) => (
   <div
-    className={`overflow-hidden animate-fade-in ${className || ""}`}
-    style={{
-      background: colors.card,
-      border: `1px solid ${colors.borderSubtle}`,
-      borderRadius: radius.lg,
-    }}
+    className={cn(
+      "overflow-hidden animate-fade-in bg-bg-card border border-border-subtle rounded-[--radius-lg]",
+      className
+    )}
   >
     {children}
   </div>

--- a/src/components/shared/WikiSectionHeader.tsx
+++ b/src/components/shared/WikiSectionHeader.tsx
@@ -1,29 +1,12 @@
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { colors, radius } from "@/lib/design-system";
 
 /**
  * WIKI SECTION HEADER — Single source of truth
  *
  * The gold-accented section header used across ALL pages.
  * Features: Radiant gold left bar, gradient background, section number + title.
- *
- * This replaces the 5 separate SectionHeader implementations that existed
- * in IntroView, BudgetInfo, CapitalInfo, FeesInfo, and WaterfallInfo.
  */
-
-const tokens = {
-  gold: colors.gold,
-  goldMuted: colors.goldMuted,
-  goldGlow: colors.goldGlow,
-  goldFill: colors.goldSubtle,
-  goldRadiant: colors.goldGlow,
-  bgHeader: colors.elevated,
-  borderMatte: colors.borderSubtle,
-  borderSubtle: colors.borderSubtle,
-  textPrimary: colors.textPrimary,
-  textDim: colors.textDim,
-};
 
 interface WikiSectionHeaderProps {
   number: string;
@@ -42,47 +25,28 @@ const WikiSectionHeader = ({
 }: WikiSectionHeaderProps) => (
   <div
     className={cn(
-      "flex items-stretch",
+      "flex items-stretch bg-gradient-to-r from-gold-glow via-bg-elevated to-bg-elevated",
+      isExpanded !== false && "border-b border-border-subtle",
       isClickable && "cursor-pointer hover:bg-gold-subtle transition-colors"
     )}
-    style={{
-      background: `linear-gradient(90deg, ${tokens.goldRadiant} 0%, ${tokens.bgHeader} 15%, ${tokens.bgHeader} 100%)`,
-      borderBottom: isExpanded !== false ? `1px solid ${tokens.borderMatte}` : "none",
-    }}
     onClick={onClick}
   >
     {/* Gold Left Bar — THE signature element */}
     <div
-      className="w-1 flex-shrink-0"
-      style={{
-        background: `linear-gradient(180deg, ${tokens.gold} 0%, ${tokens.goldMuted} 100%)`,
-        boxShadow: `0 0 12px ${tokens.goldGlow}`,
-      }}
+      className="w-1 flex-shrink-0 bg-gradient-to-b from-gold to-gold-muted"
+      style={{ boxShadow: '0 0 12px var(--gold-glow)' }}
     />
 
     {/* Section Number */}
-    <div
-      className="flex items-center justify-center px-4 py-4"
-      style={{
-        borderRight: `1px solid ${tokens.borderSubtle}`,
-        minWidth: "56px",
-        background: tokens.goldFill,
-      }}
-    >
-      <span
-        className="font-bebas text-xl tracking-wide"
-        style={{ color: tokens.gold }}
-      >
+    <div className="flex items-center justify-center px-4 py-4 border-r border-border-subtle min-w-[56px] bg-gold-subtle">
+      <span className="font-bebas text-xl tracking-wide text-gold">
         {number}
       </span>
     </div>
 
     {/* Title + Chevron */}
     <div className="flex items-center flex-1 px-4 py-4 justify-between">
-      <h2
-        className="font-bold text-xs uppercase tracking-widest"
-        style={{ color: tokens.textPrimary }}
-      >
+      <h2 className="font-bold text-xs uppercase tracking-widest text-text-primary">
         {title}
       </h2>
 
@@ -90,9 +54,8 @@ const WikiSectionHeader = ({
         <ChevronDown
           className={cn(
             "w-4 h-4 flex-shrink-0 transition-transform duration-200",
-            isExpanded && "rotate-180"
+            isExpanded ? "rotate-180 text-gold" : "text-text-dim"
           )}
-          style={{ color: isExpanded ? tokens.gold : tokens.textDim }}
         />
       )}
     </div>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -150,7 +150,7 @@ const Auth = () => {
                           document.getElementById('email')?.focus();
                         }
                       }}
-                      className="h-12 bg-bg-surface border border-border-subtle text-text-primary placeholder:text-text-dim focus:border-gold focus:ring-0 focus:ring-offset-0 transition-colors rounded-none"
+                      className="h-12 bg-bg-surface border border-border-subtle text-text-primary placeholder:text-text-dim focus:border-gold focus:ring-0 focus:ring-offset-0 transition-colors rounded-[--radius-md]"
                       required
                     />
                   </div>
@@ -181,7 +181,7 @@ const Auth = () => {
                           handleSubmit(e as any);
                         }
                       }}
-                      className="h-12 bg-bg-surface border border-border-subtle text-text-primary placeholder:text-text-dim font-mono focus:border-gold focus:ring-0 focus:ring-offset-0 transition-colors rounded-none"
+                      className="h-12 bg-bg-surface border border-border-subtle text-text-primary placeholder:text-text-dim font-mono focus:border-gold focus:ring-0 focus:ring-offset-0 transition-colors rounded-[--radius-md]"
                       required
                     />
                   </div>
@@ -190,7 +190,7 @@ const Auth = () => {
                   <Button
                     type="submit"
                     disabled={loading || !email || !name.trim()}
-                    className="w-full h-14 rounded-none font-black text-base tracking-[0.12em] bg-gold-cta text-black hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
+                    className="w-full min-h-[52px] rounded-[--radius-md] font-black text-xs uppercase tracking-[1.5px] bg-gold-cta text-black hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
                   >
                     {loading ? (
                       <Loader2 className="w-5 h-5 animate-spin" />

--- a/src/pages/BudgetInfo.tsx
+++ b/src/pages/BudgetInfo.tsx
@@ -9,27 +9,7 @@ import Header from "@/components/Header";
    WIKI CONTAINMENT: This mini wiki can ONLY link back to /intro
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
-// Sourced from design-system.ts (aligned to index.css)
-import { colors, radius } from "@/lib/design-system";
 import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
-
-const tokens = {
-  bgVoid: colors.void,
-  bgMatte: colors.card,
-  bgHeader: colors.elevated,
-  bgSurface: colors.surface,
-  gold: colors.gold,
-  goldMuted: colors.goldMuted,
-  goldSubtle: colors.goldSubtle,
-  goldGlow: colors.goldGlow,
-  borderMatte: colors.borderSubtle,
-  borderSubtle: colors.borderSubtle,
-  textPrimary: colors.textPrimary,
-  textMid: colors.textMid,
-  textDim: colors.textDim,
-  radiusMd: radius.md,
-  radiusLg: radius.lg,
-};
 
 /* ═══════════════════════════════════════════════════════════════════════════
    GOLD INTENSITY TIERS — Budget tier accent colors
@@ -53,12 +33,8 @@ interface BudgetTierCardProps {
 
 const BudgetTierCard = ({ tier, range, description, accentColor }: BudgetTierCardProps) => (
   <div
-    className="p-4 flex-1"
-    style={{
-      background: tokens.bgSurface,
-      borderRadius: tokens.radiusMd,
-      borderTop: `3px solid ${accentColor}`,
-    }}
+    className="p-4 flex-1 bg-bg-surface rounded-[--radius-md]"
+    style={{ borderTop: `3px solid ${accentColor}` }}
   >
     <span
       className="font-bebas text-xs tracking-wide uppercase"
@@ -66,13 +42,10 @@ const BudgetTierCard = ({ tier, range, description, accentColor }: BudgetTierCar
     >
       {tier}
     </span>
-    <p
-      className="text-lg font-bold text-white mt-1 mb-2"
-      style={{ fontFamily: 'Roboto Mono, monospace' }}
-    >
+    <p className="text-lg font-bold text-white mt-1 mb-2 font-mono">
       {range}
     </p>
-    <p className="text-xs leading-relaxed" style={{ color: tokens.textDim }}>
+    <p className="text-xs leading-relaxed text-text-dim">
       {description}
     </p>
   </div>
@@ -88,27 +61,14 @@ interface BudgetComponentProps {
 }
 
 const BudgetComponent = ({ category, percentage, items }: BudgetComponentProps) => (
-  <div
-    className="p-4"
-    style={{
-      background: tokens.bgSurface,
-      borderRadius: tokens.radiusMd,
-      borderLeft: `2px solid ${tokens.goldMuted}`,
-    }}
-  >
+  <div className="p-4 bg-bg-surface rounded-[--radius-md] border-l-2 border-gold-muted">
     <div className="flex items-center justify-between mb-2">
       <span className="text-sm font-semibold text-white">{category}</span>
-      <span
-        className="text-xs font-mono px-2 py-1 rounded"
-        style={{
-          background: tokens.goldSubtle,
-          color: tokens.gold,
-        }}
-      >
+      <span className="text-xs font-mono px-2 py-1 rounded bg-gold-subtle text-gold">
         {percentage}
       </span>
     </div>
-    <p className="text-xs leading-relaxed" style={{ color: tokens.textDim }}>
+    <p className="text-xs leading-relaxed text-text-dim">
       {items.join(' · ')}
     </p>
   </div>
@@ -123,21 +83,11 @@ interface MistakeCardProps {
 }
 
 const MistakeCard = ({ title, description }: MistakeCardProps) => (
-  <div
-    className="p-4 flex gap-3"
-    style={{
-      background: tokens.goldSubtle,
-      borderRadius: tokens.radiusMd,
-      border: `1px solid ${tokens.goldMuted}`,
-    }}
-  >
-    <AlertTriangle
-      className="w-5 h-5 flex-shrink-0 mt-0.5"
-      style={{ color: tokens.gold }}
-    />
+  <div className="p-4 flex gap-3 bg-gold-subtle rounded-[--radius-md] border border-gold-muted">
+    <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5 text-gold" />
     <div>
       <p className="text-sm font-semibold text-white mb-1">{title}</p>
-      <p className="text-xs leading-relaxed" style={{ color: tokens.textDim }}>
+      <p className="text-xs leading-relaxed text-text-dim">
         {description}
       </p>
     </div>
@@ -148,7 +98,7 @@ const BudgetInfo = () => {
   const navigate = useNavigate();
 
   const handleBackToOverview = () => {
-    navigate('/intro');
+    navigate(-1);
     window.scrollTo(0, 0);
   };
 
@@ -161,10 +111,7 @@ const BudgetInfo = () => {
     <>
       <Header />
 
-      <div
-        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
-        style={{ background: tokens.bgVoid }}
-      >
+      <div className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans bg-bg-void">
         <div className="max-w-2xl mx-auto space-y-6">
 
           {/* ═══════════════════════════════════════════════════════════════
@@ -174,23 +121,17 @@ const BudgetInfo = () => {
             {/* Back to Overview — ONLY navigation link allowed */}
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors mb-4"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors mb-4 text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
 
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
-              Production <span style={{ color: tokens.gold }}>Budget</span>
+              Production <span className="text-gold">Budget</span>
             </h1>
 
-            <p
-              className="text-base leading-relaxed max-w-lg"
-              style={{ color: tokens.textMid }}
-            >
+            <p className="text-base leading-relaxed max-w-lg text-text-mid">
               Your budget isn't just a number—it's the foundation of your entire deal structure.
               Everything flows from here: capital requirements, investor returns, and your ultimate profit position.
             </p>
@@ -199,7 +140,7 @@ const BudgetInfo = () => {
             <div
               className="h-px w-full"
               style={{
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
+                background: 'linear-gradient(90deg, var(--gold), var(--gold-muted) 40%, transparent 80%)'
               }}
             />
           </div>
@@ -211,10 +152,7 @@ const BudgetInfo = () => {
             <WikiSectionHeader number="01" title="Budget Range Benchmarks" />
 
             <div className="p-5 space-y-5">
-              <p
-                className="text-sm leading-relaxed"
-                style={{ color: tokens.textMid }}
-              >
+              <p className="text-sm leading-relaxed text-text-mid">
                 Independent films operate across a wide spectrum. Where you land determines
                 your financing options, crew expectations, and realistic sales projections.
               </p>
@@ -257,7 +195,7 @@ const BudgetInfo = () => {
             <WikiSectionHeader number="02" title="Budget Composition" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 A professional budget breaks into predictable categories. Understanding these
                 helps you identify where costs can flex—and where they can't.
               </p>
@@ -288,7 +226,7 @@ const BudgetInfo = () => {
                 />
               </div>
 
-              <p className="text-xs leading-relaxed pt-2" style={{ color: tokens.textDim }}>
+              <p className="text-xs leading-relaxed pt-2 text-text-dim">
                 These percentages shift based on genre and approach. VFX-heavy films push post
                 to 25%+. Star-driven projects can see ATL exceed 40%.
               </p>
@@ -327,17 +265,14 @@ const BudgetInfo = () => {
             <div
               className="h-px w-full"
               style={{
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
+                background: 'linear-gradient(90deg, transparent 10%, var(--gold-muted) 50%, transparent 90%)'
               }}
             />
 
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
@@ -346,10 +281,7 @@ const BudgetInfo = () => {
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}
-              className="text-xs transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="text-xs transition-colors text-text-dim hover:text-gold"
             >
               Ready to run the numbers? Start Simulation →
             </button>

--- a/src/pages/CapitalInfo.tsx
+++ b/src/pages/CapitalInfo.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import Header from "@/components/Header";
-import { colors, radius } from "@/lib/design-system";
 import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -11,26 +10,12 @@ import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
    WIKI CONTAINMENT: This mini wiki can ONLY link back to /intro
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
-// Sourced from design-system.ts (aligned to index.css)
-const tokens = {
-  bgVoid: colors.void,
-  bgSurface: colors.surface,
-  gold: colors.gold,
-  goldMuted: colors.goldMuted,
-  goldSubtle: colors.goldSubtle,
-  borderSubtle: colors.borderSubtle,
-  textPrimary: colors.textPrimary,
-  textMid: colors.textMid,
-  textDim: colors.textDim,
-  radiusMd: radius.md,
-  radiusLg: radius.lg,
-};
 
 const CapitalInfo = () => {
   const navigate = useNavigate();
 
   const handleBackToOverview = () => {
-    navigate('/intro');
+    navigate(-1);
     window.scrollTo(0, 0);
   };
 
@@ -43,42 +28,28 @@ const CapitalInfo = () => {
     <>
       <Header />
 
-      <div
-        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
-        style={{ background: tokens.bgVoid }}
-      >
+      <div className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans bg-bg-void">
         <div className="max-w-2xl mx-auto space-y-6">
 
           {/* PAGE HEADER */}
           <div className="space-y-4 pt-6 animate-fade-in">
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors mb-4"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors mb-4 text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
 
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
-              Capital <span style={{ color: tokens.gold }}>Stack</span>
+              Capital <span className="text-gold">Stack</span>
             </h1>
 
-            <p
-              className="text-base leading-relaxed max-w-lg"
-              style={{ color: tokens.textMid }}
-            >
+            <p className="text-base leading-relaxed max-w-lg text-text-mid">
               Understanding how independent films are financed—and who gets paid back first.
             </p>
 
-            <div
-              className="h-px w-full"
-              style={{
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
-              }}
-            />
+            <div className="h-px w-full bg-gradient-to-r from-gold via-gold-muted/40 to-transparent" />
           </div>
 
           {/* SECTION: WHAT IS A CAPITAL STACK */}
@@ -86,14 +57,14 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="01" title="What Is a Capital Stack?" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>capital stack</strong> is
+              <p className="text-sm leading-relaxed text-text-mid">
+                The <strong className="text-white">capital stack</strong> is
                 the combination of all funding sources used to finance your production. Like
                 layers in a building, each capital source sits in a specific position—and that
                 position determines when (and if) each investor gets repaid.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Most independent films can't be funded by a single source. Instead, producers
                 piece together a stack from multiple sources: equity investors, senior lenders,
                 gap financiers, tax incentives, and sometimes pre-sales or minimum guarantees.
@@ -107,31 +78,31 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="02" title="Equity Investors" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Equity</strong> is risk capital.
+              <p className="text-sm leading-relaxed text-text-mid">
+                <strong className="text-white">Equity</strong> is risk capital.
                 Equity investors give you money in exchange for ownership—a percentage of the
                 profits if the film succeeds. They don't get interest payments or guaranteed
                 returns. If the film loses money, equity investors lose their investment.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Because equity is the riskiest capital, equity investors typically demand:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Priority recoupment</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Priority recoupment</strong> —
                   they want their principal back before anyone else (except senior debt)</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Premium</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Premium</strong> —
                   a percentage on top of their investment (typically 10-25%) before profits split</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Backend participation</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Backend participation</strong> —
                   a share of profits after recoupment (often 50%)</span>
                 </li>
               </ul>
@@ -143,31 +114,31 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="03" title="Senior Debt" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Senior debt</strong> is the
+              <p className="text-sm leading-relaxed text-text-mid">
+                <strong className="text-white">Senior debt</strong> is the
                 safest position in the stack. Senior lenders get repaid first, before anyone
                 else sees a dollar. Because of this priority position, senior debt charges
                 lower rates than equity demands—but it must be repaid regardless of the film's success.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Common sources of senior debt include:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Bank loans</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Bank loans</strong> —
                   secured against pre-sales, tax credits, or minimum guarantees</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Tax credit advances</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Tax credit advances</strong> —
                   lenders who front cash against confirmed incentive rebates</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Minimum guarantee loans</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Minimum guarantee loans</strong> —
                   discounted advances against contracted distribution deals</span>
                 </li>
               </ul>
@@ -185,19 +156,19 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="04" title="Gap Financing" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                <strong style={{ color: tokens.textPrimary }}>Gap financing</strong> fills the
+              <p className="text-sm leading-relaxed text-text-mid">
+                <strong className="text-white">Gap financing</strong> fills the
                 space between your secured capital (pre-sales, tax credits) and your total budget.
                 It's called "gap" because it bridges the gap—typically 15-25% of budget.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Gap lenders take real risk. They're betting that your unsold territories will
                 eventually sell for enough to cover their loan. Because of this risk, gap financing
                 is more expensive than senior debt—expect interest rates of 12-18% plus fees.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Gap typically sits after senior debt but before equity in the recoupment waterfall.
                 Some deals subordinate gap to equity recoupment—the terms vary significantly by lender
                 and by the strength of your sales estimates.
@@ -210,45 +181,34 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="05" title="How It All Fits Together" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 A typical indie capital stack might look like this:
               </p>
 
-              <div
-                className="p-4 font-mono text-xs space-y-1"
-                style={{
-                  background: tokens.bgSurface,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.borderSubtle}`,
-                  color: tokens.textMid,
-                }}
-              >
+              <div className="p-4 font-mono text-xs space-y-1 bg-bg-surface rounded-[--radius-md] border border-border-subtle text-text-mid">
                 <div className="flex justify-between">
                   <span>Tax Credit Advance (Senior)</span>
-                  <span style={{ color: tokens.textPrimary }}>25%</span>
+                  <span className="text-white">25%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Pre-sale Loan (Senior)</span>
-                  <span style={{ color: tokens.textPrimary }}>15%</span>
+                  <span className="text-white">15%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Gap Financing</span>
-                  <span style={{ color: tokens.textPrimary }}>20%</span>
+                  <span className="text-white">20%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Equity Investment</span>
-                  <span style={{ color: tokens.textPrimary }}>40%</span>
+                  <span className="text-white">40%</span>
                 </div>
-                <div
-                  className="pt-2 mt-2 flex justify-between font-semibold"
-                  style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
-                >
-                  <span style={{ color: tokens.gold }}>Total</span>
-                  <span style={{ color: tokens.gold }}>100%</span>
+                <div className="pt-2 mt-2 flex justify-between font-semibold border-t border-border-subtle">
+                  <span className="text-gold">Total</span>
+                  <span className="text-gold">100%</span>
                 </div>
               </div>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 When revenues come in, they flow through the waterfall in order: distribution
                 fees first, then senior debt gets repaid, then gap, then equity recovers their
                 investment plus premium, and finally—if there's anything left—profits split
@@ -262,29 +222,29 @@ const CapitalInfo = () => {
             <WikiSectionHeader number="06" title="What This Means For You" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 As a producer, understanding the capital stack is essential because:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
+                  <span className="text-gold">•</span>
                   <span>It determines how your waterfall is structured—you can't negotiate
                   recoupment positions without understanding who's providing what</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
+                  <span className="text-gold">•</span>
                   <span>Each capital source has different cost implications—interest,
                   premiums, and backend participation all reduce what's available for profit</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
+                  <span className="text-gold">•</span>
                   <span>Your personal backend (producer profit) only starts after everyone
                   else is satisfied—knowing the math helps you set realistic expectations</span>
                 </li>
               </ul>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 The simulation in this tool lets you model different capital structures and see
                 exactly how each scenario affects your waterfall. Small changes in the stack can
                 have significant impacts on who actually gets paid.
@@ -294,20 +254,12 @@ const CapitalInfo = () => {
 
           {/* FOOTER — Back to Overview + subtle Start Simulation link */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">
-            <div
-              className="h-px w-full"
-              style={{
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
-              }}
-            />
+            <div className="h-px w-full bg-gradient-to-r from-transparent via-gold-muted to-transparent" />
 
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
@@ -316,10 +268,7 @@ const CapitalInfo = () => {
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}
-              className="text-xs transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="text-xs transition-colors text-text-dim hover:text-gold"
             >
               Ready to run the numbers? Start Simulation →
             </button>

--- a/src/pages/FeesInfo.tsx
+++ b/src/pages/FeesInfo.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import Header from "@/components/Header";
-import { colors, radius } from "@/lib/design-system";
 import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -12,25 +11,11 @@ import { WikiSectionHeader, WikiCard, WikiCallout } from "@/components/shared";
    Secondary exit: Subtle "Start Simulation" text link at bottom
    ═══════════════════════════════════════════════════════════════════════════ */
 
-const tokens = {
-  bgVoid: colors.void,
-  bgSurface: colors.surface,
-  gold: colors.gold,
-  goldMuted: colors.goldMuted,
-  goldSubtle: colors.goldSubtle,
-  borderSubtle: colors.borderSubtle,
-  textPrimary: colors.textPrimary,
-  textMid: colors.textMid,
-  textDim: colors.textDim,
-  radiusMd: radius.md,
-  radiusLg: radius.lg,
-};
-
 const FeesInfo = () => {
   const navigate = useNavigate();
 
   const handleBackToOverview = () => {
-    navigate('/intro');
+    navigate(-1);
     window.scrollTo(0, 0);
   };
 
@@ -44,8 +29,7 @@ const FeesInfo = () => {
       <Header />
 
       <div
-        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans"
-        style={{ background: tokens.bgVoid }}
+        className="min-h-screen text-white pt-16 pb-12 px-4 md:px-8 font-sans bg-bg-void"
       >
         <div className="max-w-2xl mx-auto space-y-6">
 
@@ -53,31 +37,24 @@ const FeesInfo = () => {
           <div className="space-y-4 pt-6 animate-fade-in">
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors mb-4"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors mb-4 text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
             </button>
 
             <h1 className="text-4xl md:text-5xl font-bebas tracking-wide leading-tight">
-              Distribution <span style={{ color: tokens.gold }}>Fees</span>
+              Distribution <span className="text-gold">Fees</span>
             </h1>
 
             <p
-              className="text-base leading-relaxed max-w-lg"
-              style={{ color: tokens.textMid }}
+              className="text-base leading-relaxed max-w-lg text-text-mid"
             >
               The money that comes off the top before your waterfall even begins.
             </p>
 
             <div
-              className="h-px w-full"
-              style={{
-                background: `linear-gradient(90deg, ${tokens.gold}, ${tokens.goldMuted} 40%, transparent 80%)`
-              }}
+              className="h-px w-full bg-gradient-to-r from-gold via-gold-muted/40 to-transparent"
             />
           </div>
 
@@ -86,14 +63,14 @@ const FeesInfo = () => {
             <WikiSectionHeader number="01" title="Why Fees Matter" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 When a streamer or buyer acquires your film for $2 million, that $2 million
-                doesn't flow directly into your waterfall. <strong style={{ color: tokens.textPrimary }}>
+                doesn't flow directly into your waterfall. <strong className="text-white">
                 Distribution fees come off the top first</strong>—before senior debt, before
                 equity recoupment, before anyone in your Operating Agreement sees a cent.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 These fees aren't optional. They're contractual obligations to the entities
                 who sold, delivered, and collected on your film. Understanding them is
                 critical because they directly reduce what's available for your waterfall.
@@ -111,39 +88,39 @@ const FeesInfo = () => {
             <WikiSectionHeader number="02" title="Sales Agent Fee" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>sales agent</strong> represents
+              <p className="text-sm leading-relaxed text-text-mid">
+                The <strong className="text-white">sales agent</strong> represents
                 your film to international buyers and domestic distributors. They attend markets
                 (Cannes, AFM, Berlin), pitch to acquisitions executives, negotiate deals, and
                 sometimes advance marketing costs.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Sales agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
+              <p className="text-sm leading-relaxed text-text-mid">
+                Sales agent fees typically range from <strong className="text-white">
                 10-20%</strong> of gross revenues, depending on:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Territory</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Territory</strong> —
                   domestic sales often command lower percentages than international</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Budget level</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Budget level</strong> —
                   larger films may negotiate better rates</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Cast/director</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Cast/director</strong> —
                   star-driven packages may warrant lower fees</span>
                 </li>
               </ul>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Some sales agents also charge <strong style={{ color: tokens.textPrimary }}>
-                market fees</strong> for attending festivals and markets, plus <strong style={{ color: tokens.textPrimary }}>
+              <p className="text-sm leading-relaxed text-text-mid">
+                Some sales agents also charge <strong className="text-white">
+                market fees</strong> for attending festivals and markets, plus <strong className="text-white">
                 recoupable expenses</strong> for marketing materials, screeners, and travel.
               </p>
             </div>
@@ -154,36 +131,36 @@ const FeesInfo = () => {
             <WikiSectionHeader number="03" title="Collection Agent Fee" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                The <strong style={{ color: tokens.textPrimary }}>collection agent</strong> (also
+              <p className="text-sm leading-relaxed text-text-mid">
+                The <strong className="text-white">collection agent</strong> (also
                 called a collection account manager or CAM) is a neutral third party who receives
                 all revenues, applies the waterfall, and distributes payments to the correct parties.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                Collection agent fees typically range from <strong style={{ color: tokens.textPrimary }}>
+              <p className="text-sm leading-relaxed text-text-mid">
+                Collection agent fees typically range from <strong className="text-white">
                 1-5%</strong> of gross revenues. Common CAMs include Fintage House, Freeway, and
                 Film Finances. While the percentage seems small, it comes off before anything else.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Why use a collection agent? They provide:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Investor confidence</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Investor confidence</strong> —
                   a neutral party ensures the waterfall is followed correctly</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Audit trail</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Audit trail</strong> —
                   detailed accounting for every dollar that flows through</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Lender requirement</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Lender requirement</strong> —
                   most senior lenders require a CAM before funding</span>
                 </li>
               </ul>
@@ -195,21 +172,21 @@ const FeesInfo = () => {
             <WikiSectionHeader number="04" title="Delivery Costs" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 When a buyer acquires your film, they don't just want the movie—they want a
-                complete <strong style={{ color: tokens.textPrimary }}>delivery package</strong>.
+                complete <strong className="text-white">delivery package</strong>.
                 This includes specific technical masters, audio mixes, subtitles, closed captions,
                 artwork, and legal documentation.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Delivery costs vary significantly but can range from $25,000 to $150,000+ depending
                 on the buyer's requirements. Streamers like Netflix have particularly detailed
                 technical specifications.
               </p>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                In most deals, delivery costs are <strong style={{ color: tokens.textPrimary }}>
+              <p className="text-sm leading-relaxed text-text-mid">
+                In most deals, delivery costs are <strong className="text-white">
                 recoupable</strong>—meaning they come off the top of your revenues, just like
                 distribution fees. Make sure your budget includes a realistic delivery allowance.
               </p>
@@ -221,50 +198,43 @@ const FeesInfo = () => {
             <WikiSectionHeader number="05" title="The Real Math" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Here's what happens to a $2,000,000 acquisition before it reaches your waterfall:
               </p>
 
               <div
-                className="p-4 font-mono text-xs space-y-1"
-                style={{
-                  background: tokens.bgSurface,
-                  borderRadius: tokens.radiusMd,
-                  border: `1px solid ${tokens.borderSubtle}`,
-                  color: tokens.textMid,
-                }}
+                className="p-4 font-mono text-xs space-y-1 bg-bg-surface rounded-[--radius-md] border border-border-subtle text-text-mid"
               >
                 <div className="flex justify-between">
                   <span>Gross Acquisition</span>
-                  <span style={{ color: tokens.textPrimary }}>$2,000,000</span>
+                  <span className="text-white">$2,000,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Sales Agent (15%)</span>
-                  <span style={{ color: tokens.goldMuted }}>− $300,000</span>
+                  <span className="text-gold-muted">− $300,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Collection Agent (3%)</span>
-                  <span style={{ color: tokens.goldMuted }}>− $60,000</span>
+                  <span className="text-gold-muted">− $60,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Market Expenses</span>
-                  <span style={{ color: tokens.goldMuted }}>− $40,000</span>
+                  <span className="text-gold-muted">− $40,000</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Delivery Costs</span>
-                  <span style={{ color: tokens.goldMuted }}>− $75,000</span>
+                  <span className="text-gold-muted">− $75,000</span>
                 </div>
                 <div
-                  className="pt-2 mt-2 flex justify-between font-semibold"
-                  style={{ borderTop: `1px solid ${tokens.borderSubtle}` }}
+                  className="pt-2 mt-2 flex justify-between font-semibold border-t border-border-subtle"
                 >
-                  <span style={{ color: tokens.gold }}>Net to Waterfall</span>
-                  <span style={{ color: tokens.gold }}>$1,525,000</span>
+                  <span className="text-gold">Net to Waterfall</span>
+                  <span className="text-gold">$1,525,000</span>
                 </div>
               </div>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
-                That's nearly <strong style={{ color: tokens.textPrimary }}>24% gone</strong> before
+              <p className="text-sm leading-relaxed text-text-mid">
+                That's nearly <strong className="text-white">24% gone</strong> before
                 your senior debt, equity investors, or profit participants see anything. And this
                 is just one territory—international sales may have additional layers of fees.
               </p>
@@ -276,35 +246,35 @@ const FeesInfo = () => {
             <WikiSectionHeader number="06" title="Negotiating Fees" />
 
             <div className="p-5 space-y-4">
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 While fees are standard in the industry, they're not set in stone. Producers
                 with leverage (strong packages, track records, or competing offers) can negotiate:
               </p>
 
-              <ul className="text-sm space-y-2 pl-4" style={{ color: tokens.textMid }}>
+              <ul className="text-sm space-y-2 pl-4 text-text-mid">
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Caps on recoupable expenses</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Caps on recoupable expenses</strong> —
                   limit how much a sales agent can charge back</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Sliding scale percentages</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Sliding scale percentages</strong> —
                   lower rates as revenues increase</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Sunset clauses</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Sunset clauses</strong> —
                   fees that reduce or expire after a certain period</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span style={{ color: tokens.gold }}>•</span>
-                  <span><strong style={{ color: tokens.textPrimary }}>Territory carve-outs</strong> —
+                  <span className="text-gold">•</span>
+                  <span><strong className="text-white">Territory carve-outs</strong> —
                   excluding territories where you have direct relationships</span>
                 </li>
               </ul>
 
-              <p className="text-sm leading-relaxed" style={{ color: tokens.textMid }}>
+              <p className="text-sm leading-relaxed text-text-mid">
                 Always have an entertainment attorney review your sales representation and
                 collection agreements before signing. Small percentage differences can translate
                 to significant dollar amounts.
@@ -315,19 +285,13 @@ const FeesInfo = () => {
           {/* FOOTER — Back to Overview + subtle Start Simulation link */}
           <div className="pt-6 flex flex-col items-center gap-4 animate-fade-in">
             <div
-              className="h-px w-full"
-              style={{
-                background: `linear-gradient(90deg, transparent 10%, ${tokens.goldMuted} 50%, transparent 90%)`
-              }}
+              className="h-px w-full bg-gradient-to-r from-transparent via-gold-muted to-transparent"
             />
 
             {/* Primary: Back to Overview */}
             <button
               onClick={handleBackToOverview}
-              className="flex items-center gap-2 text-sm transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="flex items-center gap-2 text-sm transition-colors text-text-dim hover:text-gold"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Back to Overview</span>
@@ -336,10 +300,7 @@ const FeesInfo = () => {
             {/* Secondary: Subtle exit to calculator */}
             <button
               onClick={handleStartSimulation}
-              className="text-xs transition-colors"
-              style={{ color: tokens.textDim }}
-              onMouseEnter={(e) => e.currentTarget.style.color = tokens.gold}
-              onMouseLeave={(e) => e.currentTarget.style.color = tokens.textDim}
+              className="text-xs transition-colors text-text-dim hover:text-gold"
             >
               Ready to run the numbers? Start Simulation →
             </button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -35,7 +35,7 @@ const Index = () => {
 
   const handleStartClick = () => {
     haptics.medium();
-    navigate("/intro");
+    navigate("/calculator");
   };
 
   const isComplete = phase === 'complete';

--- a/src/pages/IntroView.tsx
+++ b/src/pages/IntroView.tsx
@@ -91,11 +91,11 @@ const IntroView = () => {
             </div>
           </div>
 
-          {/* Callout / Note */}
-          <div className="bg-blue-900/10 border-l-4 border-blue-500/50 p-4 rounded-r-md flex items-start space-x-3">
-            <Info className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" />
-            <div className="text-sm text-blue-200/80">
-              <span className="font-bold text-blue-200">Pro Tip:</span> Don't worry if you see terms you don't recognize. You can access the <span className="text-white font-semibold">Glossary</span> at any time via the menu in the top right corner.
+          {/* Callout / Note — Gold-only */}
+          <div className="bg-gold/[0.04] border-l-4 border-gold/50 p-4 rounded-r-md flex items-start space-x-3">
+            <Info className="w-5 h-5 text-gold mt-0.5 flex-shrink-0" />
+            <div className="text-sm text-text-mid">
+              <span className="font-bold text-gold">Pro Tip:</span> Don't worry if you see terms you don't recognize. You can access the <span className="text-white font-semibold">Glossary</span> at any time via the menu in the top right corner.
             </div>
           </div>
 

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -333,15 +333,15 @@ const Store = () => {
               PAYMENT SUCCESSFUL
             </h1>
             <p className="text-muted-foreground mb-8 leading-relaxed">
-              Your purchase has been confirmed. You now have access to export
-              your professional reports.
+              Your purchase has been confirmed. Your professional export is
+              now available from the Waterfall tab.
             </p>
             <Button
-              onClick={() => navigate("/calculator")}
+              onClick={() => navigate("/calculator?tab=waterfall")}
               className="btn-vault w-full py-4 min-h-[52px]"
             >
               <Download className="w-5 h-5 mr-2" />
-              GO TO CALCULATOR
+              VIEW YOUR WATERFALL
             </Button>
           </div>
         </main>

--- a/src/pages/WaterfallInfo.tsx
+++ b/src/pages/WaterfallInfo.tsx
@@ -113,7 +113,7 @@ const WaterfallInfo = () => {
                   <h3 className="text-white font-bold mb-1">Sales Fees & Expenses</h3>
                   <p className="text-sm text-text-dim">
                     The Sales Agent takes their commission (10-25%) and recoups capped expenses (marketing, festivals, deliverables).
-                    <span className="block mt-1 text-red-400/80 text-xs font-medium">⚠️ TRAP: Ensure expenses are "Capped" in your contract.</span>
+                    <span className="block mt-1 text-gold text-xs font-semibold">TRAP: Ensure expenses are "Capped" in your contract.</span>
                   </p>
                 </div>
 
@@ -198,25 +198,25 @@ const WaterfallInfo = () => {
             </div>
           </div>
 
-          {/* DANGER ZONE - The Traps */}
-          <div className="bg-red-950/10 border border-red-900/30 rounded-lg p-6 space-y-4">
+          {/* COMMON TRAPS — Gold-only warning styling */}
+          <div className="bg-gold/[0.04] border border-gold/20 rounded-lg p-6 space-y-4">
             <div className="flex items-center gap-2 mb-2">
-              <ShieldAlert className="w-5 h-5 text-red-500" />
-              <h2 className="text-lg font-bold text-red-400 uppercase tracking-widest">Common Traps</h2>
+              <ShieldAlert className="w-5 h-5 text-gold" />
+              <h2 className="text-lg font-bold text-gold uppercase tracking-widest">Common Traps</h2>
             </div>
-            
+
             <div className="grid md:grid-cols-2 gap-6">
               <div>
                 <h3 className="text-white font-bold text-sm mb-1">Cross-Collateralization</h3>
                 <p className="text-xs text-text-dim leading-relaxed">
-                  When a distributor uses the profits from your film to pay for the losses of *another* film they bought. 
-                  <span className="block mt-1 text-red-400">Never allow this. Require "Single Picture Accounting".</span>
+                  When a distributor uses the profits from your film to pay for the losses of *another* film they bought.
+                  <span className="block mt-1 text-gold font-semibold">Never allow this. Require "Single Picture Accounting".</span>
                 </p>
               </div>
               <div>
                 <h3 className="text-white font-bold text-sm mb-1">Overhead Fees</h3>
                 <p className="text-xs text-text-dim leading-relaxed">
-                  Distributors often charge a flat "Overhead" fee (10-15%) on top of their commission for "office expenses." 
+                  Distributors often charge a flat "Overhead" fee (10-15%) on top of their commission for "office expenses."
                   This is pure profit for them. Fight to cap or remove it.
                 </p>
               </div>


### PR DESCRIPTION
…ld-only Tailwind

Flow fixes:
- Homepage CTA goes directly to /calculator (skip Intro gate)
- Rename "Producer's Services" to "Packages" in mobile menu
- Remove email gate from Waterfall tab (soft CTA after results instead)
- Fix ?tab= URL parameter support in Calculator
- Fix info page back buttons to use browser history
- Post-purchase success navigates to /calculator?tab=waterfall
- Add export CTA bridge on Waterfall results page
- Add tab completion indicators (gold dots) to TabBar

Design normalization:
- Convert WikiCard, WikiCallout, WikiSectionHeader from inline styles to Tailwind
- Convert BudgetInfo, CapitalInfo, FeesInfo from design-system tokens to Tailwind
- Fix WaterfallInfo red danger zone to gold-only
- Fix IntroView blue callout to gold-only
- Normalize Auth page button/input border radius

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P