### PR TITLE
Phase 2: Normalize calculator to design system

### DIFF
--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import { Info, Percent, DollarSign, Calculator } from "lucide-react";
 import { WaterfallInputs, GuildState, CapitalSelections, formatCompactCurrency, CAM_PCT, SAG_PCT, WGA_PCT, DGA_PCT } from "@/lib/waterfall";
 import { useMobileKeyboardScroll } from "@/hooks/use-mobile-keyboard";
@@ -27,12 +27,8 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
   // Mobile keyboard scroll handling
   const { ref: mobileRef, scrollIntoView } = useMobileKeyboardScroll<HTMLDivElement>();
 
-  // Auto-focus on mount
-  useEffect(() => {
-    setTimeout(() => {
-      inputRef.current?.focus();
-    }, 100);
-  }, []);
+  // REMOVED: Auto-focus on mount caused keyboard to pop up on mobile.
+  // Let user tap to focus instead.
 
   const formatValue = (value: number | undefined) => {
     if (value === undefined || value === 0) return '';

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -97,13 +97,13 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
             </p>
           </div>
           
-          {/* DEMO BUTTON - The fix for "Nothing happens" */}
+          {/* DEMO BUTTON - Primary CTA pattern */}
           <button
             onClick={handleRunDemo}
-            className="flex items-center gap-2 px-6 py-3 bg-gold text-black font-bold rounded-lg shadow-[0_0_20px_rgba(212,175,55,0.4)] hover:scale-105 transition-transform animate-pulse-subtle"
+            className="flex items-center gap-2 px-6 py-3 bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta rounded-md shadow-button hover:border-gold-cta transition-all active:scale-[0.98]"
           >
             <Play className="w-4 h-4 fill-current" />
-            <span>RUN DEMO SIMULATION</span>
+            <span className="text-sm font-bold uppercase tracking-wider">Run Demo Simulation</span>
           </button>
         </div>
       </StandardStepLayout>
@@ -142,7 +142,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
 
             {/* Demo mode exit banner */}
             {isDemoMode && (
-              <div className="flex items-center justify-between p-3 border border-gold/30 bg-gold/[0.06] rounded-lg">
+              <div className="flex items-center justify-between p-3 border border-border-default bg-gold/[0.04] rounded-lg">
                 <span className="text-xs text-gold uppercase tracking-wider font-bold">Demo Mode</span>
                 <button
                   onClick={() => setIsDemoMode(false)}
@@ -199,7 +199,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
 
             {/* ═══ EXPORT CTA — The bridge to the store ═══ */}
             {!isDemoMode && (
-              <div className="border border-gold/30 bg-gold/[0.04] rounded-lg p-5 space-y-4">
+              <div className="border border-border-default bg-gold/[0.04] rounded-lg p-5 space-y-4">
                 <div className="flex items-center gap-2">
                   <Sparkles className="w-4 h-4 text-gold" />
                   <span className="text-[10px] uppercase tracking-[0.2em] text-gold font-bold">
@@ -235,10 +235,10 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
                </CollapsibleContent>
             </Collapsible>
 
-            {/* Back to Wiki */}
+            {/* Back to Wiki — text link pattern */}
             <Link
               to="/waterfall-info"
-              className="block p-4 text-center text-xs text-gold/70 hover:text-gold hover:underline"
+              className="block p-4 text-center text-[11px] tracking-wider text-text-dim hover:text-text-mid transition-colors"
             >
               Return to Wiki Documentation
             </Link>

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -157,13 +157,15 @@ const Calculator = () => {
   const toggleGuild = useCallback((guild: keyof GuildState) => {
     haptics.light();
     setGuilds(prev => ({ ...prev, [guild]: !prev[guild] }));
-  }, [haptics]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Handle tab change — no gate, let them see their results freely
   const handleTabChange = useCallback((tab: TabId) => {
     haptics.light();
     setActiveTab(tab);
-  }, [haptics]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleEmailSuccess = () => {
     setEmailCaptured(true);
@@ -323,8 +325,8 @@ const Calculator = () => {
           onClick={handleBack}
           className={cn(
             "flex items-center gap-2 px-4 py-2 rounded-md transition-all",
-            "border border-gold-muted bg-gold-subtle text-white",
-            "hover:bg-gold hover:text-black",
+            "border border-border-subtle text-text-mid",
+            "hover:border-text-dim hover:text-text-primary",
             "active:scale-95"
           )}
         >
@@ -358,9 +360,9 @@ const Calculator = () => {
             onClick={handleNext}
             className={cn(
               "flex items-center gap-2 px-4 py-2 rounded-md transition-all",
-              "border border-gold-muted bg-gold-subtle text-white",
-              "hover:bg-gold hover:text-black",
-              "active:scale-95 animate-pulse-subtle"
+              "bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta",
+              "hover:border-gold-cta",
+              "active:scale-95 shadow-button"
             )}
           >
             <span className="text-xs font-bold uppercase tracking-wider">Next</span>


### PR DESCRIPTION
- Back/Next floating bar: Back→ghost style, Next→Primary CTA
- Demo button: arbitrary bg-gold→Primary CTA pattern
- Export CTA border: gold/30→border-default
- Wiki link: gold tint→text-link pattern (text-dim)
- DealInput: remove auto-focus on mount (mobile anti-pattern)
- Calculator: remove haptics from useCallback deps (prevents needless re-renders since useHaptics returns new ref each render)

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P