### PR TITLE
Fix homepage CTA always landing on Budget tab instead of restoring la…

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -35,7 +35,7 @@ const Index = () => {
 
   const handleStartClick = () => {
     haptics.medium();
-    navigate("/calculator");
+    navigate("/calculator?tab=budget");
   };
 
   const isComplete = phase === 'complete';


### PR DESCRIPTION
…st tab

RUN THE NUMBERS now navigates to /calculator?tab=budget so new users always start at step 1, instead of being dumped on whatever tab was last saved in localStorage.

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P