### PR TITLE
Landing page v4: snap scroll, framed sections, share button, mobile-f…

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,23 @@
 /* Scrollbar hide utility for carousels */
 .scrollbar-hide::-webkit-scrollbar { display: none; }
 
+/* ═══════════════════════════════════════════════════════════════════
+   SNAP SCROLL — proximity-based section snapping (mobile-first)
+   ═══════════════════════════════════════════════════════════════════ */
+.snap-container {
+  scroll-snap-type: y proximity;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+}
+
+.snap-section {
+  scroll-snap-align: start;
+  scroll-margin-top: 56px; /* account for header height */
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
 /* FILMMAKER.OG Design System — Premium Mobile-First
    TWO-GOLD SYSTEM:
      Metallic #D4AF37 — borders, icons, dividers, brand elements
@@ -700,6 +717,15 @@
   @keyframes bounceRight {
     0%, 100% { transform: translateX(0); }
     50% { transform: translateX(4px); }
+  }
+
+  .animate-bounce-chevron {
+    animation: bounceChevron 2s ease-in-out infinite;
+  }
+
+  @keyframes bounceChevron {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(4px); }
   }
 
   /* ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
…irst

- Add CSS scroll-snap (proximity) so sections land cleanly on scroll
- Wrap every section in SectionFrame card container (bg-elevated, rounded-2xl, subtle border)
- Clickable chevron buttons that smooth-scroll to next section with bounce animation
- Add Web Share API button (native Android/iOS share sheet with clipboard fallback)
- Reorder: Mission → Industry Charges → What You Get → How It Works → Use Cases → Problem
- Rename chatbot section: "Ask Our Friendly Chatbot" with AI-Powered Guidance eyebrow
- Simplify final CTA: logo + single button + "No account required. No credit card. Just clarity."
- Remove "Know Your Numbers Before You Sign" verbiage from final CTA
- Share button appears on both hero and final CTA sections

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P