### PR TITLE
Phase 3: Normalize store pages to design system

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -28,17 +28,17 @@ const Store = () => {
   /* ─── SUCCESS VIEW ─── */
   if (showSuccess) {
     return (
-      <div className="min-h-screen bg-background flex flex-col">
+      <div className="min-h-screen bg-bg-void flex flex-col">
         <Header title="SUCCESS" />
         <main className="flex-1 px-6 py-16 flex items-center justify-center animate-fade-in">
           <div className="text-center max-w-md">
             <div className="w-20 h-20 border-2 border-gold mx-auto mb-6 rounded-lg flex items-center justify-center">
               <Check className="w-10 h-10 text-gold" />
             </div>
-            <h1 className="font-bebas text-4xl text-foreground mb-4">
+            <h1 className="font-bebas text-4xl text-text-primary mb-4">
               PAYMENT SUCCESSFUL
             </h1>
-            <p className="text-muted-foreground mb-8 leading-relaxed">
+            <p className="text-text-dim mb-8 leading-relaxed">
               Your purchase has been confirmed. Your professional export is
               now available from the Waterfall tab.
             </p>
@@ -57,7 +57,7 @@ const Store = () => {
 
   /* ─── MAIN STORE VIEW ─── */
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-bg-void flex flex-col">
       <Header title="PACKAGES" />
 
       <main className="flex-1 animate-fade-in">
@@ -80,7 +80,7 @@ const Store = () => {
               Democratizing the Business of Film
             </p>
 
-            <h1 className="font-bebas text-[clamp(2.2rem,8vw,3.5rem)] leading-[1.05] text-foreground mb-5">
+            <h1 className="font-bebas text-[clamp(2.2rem,8vw,3.5rem)] leading-[1.05] text-text-primary mb-5">
               TURN YOUR NUMBERS
               <br />
               INTO A{" "}
@@ -96,7 +96,7 @@ const Store = () => {
               to produce.
             </p>
 
-            <div className="inline-flex items-center gap-2 px-5 py-2.5 border border-gold/30 bg-gold/5 rounded-sm">
+            <div className="inline-flex items-center gap-2 px-5 py-2.5 border border-border-default bg-gold/[0.04] rounded-sm">
               <Sparkles className="w-4 h-4 text-gold" />
               <span className="text-gold text-[11px] tracking-[0.15em] uppercase font-semibold">
                 Founders Pricing
@@ -144,7 +144,7 @@ const Store = () => {
             PACKAGE CARDS — Link to detail pages
             ═══════════════════════════════════════════════════════════ */}
         <section className="px-4 sm:px-6 py-10 max-w-5xl mx-auto">
-          <h2 className="font-bebas text-2xl tracking-[0.1em] text-foreground text-center mb-2">
+          <h2 className="font-bebas text-2xl tracking-[0.1em] text-text-primary text-center mb-2">
             CHOOSE YOUR PACKAGE
           </h2>
           <p className="text-text-dim text-xs text-center mb-8 max-w-md mx-auto">
@@ -182,8 +182,8 @@ const Store = () => {
                       className={cn(
                         "w-9 h-9 rounded-md flex items-center justify-center flex-shrink-0",
                         isFeatured
-                          ? "bg-gold/15 border border-gold/30"
-                          : "bg-white/5 border border-white/10"
+                          ? "bg-gold/10 border border-border-default"
+                          : "bg-bg-elevated border border-border-subtle"
                       )}
                     >
                       <Icon
@@ -193,7 +193,7 @@ const Store = () => {
                         )}
                       />
                     </div>
-                    <h3 className="font-bebas text-xl text-foreground leading-tight">
+                    <h3 className="font-bebas text-xl text-text-primary leading-tight">
                       {product.name.toUpperCase()}
                     </h3>
                   </div>
@@ -258,7 +258,7 @@ const Store = () => {
                             isFeatured ? "text-gold" : "text-text-dim"
                           )}
                         />
-                        <span className="text-foreground text-[13px] leading-snug">
+                        <span className="text-text-primary text-[13px] leading-snug">
                           {feature}
                         </span>
                       </li>
@@ -301,7 +301,7 @@ const Store = () => {
         <section className="border-t border-border-subtle bg-bg-elevated px-6 py-10">
           <div className="max-w-2xl mx-auto text-center">
             <Shield className="w-6 h-6 text-gold mx-auto mb-4" />
-            <h3 className="font-bebas text-xl tracking-[0.1em] text-foreground mb-3">
+            <h3 className="font-bebas text-xl tracking-[0.1em] text-text-primary mb-3">
               WHO THIS IS FOR
             </h3>
             <p className="text-text-mid text-sm leading-relaxed max-w-lg mx-auto mb-6">

--- a/src/pages/StoreCompare.tsx
+++ b/src/pages/StoreCompare.tsx
@@ -13,7 +13,7 @@ const StoreCompare = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-bg-void flex flex-col">
       <Header title="PACKAGES" />
 
       <main className="flex-1 animate-fade-in">
@@ -21,7 +21,7 @@ const StoreCompare = () => {
         <div className="px-6 pt-6 max-w-5xl mx-auto">
           <button
             onClick={() => navigate("/store")}
-            className="flex items-center gap-2 text-sm text-text-dim hover:text-gold transition-colors"
+            className="flex items-center gap-2 text-sm text-text-dim hover:text-text-mid transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
             All Packages
@@ -30,7 +30,7 @@ const StoreCompare = () => {
 
         {/* HEADER */}
         <section className="px-6 pt-8 pb-6 max-w-5xl mx-auto text-center">
-          <h1 className="font-bebas text-3xl md:text-4xl tracking-[0.1em] text-foreground mb-3">
+          <h1 className="font-bebas text-3xl md:text-4xl tracking-[0.1em] text-text-primary mb-3">
             COMPARE ALL PACKAGES
           </h1>
           <p className="text-text-mid text-sm max-w-lg mx-auto">
@@ -77,7 +77,7 @@ const StoreCompare = () => {
                       <span
                         className={cn(
                           "font-mono font-bold",
-                          p.featured ? "text-gold-cta text-base" : "text-foreground"
+                          p.featured ? "text-gold-cta text-base" : "text-text-primary"
                         )}
                       >
                         ${p.price.toLocaleString()}
@@ -100,7 +100,7 @@ const StoreCompare = () => {
                           ) : val === false ? (
                             <Minus className="w-3.5 h-3.5 text-white/10 mx-auto" />
                           ) : (
-                            <span className="text-foreground text-[11px] font-semibold">
+                            <span className="text-text-primary text-[11px] font-semibold">
                               {val}
                             </span>
                           )}
@@ -124,15 +124,15 @@ const StoreCompare = () => {
                   key={product.id}
                   onClick={() => navigate(`/store/${product.slug}`)}
                   className={cn(
-                    "text-left p-4 rounded-[--radius-lg] border transition-all hover:border-gold/40",
+                    "text-left p-4 rounded-[--radius-lg] border transition-all hover:border-border-default",
                     product.featured
-                      ? "bg-gold/[0.04] border-gold/20"
+                      ? "bg-gold/[0.04] border-border-default"
                       : "bg-bg-card border-border-subtle"
                   )}
                 >
                   <div className="flex items-center gap-3 mb-2">
                     <Icon className={cn("w-4 h-4", product.featured ? "text-gold" : "text-text-dim")} />
-                    <span className="font-bebas text-lg text-foreground">{product.name.toUpperCase()}</span>
+                    <span className="font-bebas text-lg text-text-primary">{product.name.toUpperCase()}</span>
                   </div>
                   <p className={cn("font-mono text-xl font-bold mb-2", product.featured ? "text-gold-cta" : "text-gold")}>
                     ${product.price.toLocaleString()}

--- a/src/pages/StorePackage.tsx
+++ b/src/pages/StorePackage.tsx
@@ -37,12 +37,12 @@ const StorePackage = () => {
 
   if (!product) {
     return (
-      <div className="min-h-screen bg-background flex flex-col">
+      <div className="min-h-screen bg-bg-void flex flex-col">
         <Header title="NOT FOUND" />
         <main className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <p className="text-text-mid mb-4">Package not found.</p>
-            <button onClick={() => navigate("/store")} className="text-gold text-sm hover:underline">
+            <button onClick={() => navigate("/store")} className="text-text-dim text-sm hover:text-text-mid transition-colors">
               Back to Packages
             </button>
           </div>
@@ -90,7 +90,7 @@ const StorePackage = () => {
   const next = currentIdx < products.length - 1 ? products[currentIdx + 1] : null;
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-bg-void flex flex-col">
       <Header title="PACKAGES" />
 
       <main className="flex-1 animate-fade-in">
@@ -98,7 +98,7 @@ const StorePackage = () => {
         <div className="px-6 pt-6 max-w-2xl mx-auto">
           <button
             onClick={() => navigate("/store")}
-            className="flex items-center gap-2 text-sm text-text-dim hover:text-gold transition-colors"
+            className="flex items-center gap-2 text-sm text-text-dim hover:text-text-mid transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
             All Packages
@@ -121,14 +121,14 @@ const StorePackage = () => {
               className={cn(
                 "w-12 h-12 rounded-md flex items-center justify-center flex-shrink-0",
                 isFeatured
-                  ? "bg-gold/15 border border-gold/30"
-                  : "bg-white/5 border border-white/10"
+                  ? "bg-gold/10 border border-border-default"
+                  : "bg-bg-elevated border border-border-subtle"
               )}
             >
               <Icon className={cn("w-5 h-5", isFeatured ? "text-gold" : "text-text-dim")} />
             </div>
             <div>
-              <h1 className="font-bebas text-3xl md:text-4xl text-foreground leading-tight">
+              <h1 className="font-bebas text-3xl md:text-4xl text-text-primary leading-tight">
                 {product.name.toUpperCase()}
               </h1>
               <p className="text-text-dim text-[10px] tracking-[0.2em] uppercase">
@@ -176,7 +176,7 @@ const StorePackage = () => {
         <section className="px-6 pb-8 max-w-2xl mx-auto space-y-6">
           {product.detailSections.map((section, i) => (
             <div key={i} className="bg-bg-card border border-border-subtle rounded-[--radius-lg] p-5">
-              <h3 className="font-bebas text-lg tracking-[0.08em] text-foreground mb-3">
+              <h3 className="font-bebas text-lg tracking-[0.08em] text-text-primary mb-3">
                 {section.title.toUpperCase()}
               </h3>
               <p className="text-text-mid text-sm leading-relaxed">
@@ -189,14 +189,14 @@ const StorePackage = () => {
         {/* FEATURES LIST */}
         <section className="px-6 pb-8 max-w-2xl mx-auto">
           <div className="bg-bg-card border border-border-subtle rounded-[--radius-lg] p-5">
-            <h3 className="font-bebas text-lg tracking-[0.08em] text-foreground mb-4">
+            <h3 className="font-bebas text-lg tracking-[0.08em] text-text-primary mb-4">
               WHAT'S INCLUDED
             </h3>
             <ul className="space-y-3">
               {product.features.map((feature, i) => (
                 <li key={i} className="flex items-start gap-3">
                   <Check className={cn("w-4 h-4 mt-0.5 flex-shrink-0", isFeatured ? "text-gold" : "text-text-dim")} />
-                  <span className="text-foreground text-[13px] leading-snug">{feature}</span>
+                  <span className="text-text-primary text-[13px] leading-snug">{feature}</span>
                 </li>
               ))}
             </ul>
@@ -205,7 +205,7 @@ const StorePackage = () => {
 
         {/* BUYER MATH */}
         <section className="px-6 pb-8 max-w-2xl mx-auto">
-          <div className="bg-white/[0.02] border border-white/[0.04] rounded-md px-4 py-3">
+          <div className="bg-bg-card border border-border-subtle rounded-md px-4 py-3">
             <p className="text-text-dim text-[11px] leading-relaxed italic">
               "{product.buyerMath}"
             </p>
@@ -217,10 +217,10 @@ const StorePackage = () => {
           <div className={cn(
             "rounded-[--radius-lg] p-6 space-y-4",
             isFeatured
-              ? "bg-gold/[0.04] border border-gold/20"
+              ? "bg-gold/[0.04] border border-border-default"
               : "bg-bg-card border border-border-subtle"
           )}>
-            <h3 className="font-bebas text-lg tracking-[0.08em] text-foreground">
+            <h3 className="font-bebas text-lg tracking-[0.08em] text-text-primary">
               GET {product.name.toUpperCase()}
             </h3>
 
@@ -235,7 +235,7 @@ const StorePackage = () => {
                   placeholder="your@email.com"
                   value={guestEmail}
                   onChange={(e) => setGuestEmail(e.target.value)}
-                  className="bg-bg-elevated border-border-subtle text-foreground h-12"
+                  className="bg-bg-elevated border-border-subtle text-text-primary h-12"
                 />
                 <p className="text-text-dim text-[10px] mt-2">
                   Required for purchase confirmation and document access.
@@ -274,7 +274,7 @@ const StorePackage = () => {
         <section className="px-6 pb-6 max-w-2xl mx-auto text-center">
           <button
             onClick={() => navigate("/store/compare")}
-            className="text-text-dim text-[11px] tracking-[0.15em] uppercase hover:text-gold transition-colors"
+            className="text-text-dim text-[11px] tracking-[0.15em] uppercase hover:text-text-mid transition-colors"
           >
             Compare All Packages →
           </button>
@@ -286,7 +286,7 @@ const StorePackage = () => {
             {prev ? (
               <button
                 onClick={() => navigate(`/store/${prev.slug}`)}
-                className="flex items-center gap-2 text-text-dim hover:text-gold transition-colors text-sm"
+                className="flex items-center gap-2 text-text-dim hover:text-text-mid transition-colors text-sm"
               >
                 <ArrowLeft className="w-4 h-4" />
                 <span className="hidden sm:inline">{prev.name}</span>
@@ -296,7 +296,7 @@ const StorePackage = () => {
             {next ? (
               <button
                 onClick={() => navigate(`/store/${next.slug}`)}
-                className="flex items-center gap-2 text-text-dim hover:text-gold transition-colors text-sm"
+                className="flex items-center gap-2 text-text-dim hover:text-text-mid transition-colors text-sm"
               >
                 <span className="hidden sm:inline">{next.name}</span>
                 <span className="sm:hidden">Next</span>


### PR DESCRIPTION
- Replace shadcn defaults (bg-background→bg-bg-void, text-foreground→text-text-primary, text-muted-foreground→text-text-dim)
- Icon containers: arbitrary white/gold opacities→design system tokens (bg-bg-elevated border-border-subtle, bg-gold/10 border-border-default)
- Founders badge: border-gold/30→border-border-default
- Buyer math section: bg-white→bg-bg-card border-border-subtle
- Featured purchase border: border-gold/20→border-border-default
- Navigation links: hover:text-gold→hover:text-text-mid (text-link pattern)
- Compare cards: hover:border-gold/40→hover:border-border-default

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P