### PR TITLE
Landing page v6: trust bar, content heights, fade animations, beta la…

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,6 +27,9 @@ const Header = ({ title }: HeaderProps) => {
             <span className="font-bebas text-lg tracking-[0.2em] text-gold group-hover:text-white transition-colors duration-200">
               FILMMAKER<span className="text-white group-hover:text-gold transition-colors duration-200">.OG</span>
             </span>
+            <span className="text-[8px] font-bold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
+              BETA
+            </span>
           </button>
 
           {/* Center: Title (optional) */}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -198,7 +198,7 @@ const MobileMenu = () => {
 
         <div className="pt-6 border-t border-border-default">
           <p className="font-bebas text-xs text-text-dim tracking-[0.1em] px-3">
-            FILMMAKER.OG v2.1.0
+            FILMMAKER.OG &middot; BETA
           </p>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -794,4 +794,22 @@
   .animate-progress-draw {
     animation: progress-line-draw 0.6s ease-out forwards;
   }
+
+  /* ═══════════════════════════════════════════════════════════════════
+     TYPING INDICATOR DOTS (chatbot cards)
+     ═══════════════════════════════════════════════════════════════════ */
+  @keyframes typingDot {
+    0%, 60%, 100% { opacity: 0.3; transform: scale(1); }
+    30% { opacity: 1; transform: scale(1.3); }
+  }
+
+  .animate-typing-dot-1 {
+    animation: typingDot 1.4s ease-in-out infinite;
+  }
+  .animate-typing-dot-2 {
+    animation: typingDot 1.4s ease-in-out 0.2s infinite;
+  }
+  .animate-typing-dot-3 {
+    animation: typingDot 1.4s ease-in-out 0.4s infinite;
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -31,6 +31,7 @@ import {
   Mail,
   Instagram,
   Link2,
+  Bot,
 } from "lucide-react";
 import filmmakerLogo from "@/assets/filmmaker-logo.jpg";
 import Header from "@/components/Header";
@@ -44,23 +45,17 @@ const SHARE_TEXT = "Free film finance simulator — model your deal structure, c
 const SHARE_TITLE = "FILMMAKER.OG — See Where Every Dollar Goes";
 
 /* ═══════════════════════════════════════════════════════════════════
-   SECTION IDS — for snap scroll + chevron navigation
+   TRUST BAR STATEMENTS
    ═══════════════════════════════════════════════════════════════════ */
-const SECTION_IDS = [
-  "hero",
-  "industry-charges",
-  "deliverables",
-  "how-it-works",
-  "use-cases",
-  "problem",
-  "mission",
-  "chatbot",
-  "faq",
-  "final-cta",
-] as const;
+const trustStatements = [
+  "Modeled on real independent film deal structures",
+  "Built by working producers",
+  "Institutional-grade financial modeling",
+  "No account required",
+];
 
 /* ═══════════════════════════════════════════════════════════════════
-   SCENARIO PROMPTS — Future chatbot bridge (with copy)
+   SCENARIO PROMPTS — Chatbot bridge (with copy)
    ═══════════════════════════════════════════════════════════════════ */
 const scenarioPrompts = [
   {
@@ -93,132 +88,50 @@ const scenarioPrompts = [
    INDUSTRY COST COMPARISON
    ═══════════════════════════════════════════════════════════════════ */
 const industryCosts = [
-  {
-    icon: Gavel,
-    label: "Entertainment Lawyer",
-    cost: "$5K–$15K",
-    note: "Per deal analysis",
-  },
-  {
-    icon: Calculator,
-    label: "Finance Consultant",
-    cost: "$10K–$30K",
-    note: "Financial modeling",
-  },
-  {
-    icon: UserCheck,
-    label: "Producer's Rep",
-    cost: "5–10%",
-    note: "Percentage of deal",
-  },
-  {
-    icon: Briefcase,
-    label: "Sales Agent",
-    cost: "10–25%",
-    note: "Of gross revenue",
-  },
+  { icon: Gavel, label: "Entertainment Lawyer", cost: "$5K–$15K", note: "Per deal analysis" },
+  { icon: Calculator, label: "Finance Consultant", cost: "$10K–$30K", note: "Financial modeling" },
+  { icon: UserCheck, label: "Producer's Rep", cost: "5–10%", note: "Percentage of deal" },
+  { icon: Briefcase, label: "Sales Agent", cost: "10–25%", note: "Of gross revenue" },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    FAQ DATA
    ═══════════════════════════════════════════════════════════════════ */
 const faqs = [
-  {
-    q: "Who is this for?",
-    a: "Independent producers, directors, and investors. Whether you're raising $50K or $5M, the mechanics of recoupment are the same. If you intend to sell your film for profit, you need this.",
-  },
-  {
-    q: "How does the calculator work?",
-    a: "Four steps: set your budget, build your capital stack, model an acquisition deal, and see exactly where every dollar goes in the waterfall. It takes about 2 minutes.",
-  },
-  {
-    q: "Is this financial or legal advice?",
-    a: "No. This is a simulation tool for estimation and planning purposes only. Always consult a qualified entertainment attorney or accountant for final deal structures.",
-  },
-  {
-    q: 'What is a "waterfall"?',
-    a: "A waterfall is the priority order in which revenue from your film is distributed — who gets paid first, second, and last. Most filmmakers sign deals without ever seeing theirs.",
-  },
-  {
-    q: "Is the calculator free?",
-    a: "Yes, the simulation is completely free. Run as many scenarios as you want, adjust the variables, and see different outcomes. No paywalls, no limits.",
-  },
-  {
-    q: "Do I need an account?",
-    a: "No. You can use the calculator without signing up. If you want to save your work, we offer a simple magic link — no password required.",
-  },
+  { q: "Who is this for?", a: "Independent producers, directors, and investors. Whether you're raising $50K or $5M, the mechanics of recoupment are the same. If you intend to sell your film for profit, you need this." },
+  { q: "How does the calculator work?", a: "Four steps: set your budget, build your capital stack, model an acquisition deal, and see exactly where every dollar goes in the waterfall. It takes about 2 minutes." },
+  { q: "Is this financial or legal advice?", a: "No. This is a simulation tool for estimation and planning purposes only. Always consult a qualified entertainment attorney or accountant for final deal structures." },
+  { q: 'What is a "waterfall"?', a: "A waterfall is the priority order in which revenue from your film is distributed — who gets paid first, second, and last. Most filmmakers sign deals without ever seeing theirs." },
+  { q: "Is the calculator free?", a: "Yes, the simulation is completely free. Run as many scenarios as you want, adjust the variables, and see different outcomes. No paywalls, no limits." },
+  { q: "Do I need an account?", a: "No. You can use the calculator without signing up. If you want to save your work, we offer a simple magic link — no password required." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    HOW IT WORKS STEPS (static — not clickable)
    ═══════════════════════════════════════════════════════════════════ */
 const steps = [
-  {
-    num: "01",
-    title: "Set Your Budget",
-    desc: "Enter your total production budget and select any guild/union signatories. This establishes the baseline for everything that follows.",
-    icon: DollarSign,
-  },
-  {
-    num: "02",
-    title: "Build Your Capital Stack",
-    desc: "Choose where your money is coming from — equity, pre-sales, gap financing, tax incentives. Each source has different recoupment priorities.",
-    icon: Layers,
-  },
-  {
-    num: "03",
-    title: "Model the Deal",
-    desc: "Set the acquisition price, distribution fees, and marketing spend. This is where you see how much actually comes back.",
-    icon: Handshake,
-  },
-  {
-    num: "04",
-    title: "See the Waterfall",
-    desc: "Watch every dollar flow through the priority chain. See exactly who gets paid, in what order, and what's left for you.",
-    icon: BarChart3,
-  },
+  { num: "01", title: "Set Your Budget", desc: "Enter your total production budget and select any guild/union signatories. This establishes the baseline for everything that follows.", icon: DollarSign },
+  { num: "02", title: "Build Your Capital Stack", desc: "Choose where your money is coming from — equity, pre-sales, gap financing, tax incentives. Each source has different recoupment priorities.", icon: Layers },
+  { num: "03", title: "Model the Deal", desc: "Set the acquisition price, distribution fees, and marketing spend. This is where you see how much actually comes back.", icon: Handshake },
+  { num: "04", title: "See the Waterfall", desc: "Watch every dollar flow through the priority chain. See exactly who gets paid, in what order, and what's left for you.", icon: BarChart3, callout: "Most filmmakers sign deals without ever seeing their waterfall. This tool shows you yours in under 2 minutes." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    USE CASES
    ═══════════════════════════════════════════════════════════════════ */
 const useCases = [
-  {
-    icon: TrendingUp,
-    title: "Before You Raise",
-    desc: "Run the numbers before you pitch investors. Know exactly what you're offering and what they'll get back.",
-  },
-  {
-    icon: Pen,
-    title: "Before You Sign",
-    desc: "A distributor made an offer. Model the deal terms and see what's actually left for you before you sign.",
-  },
-  {
-    icon: Target,
-    title: "Before You Greenlight",
-    desc: "You have the budget, the script, the team. Make sure the financial structure actually works.",
-  },
+  { icon: TrendingUp, title: "Before You Raise", desc: "Run the numbers before you pitch investors. Know exactly what you're offering and what they'll get back." },
+  { icon: Pen, title: "Before You Sign", desc: "A distributor made an offer. Model the deal terms and see what's actually left for you before you sign." },
+  { icon: Target, title: "Before You Greenlight", desc: "You have the budget, the script, the team. Make sure the financial structure actually works." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    PROBLEM CARDS
    ═══════════════════════════════════════════════════════════════════ */
 const problemCards = [
-  {
-    icon: Receipt,
-    title: "Hidden Fee Structures",
-    body: "Distribution fees, marketing expenses, and producer's reps can eat 50–70% of revenue before anyone gets paid. Most filmmakers don't see this until it's too late.",
-  },
-  {
-    icon: EyeOff,
-    title: "No Waterfall Visibility",
-    body: "You signed the deal, but do you know who gets paid first? Second? Last? If you can't map the waterfall, you can't protect your backend.",
-  },
-  {
-    icon: Scale,
-    title: "Information Asymmetry",
-    body: "Agencies, studios, and distributors thrive on you not knowing the numbers. The less you understand, the better their deal — and the worse yours.",
-  },
+  { icon: Receipt, title: "Hidden Fee Structures", body: "Distribution fees, marketing expenses, and producer's reps can eat 50–70% of revenue before anyone gets paid. Most filmmakers don't see this until it's too late." },
+  { icon: EyeOff, title: "No Waterfall Visibility", body: "You signed the deal, but do you know who gets paid first? Second? Last? If you can't map the waterfall, you can't protect your backend." },
+  { icon: Scale, title: "Information Asymmetry", body: "Agencies, studios, and distributors thrive on you not knowing the numbers. The less you understand, the better their deal — and the worse yours." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -228,26 +141,11 @@ const FaqItem = ({ q, a }: { q: string; a: string }) => {
   const [open, setOpen] = useState(false);
   return (
     <div className="border-b border-border-subtle last:border-b-0">
-      <button
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between py-4 text-left group"
-      >
-        <span className="text-text-primary text-sm font-medium pr-4 group-hover:text-text-mid transition-colors">
-          {q}
-        </span>
-        <ChevronDown
-          className={cn(
-            "w-4 h-4 text-gold flex-shrink-0 transition-transform duration-200",
-            open && "rotate-180"
-          )}
-        />
+      <button onClick={() => setOpen(!open)} className="w-full flex items-center justify-between py-4 text-left group">
+        <span className="text-text-primary text-sm font-medium pr-4 group-hover:text-text-mid transition-colors">{q}</span>
+        <ChevronDown className={cn("w-4 h-4 text-gold flex-shrink-0 transition-transform duration-200", open && "rotate-180")} />
       </button>
-      <div
-        className={cn(
-          "overflow-hidden transition-all duration-200",
-          open ? "max-h-40 pb-4" : "max-h-0"
-        )}
-      >
+      <div className={cn("overflow-hidden transition-all duration-200", open ? "max-h-40 pb-4" : "max-h-0")}>
         <p className="text-text-dim text-sm leading-relaxed">{a}</p>
       </div>
     </div>
@@ -255,47 +153,30 @@ const FaqItem = ({ q, a }: { q: string; a: string }) => {
 };
 
 /* ═══════════════════════════════════════════════════════════════════
-   SECTION HEADER (eyebrow + title)
+   SECTION HEADER
    ═══════════════════════════════════════════════════════════════════ */
-const SectionHeader = ({
-  eyebrow,
-  title,
-  subtitle,
-  icon: Icon,
-}: {
-  eyebrow: string;
-  title: string;
-  subtitle?: string;
+const SectionHeader = ({ eyebrow, title, subtitle, icon: Icon }: {
+  eyebrow: string; title: string; subtitle?: string;
   icon?: React.ComponentType<{ className?: string }>;
 }) => (
-  <div className="text-center mb-8">
+  <div className="text-center mb-6">
     <div className="flex items-center gap-2 justify-center mb-3">
       {Icon && <Icon className="w-4 h-4 text-gold" />}
-      <p className="text-gold text-[10px] tracking-[0.3em] uppercase font-semibold">
-        {eyebrow}
-      </p>
+      <p className="text-gold text-[10px] tracking-[0.3em] uppercase font-semibold">{eyebrow}</p>
     </div>
-    <h2 className="font-bebas text-2xl md:text-3xl tracking-[0.08em] text-text-primary">
-      {title}
-    </h2>
-    {subtitle && (
-      <p className="text-text-mid text-sm text-center max-w-lg mx-auto mt-3 leading-relaxed">
-        {subtitle}
-      </p>
-    )}
+    <h2 className="font-bebas text-2xl md:text-3xl tracking-[0.08em] text-text-primary">{title}</h2>
+    {subtitle && <p className="text-text-mid text-sm text-center max-w-lg mx-auto mt-3 leading-relaxed">{subtitle}</p>}
   </div>
 );
 
 /* ═══════════════════════════════════════════════════════════════════
-   SECTION CHEVRON — bigger, clickable, scrolls to next section
+   SECTION CHEVRON
    ═══════════════════════════════════════════════════════════════════ */
 const SectionChevron = ({ nextId, large }: { nextId?: string; large?: boolean }) => {
   const handleClick = useCallback(() => {
     if (!nextId) return;
     const el = document.getElementById(nextId);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [nextId]);
 
   if (!nextId) return null;
@@ -305,46 +186,51 @@ const SectionChevron = ({ nextId, large }: { nextId?: string; large?: boolean })
       onClick={handleClick}
       className={cn(
         "flex items-center justify-center mx-auto rounded-full border border-white/10 hover:border-gold/40 transition-all group",
-        large ? "w-12 h-12 mt-8" : "w-10 h-10 mt-6"
+        large ? "w-12 h-12 mt-6" : "w-10 h-10 mt-5"
       )}
       aria-label="Scroll to next section"
     >
-      <ChevronDown
-        className={cn(
-          "text-text-dim group-hover:text-gold animate-bounce-chevron transition-colors",
-          large ? "w-6 h-6" : "w-5 h-5"
-        )}
-      />
+      <ChevronDown className={cn(
+        "text-text-dim group-hover:text-gold animate-bounce-chevron transition-colors",
+        large ? "w-6 h-6" : "w-5 h-5"
+      )} />
     </button>
   );
 };
 
 /* ═══════════════════════════════════════════════════════════════════
-   SECTION FRAME — wraps each section in a visible card container
+   SECTION FRAME — content-driven height (no forced min-h)
    ═══════════════════════════════════════════════════════════════════ */
-const SectionFrame = ({
-  id,
-  children,
-  className,
-}: {
-  id: string;
-  children: React.ReactNode;
-  className?: string;
+const SectionFrame = ({ id, children, className }: {
+  id: string; children: React.ReactNode; className?: string;
 }) => (
-  <section
-    id={id}
-    className="snap-section min-h-[80vh] flex flex-col justify-center px-4 py-3"
-  >
-    <div
-      className={cn(
-        "bg-bg-elevated border border-white/[0.06] rounded-2xl overflow-hidden p-6",
-        className
-      )}
-    >
+  <section id={id} className="snap-section px-4 py-2">
+    <div className={cn("bg-bg-elevated border border-white/[0.06] rounded-2xl overflow-hidden p-6", className)}>
       {children}
     </div>
   </section>
 );
+
+/* ═══════════════════════════════════════════════════════════════════
+   SECTION FADE-IN HOOK (IntersectionObserver)
+   ═══════════════════════════════════════════════════════════════════ */
+const useFadeIn = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setVisible(true); observer.disconnect(); } },
+      { threshold: 0.15 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, className: cn("transition-all duration-500 ease-out", visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4") };
+};
 
 /* ═══════════════════════════════════════════════════════════════════
    MAIN INDEX COMPONENT
@@ -357,40 +243,39 @@ const Index = () => {
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
 
-  // Detect returning user with saved data
+  // Fade-in refs for each section
+  const fade1 = useFadeIn();
+  const fade2 = useFadeIn();
+  const fade3 = useFadeIn();
+  const fade4 = useFadeIn();
+  const fade5 = useFadeIn();
+  const fade6 = useFadeIn();
+  const fade7 = useFadeIn();
+  const fade8 = useFadeIn();
+  const fade9 = useFadeIn();
+
   const savedState = useMemo(() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (!raw) return null;
       const parsed = JSON.parse(raw);
-      if (parsed?.inputs?.budget > 0) {
-        return {
-          budget: parsed.inputs.budget as number,
-          activeTab: parsed.activeTab as string,
-        };
-      }
+      if (parsed?.inputs?.budget > 0) return { budget: parsed.inputs.budget as number, activeTab: parsed.activeTab as string };
     } catch { /* ignore */ }
     return null;
   }, []);
 
   const isReturningUser = savedState !== null;
 
-  // Intro plays ONCE — check localStorage flag
   const hasSeenIntro = useMemo(() => {
-    try {
-      return localStorage.getItem(INTRO_SEEN_KEY) === "true";
-    } catch { return false; }
+    try { return localStorage.getItem(INTRO_SEEN_KEY) === "true"; } catch { return false; }
   }, []);
 
   const shouldSkip = searchParams.get("skipIntro") === "true" || hasSeenIntro;
 
-  const [phase, setPhase] = useState<
-    'dark' | 'beam' | 'logo' | 'pulse' | 'tagline' | 'complete'
-  >(shouldSkip ? 'complete' : 'dark');
+  const [phase, setPhase] = useState<'dark' | 'beam' | 'logo' | 'pulse' | 'tagline' | 'complete'>(shouldSkip ? 'complete' : 'dark');
 
   useEffect(() => {
     if (shouldSkip) return;
-
     const timers = [
       setTimeout(() => setPhase('beam'), 400),
       setTimeout(() => setPhase('logo'), 1200),
@@ -398,61 +283,38 @@ const Index = () => {
       setTimeout(() => setPhase('tagline'), 2800),
       setTimeout(() => setPhase('complete'), 4000),
     ];
-
     return () => timers.forEach(clearTimeout);
   }, [shouldSkip]);
 
-  // Mark intro as seen when it finishes
   useEffect(() => {
     if (phase === 'complete' && !hasSeenIntro) {
       try { localStorage.setItem(INTRO_SEEN_KEY, "true"); } catch { /* ignore */ }
     }
   }, [phase, hasSeenIntro]);
 
-  const handleStartClick = () => {
-    haptics.medium();
-    navigate("/calculator?tab=budget");
-  };
-
-  const handleContinueClick = () => {
-    haptics.medium();
-    navigate("/calculator");
-  };
-
-  const handleStartFresh = () => {
-    haptics.light();
-    navigate("/calculator?tab=budget&reset=true");
-  };
+  const handleStartClick = () => { haptics.medium(); navigate("/calculator?tab=budget"); };
+  const handleContinueClick = () => { haptics.medium(); navigate("/calculator"); };
+  const handleStartFresh = () => { haptics.light(); navigate("/calculator?tab=budget&reset=true"); };
 
   const handleCopyPrompt = useCallback((text: string, index: number) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedIndex(index);
       setTimeout(() => setCopiedIndex(null), 1500);
-    }).catch(() => { /* fallback: do nothing */ });
+    }).catch(() => {});
   }, []);
 
   const handleShare = useCallback(async () => {
     if (navigator.share) {
-      try {
-        await navigator.share({
-          title: SHARE_TITLE,
-          text: SHARE_TEXT,
-          url: SHARE_URL,
-        });
-        return;
-      } catch {
-        // User cancelled or API failed — fall through to clipboard
-      }
+      try { await navigator.share({ title: SHARE_TITLE, text: SHARE_TEXT, url: SHARE_URL }); return; } catch {}
     }
     handleCopyLink();
   }, []);
 
   const handleCopyLink = useCallback(() => {
-    const shareContent = `${SHARE_TEXT}\n\n${SHARE_URL}`;
-    navigator.clipboard.writeText(shareContent).then(() => {
+    navigator.clipboard.writeText(`${SHARE_TEXT}\n\n${SHARE_URL}`).then(() => {
       setLinkCopied(true);
       setTimeout(() => setLinkCopied(false), 2000);
-    }).catch(() => { /* do nothing */ });
+    }).catch(() => {});
   }, []);
 
   const isComplete = phase === 'complete';
@@ -467,15 +329,10 @@ const Index = () => {
 
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black">
 
-        {/* ═══════════════════════════════════════════════════════════════════
-            CINEMATIC INTRO (plays once only)
-            ═══════════════════════════════════════════════════════════════════ */}
+        {/* ═══════ CINEMATIC INTRO (plays once only) ═══════ */}
         {!shouldSkip && (
           <div
-            className={cn(
-              "fixed inset-0 z-[100] flex items-center justify-center transition-opacity duration-1000",
-              isComplete ? "opacity-0 pointer-events-none" : "opacity-100"
-            )}
+            className={cn("fixed inset-0 z-[100] flex items-center justify-center transition-opacity duration-1000", isComplete ? "opacity-0 pointer-events-none" : "opacity-100")}
             style={{ backgroundColor: '#000000' }}
           >
             <div className={cn("absolute inset-0 pointer-events-none transition-all duration-1000", showBeam ? "opacity-100" : "opacity-0")}
@@ -503,122 +360,84 @@ const Index = () => {
           </div>
         )}
 
-        {/* ═══════════════════════════════════════════════════════════════════
-            LANDING PAGE — snap scroll container
-            ═══════════════════════════════════════════════════════════════════ */}
-        <main
-          className={cn(
-            "flex-1 flex flex-col transition-all duration-700 snap-container",
-            isComplete ? "opacity-100" : "opacity-0"
-          )}
-        >
+        {/* ═══════ LANDING PAGE ═══════ */}
+        <main className={cn("flex-1 flex flex-col transition-all duration-700 snap-container", isComplete ? "opacity-100" : "opacity-0")}>
           <div className="vignette" />
 
-          {/* ── SECTION 1: HERO ── */}
-          <section
-            id="hero"
-            className="snap-section min-h-screen flex flex-col justify-center relative overflow-hidden"
-          >
-            <div
-              className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none animate-spotlight-pulse"
-              style={{
-                width: '100vw',
-                height: '75vh',
-                background: `radial-gradient(ellipse 50% 40% at 50% 10%, rgba(212,175,55,0.1) 0%, rgba(212,175,55,0.04) 40%, transparent 70%)`,
-              }}
-            />
-            <div className="relative px-6 pt-20 pb-6 max-w-xl mx-auto text-center">
-              <div className="mb-8 relative inline-block">
-                <div
-                  className="absolute inset-0 -m-8"
-                  style={{
-                    background: 'radial-gradient(circle, rgba(212,175,55,0.2) 0%, transparent 70%)',
-                    filter: 'blur(16px)',
-                  }}
-                />
-                <img
-                  src={filmmakerLogo}
-                  alt="Filmmaker.OG"
-                  className="relative w-32 h-32 object-contain rounded-lg"
-                  style={{ filter: 'brightness(1.15) drop-shadow(0 0 25px rgba(212,175,55,0.45))' }}
-                />
+          {/* ── HERO ── */}
+          <section id="hero" className="snap-section min-h-[calc(100vh-56px)] flex flex-col justify-center relative overflow-hidden">
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none animate-spotlight-pulse"
+              style={{ width: '100vw', height: '75vh', background: `radial-gradient(ellipse 50% 40% at 50% 10%, rgba(212,175,55,0.1) 0%, rgba(212,175,55,0.04) 40%, transparent 70%)` }} />
+            <div className="relative px-6 pt-10 pb-4 max-w-xl mx-auto text-center">
+              <div className="mb-6 relative inline-block">
+                <div className="absolute inset-0 -m-8" style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.2) 0%, transparent 70%)', filter: 'blur(16px)' }} />
+                <img src={filmmakerLogo} alt="Filmmaker.OG" className="relative w-28 h-28 object-contain rounded-lg"
+                  style={{ filter: 'brightness(1.15) drop-shadow(0 0 25px rgba(212,175,55,0.45))' }} />
               </div>
-              <p className="text-gold text-[10px] tracking-[0.35em] uppercase mb-5 font-semibold">
-                Free Film Finance Simulator
-              </p>
-              <h1 className="font-bebas text-[clamp(2.4rem,9vw,3.8rem)] leading-[1.05] text-text-primary mb-5">
+              <p className="text-gold text-[10px] tracking-[0.35em] uppercase mb-4 font-semibold">Free Film Finance Simulator</p>
+              <h1 className="font-bebas text-[clamp(2.2rem,8vw,3.6rem)] leading-[1.05] text-text-primary mb-4">
                 SEE WHERE EVERY<br />DOLLAR <span className="text-gold">GOES</span>
               </h1>
-              <p className="text-text-mid text-sm leading-relaxed max-w-md mx-auto mb-10">
+              <p className="text-text-mid text-sm leading-relaxed max-w-md mx-auto mb-8">
                 Model your film's deal structure, capital stack, and revenue waterfall — the same analysis
                 the industry gatekeepers use. Free to simulate. Takes 2 minutes.
               </p>
 
               {isReturningUser ? (
                 <div className="w-full max-w-[320px] mx-auto space-y-3">
-                  <button
-                    onClick={handleContinueClick}
-                    className="w-full h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta"
-                  >
-                    <span className="flex items-center justify-center gap-2">
-                      CONTINUE SIMULATION <ArrowRight size={18} />
-                    </span>
+                  <button onClick={handleContinueClick}
+                    className="w-full h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                    <span className="flex items-center justify-center gap-2">CONTINUE SIMULATION <ArrowRight size={18} /></span>
                   </button>
-                  <p className="text-text-dim text-[11px] tracking-wider text-center">
-                    {formatCompactCurrency(savedState!.budget)} budget in progress
-                  </p>
-                  <button
-                    onClick={handleStartFresh}
-                    className="w-full flex items-center justify-center gap-1.5 text-[11px] tracking-wider text-text-dim hover:text-text-mid transition-colors py-2"
-                  >
+                  <p className="text-text-dim text-[11px] tracking-wider text-center">{formatCompactCurrency(savedState!.budget)} budget in progress</p>
+                  <button onClick={handleStartFresh}
+                    className="w-full flex items-center justify-center gap-1.5 text-[11px] tracking-wider text-text-dim hover:text-text-mid transition-colors py-2">
                     <RotateCcw className="w-3 h-3" /> Start fresh
                   </button>
                 </div>
               ) : (
                 <div className="w-full max-w-[320px] mx-auto">
-                  <button
-                    onClick={handleStartClick}
-                    className="w-full h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta"
-                  >
-                    <span className="flex items-center justify-center gap-2">
-                      RUN THE NUMBERS <ArrowRight size={18} />
-                    </span>
+                  <button onClick={handleStartClick}
+                    className="w-full h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                    <span className="flex items-center justify-center gap-2">RUN THE NUMBERS <ArrowRight size={18} /></span>
                   </button>
-                  <p className="text-text-dim text-[11px] tracking-wider mt-4">No account required</p>
+                  <p className="text-text-dim text-[11px] tracking-wider mt-3">No account required</p>
                 </div>
               )}
 
-              {/* Chevron — big and immediately visible */}
-              <SectionChevron nextId="industry-charges" large />
+              <SectionChevron nextId="trust-bar" large />
             </div>
           </section>
 
-          {/* ── SECTION 2: WHAT THE INDUSTRY CHARGES ── */}
-          <SectionFrame id="industry-charges">
-            <div className="max-w-2xl mx-auto">
-              <SectionHeader
-                icon={Gavel}
-                eyebrow="The Industry Standard"
-                title="WHAT OTHERS CHARGE FOR THIS ANALYSIS"
-                subtitle="This is the cost of understanding your own deal. Until now."
-              />
+          {/* ── TRUST BAR ── */}
+          <section id="trust-bar" className="snap-section px-6 py-2">
+            <div ref={fade1.ref} className={fade1.className}>
+              <div className="flex items-center justify-center gap-2 flex-wrap">
+                {trustStatements.map((s, i) => (
+                  <span key={i} className="flex items-center gap-2">
+                    {i > 0 && <span className="text-gold/40 text-[8px]">&#9670;</span>}
+                    <span className="text-text-dim text-[10px] tracking-wider uppercase whitespace-nowrap">{s}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          </section>
 
+          {/* ── INDUSTRY CHARGES ── */}
+          <SectionFrame id="industry-charges">
+            <div ref={fade2.ref} className={cn(fade2.className, "max-w-2xl mx-auto")}>
+              <SectionHeader icon={Gavel} eyebrow="The Industry Standard" title="WHAT OTHERS CHARGE FOR THIS ANALYSIS" subtitle="This is the cost of understanding your own deal. Until now." />
               <div className="grid grid-cols-2 gap-3 mb-4">
                 {industryCosts.map((item) => {
                   const Icon = item.icon;
                   return (
-                    <div
-                      key={item.label}
-                      className="bg-bg-card border border-border-subtle rounded-xl p-4 relative overflow-hidden"
-                    >
+                    <div key={item.label} className="bg-bg-card border border-border-subtle rounded-xl p-4 relative overflow-hidden">
                       <div className="absolute top-0 right-0 w-16 h-16 bg-gold/[0.03] rounded-full blur-2xl translate-x-4 -translate-y-4" />
                       <div className="relative">
                         <div className="w-8 h-8 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center mb-3">
                           <Icon className="w-3.5 h-3.5 text-gold" />
                         </div>
-                        <p className="font-mono text-lg md:text-xl font-bold text-text-primary line-through decoration-text-dim/30 mb-0.5">
-                          {item.cost}
-                        </p>
+                        <p className="font-mono text-lg md:text-xl font-bold text-text-primary line-through decoration-text-dim/30 mb-0.5">{item.cost}</p>
                         <p className="text-text-dim text-[10px] tracking-wider uppercase">{item.label}</p>
                         <p className="text-text-dim text-[10px] mt-1">{item.note}</p>
                       </div>
@@ -626,8 +445,6 @@ const Index = () => {
                   );
                 })}
               </div>
-
-              {/* FREE card — hero treatment */}
               <div className="bg-gold/[0.06] border border-gold/30 rounded-xl p-5 relative overflow-hidden">
                 <div className="absolute inset-0 bg-gradient-to-r from-gold/[0.04] via-transparent to-gold/[0.04]" />
                 <div className="relative flex items-center justify-between">
@@ -640,25 +457,17 @@ const Index = () => {
                       <p className="text-text-dim text-[10px] tracking-wider uppercase">The same analysis. Free.</p>
                     </div>
                   </div>
-                  <p className="font-mono text-2xl md:text-3xl font-bold text-gold-cta">
-                    Free
-                  </p>
+                  <p className="font-mono text-2xl md:text-3xl font-bold text-gold-cta">Free</p>
                 </div>
               </div>
             </div>
             <SectionChevron nextId="deliverables" />
           </SectionFrame>
 
-          {/* ── SECTION 3: WHAT YOU GET (right after industry charges) ── */}
+          {/* ── WHAT YOU GET ── */}
           <SectionFrame id="deliverables">
-            <div className="max-w-2xl mx-auto">
-              <SectionHeader
-                icon={FileSpreadsheet}
-                eyebrow="What You Get"
-                title="PROFESSIONAL FINANCIAL DOCUMENTS"
-                subtitle="Designed so anyone — your investor, your business partner, your family — can understand your film's financials at a glance."
-              />
-
+            <div ref={fade3.ref} className={cn(fade3.className, "max-w-2xl mx-auto")}>
+              <SectionHeader icon={FileSpreadsheet} eyebrow="What You Get" title="PROFESSIONAL FINANCIAL DOCUMENTS" subtitle="Designed so anyone — your investor, your business partner, your family — can understand your film's financials at a glance." />
               <div className="grid grid-cols-2 gap-3">
                 {[
                   { icon: FileSpreadsheet, title: "6-Sheet Excel Workbook", desc: "Executive summary, full waterfall ledger, capital stack breakdown, investor return summary, and plain-English glossary." },
@@ -682,26 +491,32 @@ const Index = () => {
             <SectionChevron nextId="how-it-works" />
           </SectionFrame>
 
-          {/* ── SECTION 4: HOW IT WORKS ── */}
+          {/* ── HOW IT WORKS ── */}
           <SectionFrame id="how-it-works">
-            <div className="max-w-3xl mx-auto">
+            <div ref={fade4.ref} className={cn(fade4.className, "max-w-3xl mx-auto")}>
               <SectionHeader eyebrow="How It Works" title="FOUR STEPS TO CLARITY" />
-
               <div className="space-y-3">
                 {steps.map((step) => {
                   const Icon = step.icon;
                   return (
-                    <div key={step.num} className="flex items-start gap-4 bg-bg-card border border-border-subtle rounded-xl p-4">
-                      <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center">
-                        <Icon className="w-4 h-4 text-gold" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-mono text-[10px] text-text-dim tracking-wider">{step.num}</span>
-                          <h3 className="text-text-primary text-sm font-semibold">{step.title}</h3>
+                    <div key={step.num}>
+                      <div className="flex items-start gap-4 bg-bg-card border border-border-subtle rounded-xl p-4">
+                        <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center">
+                          <Icon className="w-4 h-4 text-gold" />
                         </div>
-                        <p className="text-text-dim text-xs leading-relaxed">{step.desc}</p>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="font-mono text-[10px] text-text-dim tracking-wider">{step.num}</span>
+                            <h3 className="text-text-primary text-sm font-semibold">{step.title}</h3>
+                          </div>
+                          <p className="text-text-dim text-xs leading-relaxed">{step.desc}</p>
+                        </div>
                       </div>
+                      {step.callout && (
+                        <div className="mt-2 mx-4 px-4 py-2.5 border-l-2 border-gold/30 bg-gold/[0.03] rounded-r-lg">
+                          <p className="text-gold/80 text-[11px] leading-relaxed italic">{step.callout}</p>
+                        </div>
+                      )}
                     </div>
                   );
                 })}
@@ -710,11 +525,10 @@ const Index = () => {
             <SectionChevron nextId="use-cases" />
           </SectionFrame>
 
-          {/* ── SECTION 5: WHEN TO USE THIS ── */}
+          {/* ── WHEN TO USE THIS ── */}
           <SectionFrame id="use-cases">
-            <div className="max-w-3xl mx-auto">
+            <div ref={fade5.ref} className={cn(fade5.className, "max-w-3xl mx-auto")}>
               <SectionHeader eyebrow="When To Use This" title="THREE MOMENTS THAT DEFINE YOUR DEAL" />
-
               <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                 {useCases.map((uc) => {
                   const Icon = uc.icon;
@@ -733,15 +547,10 @@ const Index = () => {
             <SectionChevron nextId="problem" />
           </SectionFrame>
 
-          {/* ── SECTION 6: THE PROBLEM ── */}
+          {/* ── THE PROBLEM ── */}
           <SectionFrame id="problem">
-            <div className="max-w-3xl mx-auto">
-              <SectionHeader
-                eyebrow="The Problem"
-                title="WHY MOST INDIE FILMS LOSE MONEY"
-                subtitle="It's not because the films are bad. It's because filmmakers sign deals they don't understand."
-              />
-
+            <div ref={fade6.ref} className={cn(fade6.className, "max-w-3xl mx-auto")}>
+              <SectionHeader eyebrow="The Problem" title="WHY MOST INDIE FILMS LOSE MONEY" subtitle="It's not because the films are bad. It's because filmmakers sign deals they don't understand." />
               <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                 {problemCards.map((card) => {
                   const Icon = card.icon;
@@ -760,9 +569,9 @@ const Index = () => {
             <SectionChevron nextId="mission" />
           </SectionFrame>
 
-          {/* ── SECTION 7: MISSION / DEMOCRATIZATION ── */}
+          {/* ── MISSION ── */}
           <SectionFrame id="mission">
-            <div className="max-w-2xl mx-auto">
+            <div ref={fade7.ref} className={cn(fade7.className, "max-w-2xl mx-auto")}>
               <div className="relative overflow-hidden">
                 <div className="absolute top-0 right-0 w-64 h-64 bg-gold/5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" />
                 <div className="relative z-10">
@@ -772,21 +581,11 @@ const Index = () => {
                     </div>
                     <p className="text-gold text-[10px] tracking-[0.3em] uppercase font-semibold">Our Mission</p>
                   </div>
-                  <h2 className="font-bebas text-2xl md:text-3xl tracking-[0.08em] text-text-primary mb-4">
-                    DEMOCRATIZING THE BUSINESS OF FILM
-                  </h2>
+                  <h2 className="font-bebas text-2xl md:text-3xl tracking-[0.08em] text-text-primary mb-4">DEMOCRATIZING THE BUSINESS OF FILM</h2>
                   <div className="space-y-3 text-text-mid text-sm leading-relaxed">
-                    <p>
-                      For too long, the mechanics of film finance have been obscured by gatekeepers.
-                      Agencies, distributors, and studios thrive on information asymmetry. They know the numbers; you don't.
-                    </p>
-                    <p className="text-text-primary font-medium">
-                      We built this tool to level the playing field.
-                    </p>
-                    <p>
-                      This tool extracts the proprietary logic used by top-tier entertainment lawyers and sales agents,
-                      putting institutional-grade modeling directly into your hands. Free simulation. Just the math.
-                    </p>
+                    <p>For too long, the mechanics of film finance have been obscured by gatekeepers. Agencies, distributors, and studios thrive on information asymmetry. They know the numbers; you don't.</p>
+                    <p className="text-text-primary font-medium">We built this tool to level the playing field.</p>
+                    <p>This tool extracts the proprietary logic used by top-tier entertainment lawyers and sales agents, putting institutional-grade modeling directly into your hands. Free simulation. Just the math.</p>
                   </div>
                 </div>
               </div>
@@ -794,84 +593,66 @@ const Index = () => {
             <SectionChevron nextId="chatbot" />
           </SectionFrame>
 
-          {/* ── SECTION 8: ASK OUR FRIENDLY CHATBOT (with copy) ── */}
-          <section
-            id="chatbot"
-            className="snap-section min-h-[80vh] flex flex-col justify-center px-4 py-3"
-          >
-            <div className="bg-bg-elevated border border-white/[0.06] rounded-2xl overflow-hidden p-6 pb-3">
-              <div className="max-w-3xl mx-auto mb-6">
-                <SectionHeader
-                  icon={MessageCircle}
-                  eyebrow="AI-Powered Guidance"
-                  title="ASK OUR FRIENDLY CHATBOT"
-                  subtitle="Copy any prompt below and get instant answers about your deal. Coming soon."
-                />
+          {/* ── CHATBOT ── */}
+          <section id="chatbot" className="snap-section px-4 py-2">
+            <div ref={fade8.ref} className={cn(fade8.className, "bg-bg-elevated border border-white/[0.06] rounded-2xl overflow-hidden p-6 pb-3")}>
+              <div className="max-w-3xl mx-auto mb-5">
+                <SectionHeader icon={Bot} eyebrow="AI-Powered Guidance" title="ASK OUR CHATBOT"
+                  subtitle="Have a question about your deal? Copy a prompt or ask your own." />
               </div>
 
-              <div
-                ref={carouselRef}
-                className="flex gap-3 overflow-x-auto snap-x snap-mandatory px-1 pb-4 scrollbar-hide"
-                style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-              >
+              <div ref={carouselRef} className="flex gap-3 overflow-x-auto snap-x snap-mandatory px-1 pb-4 scrollbar-hide"
+                style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
                 {scenarioPrompts.map((item, i) => (
-                  <div
-                    key={i}
-                    className="flex-shrink-0 w-[250px] snap-center bg-bg-card border border-border-subtle rounded-xl p-4 text-left hover:border-border-default transition-colors group"
-                  >
+                  <div key={i} className="flex-shrink-0 w-[250px] snap-center bg-bg-card border border-border-subtle rounded-xl p-4 text-left hover:border-border-default transition-colors group">
                     <div className="flex items-start gap-3 mb-3">
                       <div className="w-6 h-6 rounded-full bg-bg-elevated border border-border-subtle flex items-center justify-center flex-shrink-0 mt-0.5">
                         <MessageCircle className="w-3 h-3 text-gold" />
                       </div>
-                      <p className="text-text-primary text-sm font-medium leading-snug">
-                        {item.prompt}
-                      </p>
+                      <p className="text-text-primary text-sm font-medium leading-snug">{item.prompt}</p>
                     </div>
-                    <p className="text-text-dim text-[11px] leading-relaxed mb-3 pl-9">
-                      {item.context}
-                    </p>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCopyPrompt(item.prompt, i);
-                      }}
-                      className="flex items-center gap-1.5 text-[11px] tracking-wider font-semibold pl-9 transition-colors"
-                    >
-                      {copiedIndex === i ? (
-                        <span className="text-green-400 flex items-center gap-1.5">
-                          <Check className="w-3 h-3" /> Copied
-                        </span>
-                      ) : (
-                        <span className="text-gold-cta flex items-center gap-1.5">
-                          <Copy className="w-3 h-3" /> Copy prompt
-                        </span>
-                      )}
-                    </button>
+                    <p className="text-text-dim text-[11px] leading-relaxed mb-3 pl-9">{item.context}</p>
+                    <div className="flex items-center justify-between pl-9">
+                      <button onClick={(e) => { e.stopPropagation(); handleCopyPrompt(item.prompt, i); }}
+                        className="flex items-center gap-1.5 text-[11px] tracking-wider font-semibold transition-colors">
+                        {copiedIndex === i ? (
+                          <span className="text-green-400 flex items-center gap-1.5"><Check className="w-3 h-3" /> Copied</span>
+                        ) : (
+                          <span className="text-gold-cta flex items-center gap-1.5"><Copy className="w-3 h-3" /> Copy prompt</span>
+                        )}
+                      </button>
+                      {/* Typing indicator */}
+                      <div className="flex items-center gap-[3px] pr-1">
+                        <span className="w-1 h-1 rounded-full bg-gold/40 animate-typing-dot-1" />
+                        <span className="w-1 h-1 rounded-full bg-gold/40 animate-typing-dot-2" />
+                        <span className="w-1 h-1 rounded-full bg-gold/40 animate-typing-dot-3" />
+                      </div>
+                    </div>
                   </div>
                 ))}
+              </div>
+
+              {/* Get started signpost — not clickable yet */}
+              <div className="text-center mt-3 mb-2">
+                <div className="inline-flex items-center gap-2 text-text-dim text-[11px] tracking-wider">
+                  <Bot className="w-3.5 h-3.5 text-gold/50" />
+                  <span>Not sure where to start? Ask our chatbot.</span>
+                </div>
               </div>
             </div>
             <SectionChevron nextId="faq" />
           </section>
 
-          {/* ── SECTION 9: FAQ ── */}
+          {/* ── FAQ ── */}
           <SectionFrame id="faq">
-            <div className="max-w-xl mx-auto">
-              <SectionHeader
-                icon={MessageCircle}
-                eyebrow="Common Questions"
-                title="WHAT FILMMAKERS ASK"
-              />
+            <div ref={fade9.ref} className={cn(fade9.className, "max-w-xl mx-auto")}>
+              <SectionHeader icon={MessageCircle} eyebrow="Common Questions" title="WHAT FILMMAKERS ASK" />
               <div className="bg-bg-card border border-border-subtle rounded-xl px-5">
-                {faqs.map((faq) => (
-                  <FaqItem key={faq.q} q={faq.q} a={faq.a} />
-                ))}
+                {faqs.map((faq) => <FaqItem key={faq.q} q={faq.q} a={faq.a} />)}
               </div>
-              <div className="text-center mt-6">
-                <button
-                  onClick={() => navigate("/intro")}
-                  className="inline-flex items-center gap-2 text-gold-cta hover:text-gold text-xs tracking-wider font-semibold transition-colors py-2 px-4 rounded-lg border border-gold-cta/20 hover:border-gold/40 bg-gold-cta-subtle"
-                >
+              <div className="text-center mt-5">
+                <button onClick={() => navigate("/intro")}
+                  className="inline-flex items-center gap-2 text-gold-cta hover:text-gold text-xs tracking-wider font-semibold transition-colors py-2 px-4 rounded-lg border border-gold-cta/20 hover:border-gold/40 bg-gold-cta-subtle">
                   <BookOpen className="w-3.5 h-3.5" />
                   Read the full protocol documentation
                 </button>
@@ -880,92 +661,54 @@ const Index = () => {
             <SectionChevron nextId="final-cta" />
           </SectionFrame>
 
-          {/* ── SECTION 10: FINAL CTA — clean and simple ── */}
-          <section
-            id="final-cta"
-            className="snap-section min-h-[60vh] flex flex-col justify-center relative px-4 py-3 overflow-hidden"
-          >
-            <div
-              className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
-              style={{
-                width: '100vw',
-                height: '100%',
-                background: `radial-gradient(ellipse 60% 60% at 50% 0%, rgba(212,175,55,0.06) 0%, transparent 70%)`,
-              }}
-            />
+          {/* ── FINAL CTA ── */}
+          <section id="final-cta" className="snap-section py-10 flex flex-col justify-center relative px-4 overflow-hidden">
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
+              style={{ width: '100vw', height: '100%', background: `radial-gradient(ellipse 60% 60% at 50% 0%, rgba(212,175,55,0.06) 0%, transparent 70%)` }} />
             <div className="relative max-w-md mx-auto text-center">
-              <img
-                src={filmmakerLogo}
-                alt="Filmmaker.OG"
-                className="w-16 h-16 object-contain rounded-lg mx-auto mb-6"
-                style={{ filter: 'brightness(1.1) drop-shadow(0 0 15px rgba(212,175,55,0.3))' }}
-              />
-              <button
-                onClick={handleStartClick}
-                className="w-full max-w-[320px] h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta"
-              >
-                <span className="flex items-center justify-center gap-2">
-                  START FREE SIMULATION <ArrowRight size={18} />
-                </span>
+              <img src={filmmakerLogo} alt="Filmmaker.OG" className="w-16 h-16 object-contain rounded-lg mx-auto mb-6"
+                style={{ filter: 'brightness(1.1) drop-shadow(0 0 15px rgba(212,175,55,0.3))' }} />
+              <button onClick={handleStartClick}
+                className="w-full max-w-[320px] h-14 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                <span className="flex items-center justify-center gap-2">START FREE SIMULATION <ArrowRight size={18} /></span>
               </button>
-              <p className="text-text-dim text-[11px] tracking-wider mt-4">
-                No account required. No credit card. Just clarity.
-              </p>
+              <p className="text-text-dim text-[11px] tracking-wider mt-4">No account required. No credit card. Just clarity.</p>
             </div>
           </section>
 
           {/* ── FOOTER ── */}
           <footer className="border-t border-border-subtle py-8 px-6">
             <div className="max-w-md mx-auto">
-              {/* Contact + Share row */}
-              <div className="flex items-center justify-center gap-3 mb-6">
-                <a
-                  href="mailto:thefilmmaker.og@gmail.com"
-                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-text-dim hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30"
-                >
-                  <Mail className="w-3.5 h-3.5" />
-                  <span>Email</span>
+              <div className="flex items-center justify-center gap-3 mb-5 flex-wrap">
+                <a href="mailto:thefilmmaker.og@gmail.com"
+                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-gold/70 hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30">
+                  <Mail className="w-3.5 h-3.5" /><span>Email</span>
                 </a>
-                <a
-                  href="https://www.instagram.com/filmmaker.og"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-text-dim hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30"
-                >
-                  <Instagram className="w-3.5 h-3.5" />
-                  <span>Instagram</span>
+                <a href="https://www.instagram.com/filmmaker.og" target="_blank" rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-gold/70 hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30">
+                  <Instagram className="w-3.5 h-3.5" /><span>Instagram</span>
                 </a>
-                <button
-                  onClick={handleShare}
-                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-text-dim hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30"
-                >
-                  <Share2 className="w-3.5 h-3.5" />
-                  <span>Share</span>
+                <button onClick={handleShare}
+                  className="flex items-center gap-1.5 text-[11px] tracking-wider text-gold/70 hover:text-gold transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30">
+                  <Share2 className="w-3.5 h-3.5" /><span>Share</span>
                 </button>
-                <button
-                  onClick={handleCopyLink}
-                  className="flex items-center gap-1.5 text-[11px] tracking-wider transition-colors py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30"
-                >
+                <button onClick={handleCopyLink}
+                  className="flex items-center gap-1.5 text-[11px] tracking-wider py-2 px-3 rounded-full border border-white/[0.06] hover:border-gold/30 transition-colors">
                   {linkCopied ? (
-                    <>
-                      <Check className="w-3.5 h-3.5 text-green-400" />
-                      <span className="text-green-400">Copied!</span>
-                    </>
+                    <><Check className="w-3.5 h-3.5 text-green-400" /><span className="text-green-400">Copied!</span></>
                   ) : (
-                    <>
-                      <Link2 className="w-3.5 h-3.5 text-text-dim" />
-                      <span className="text-text-dim">Copy URL</span>
-                    </>
+                    <><Link2 className="w-3.5 h-3.5 text-gold/70" /><span className="text-gold/70 hover:text-gold">Copy URL</span></>
                   )}
                 </button>
               </div>
 
-              {/* Disclaimer */}
-              <p className="text-text-dim text-[10px] tracking-wide leading-relaxed text-center">
+              <p className="text-text-dim text-[10px] tracking-wide leading-relaxed text-center mb-3">
                 This tool is for educational and informational purposes only.
                 It does not constitute legal, tax, accounting, or investment advice.
-                Consult a qualified entertainment attorney before making any
-                investment or financing decisions.
+                Consult a qualified entertainment attorney before making any investment or financing decisions.
+              </p>
+              <p className="text-text-dim text-[10px] tracking-wider text-center uppercase">
+                FILMMAKER.OG &middot; BETA
               </p>
             </div>
           </footer>


### PR DESCRIPTION
…bel, chatbot present-tense

- Hero: reduce padding (pt-10 pb-4), tighter chevron (mt-6), logo w-28
- Trust bar: 4 institutional statements with gold diamond separators between hero and content
- All sections: drop forced min-h-[80vh], content-driven heights with consistent py-2 gaps
- Section fade-in animations via IntersectionObserver (opacity + translateY)
- Waterfall callout on Step 04: gold left-border quote block reinforcing what a waterfall is
- Chatbot section: present-tense language ("Ask our chatbot"), typing indicator dots animation
- "Not sure where to start? Ask our chatbot." signpost (not clickable yet)
- Beta label: gold pill badge in header next to .OG, footer shows FILMMAKER.OG · BETA
- MobileMenu footer updated to BETA
- Footer icons: gold treatment (text-gold/70, hover:text-gold)
- SectionHeader mb reduced from mb-8 to mb-6 for tighter feel

https://claude.ai/code/session_014GbtHSHfQMEthJyGA3Dq1P