### PR TITLE
Landing page v2: 11 sections, intro-once, modernized menu

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { Menu, X, Home, Calculator, BookOpen, Book, Mail, Instagram, Briefcase } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Home, Calculator, BookOpen, Book, Mail, Instagram, Briefcase } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const MobileMenu = () => {
@@ -14,11 +14,32 @@ const MobileMenu = () => {
 
   return (
     <>
+      {/* Animated Hamburger Button */}
       <button
-        onClick={() => setIsOpen(true)}
-        className="p-2 text-gold hover:bg-gold/10 rounded-full transition-colors"
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative w-10 h-10 flex items-center justify-center rounded-lg hover:bg-bg-elevated transition-colors"
+        aria-label={isOpen ? "Close menu" : "Open menu"}
       >
-        <Menu className="w-6 h-6" />
+        <div className="w-5 h-4 relative flex flex-col justify-between">
+          <span
+            className={cn(
+              "block h-[1.5px] w-full bg-gold rounded-full transition-all duration-300 origin-center",
+              isOpen && "translate-y-[7px] rotate-45"
+            )}
+          />
+          <span
+            className={cn(
+              "block h-[1.5px] w-full bg-gold rounded-full transition-all duration-300",
+              isOpen ? "opacity-0 scale-x-0" : "opacity-100 scale-x-100"
+            )}
+          />
+          <span
+            className={cn(
+              "block h-[1.5px] w-full bg-gold rounded-full transition-all duration-300 origin-center",
+              isOpen && "-translate-y-[7px] -rotate-45"
+            )}
+          />
+        </div>
       </button>
 
       {/* Overlay */}
@@ -39,16 +60,20 @@ const MobileMenu = () => {
         <div className="flex justify-end mb-8">
           <button
             onClick={() => setIsOpen(false)}
-            className="p-2 text-text-dim hover:text-white rounded-full hover:bg-bg-elevated transition-colors"
+            className="relative w-10 h-10 flex items-center justify-center rounded-lg hover:bg-bg-elevated transition-colors"
+            aria-label="Close menu"
           >
-            <X className="w-6 h-6" />
+            <div className="w-5 h-4 relative">
+              <span className="block h-[1.5px] w-full bg-text-dim rounded-full absolute top-1/2 -translate-y-1/2 rotate-45 transition-colors hover:bg-white" />
+              <span className="block h-[1.5px] w-full bg-text-dim rounded-full absolute top-1/2 -translate-y-1/2 -rotate-45 transition-colors hover:bg-white" />
+            </div>
           </button>
         </div>
 
         <div className="space-y-6 flex-1">
           <div className="space-y-2">
             <h3 className="font-bebas text-xs text-text-dim uppercase tracking-[0.2em] pl-3">Menu</h3>
-            
+
             <button
               onClick={() => handleNavigate('/store')}
               className="w-full flex items-center gap-3 p-3 rounded-lg text-text-primary hover:bg-bg-elevated transition-colors text-left group"
@@ -92,7 +117,7 @@ const MobileMenu = () => {
 
           <div className="space-y-2 pt-6 border-t border-border-subtle">
             <h3 className="font-bebas text-xs text-text-dim uppercase tracking-[0.2em] pl-3">Contact</h3>
-            
+
             <a
               href="mailto:thefilmmaker.og@gmail.com"
               className="w-full flex items-center gap-3 p-3 rounded-lg text-text-primary hover:bg-bg-elevated transition-colors text-left group"

--- a/src/index.css
+++ b/src/index.css
@@ -402,6 +402,14 @@
     opacity: 0.3;
   }
 
+  .gold-section-divider {
+    height: 1px;
+    max-width: 120px;
+    margin: 0 auto;
+    background: linear-gradient(90deg, transparent 0%, var(--gold) 50%, transparent 100%);
+    opacity: 0.35;
+  }
+
   /* ═══════════════════════════════════════════════════════════════════
      TAB BAR — Fixed bottom navigation
      ═══════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
Major landing page improvements:
- Intro plays once only (localStorage flag), back button goes straight to homepage
- New section order: Hero → What Others Charge (prominent) → When To Use This → The Problem → Democratization → How It Works → What You Get → Scenario Prompts → FAQ → Store Tease → Final CTA
- Trust bar moved to section 2 with larger type and card container
- Added 3 new sections: Use Cases, Democratization manifesto, Deliverables
- Scenario prompts are now action-oriented (chatbot bridge), no quotes
- Four Steps to Clarity is static (not clickable)
- Logo on homepage matches intro size (128px)
- All sections use card containers (bg-card, rounded-xl) with gold dividers
- More vertical padding (py-20) for visual breathing room
- Scroll hint chevron below hero
- Hamburger menu: replaced lucide icons with CSS-animated 3-line → X transition
- Added gold-section-divider CSS class

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P