### PR TITLE
Enforce font weight guide: Inter 400/600, Roboto Mono 500 only

### DIFF
--- a/src/components/EmailGateModal.tsx
+++ b/src/components/EmailGateModal.tsx
@@ -118,7 +118,7 @@ const EmailGateModal = ({ isOpen, onClose, onSuccess, onSkip }: EmailGateModalPr
               <button
                 type="submit"
                 disabled={loading || !email}
-                className="w-full h-12 font-black text-sm tracking-wider bg-gold-cta text-black hover:brightness-110 disabled:opacity-40 transition-all active:scale-[0.98]"
+                className="w-full h-12 font-semibold text-sm tracking-wider bg-gold-cta text-black hover:brightness-110 disabled:opacity-40 transition-all active:scale-[0.98]"
               >
                 {loading ? (
                   <Loader2 className="w-5 h-5 animate-spin mx-auto" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ const Header = ({ title }: HeaderProps) => {
             <span className="font-bebas text-lg tracking-[0.2em] text-gold group-hover:text-white transition-colors duration-200">
               FILMMAKER<span className="text-white group-hover:text-gold transition-colors duration-200">.OG</span>
             </span>
-            <span className="text-[10px] font-bold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
+            <span className="text-[10px] font-semibold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
               BETA
             </span>
           </button>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -201,7 +201,7 @@ const MobileMenu = () => {
             <span className="font-bebas text-lg tracking-[0.2em] text-gold">
               FILMMAKER<span className="text-white">.OG</span>
             </span>
-            <span className="text-[8px] font-bold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
+            <span className="text-[8px] font-semibold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
               BETA
             </span>
           </div>

--- a/src/components/calculator/DisclaimerFooter.tsx
+++ b/src/components/calculator/DisclaimerFooter.tsx
@@ -6,7 +6,7 @@ const DisclaimerFooter = () => {
       <div className="flex items-start gap-3">
         <AlertTriangle className="w-4 h-4 text-gold/40 flex-shrink-0 mt-0.5" />
         <p className="text-[10px] text-text-dim leading-relaxed">
-          <span className="text-gold font-medium">Educational model only.</span>{" "}
+          <span className="text-gold font-semibold">Educational model only.</span>{" "}
           Not financial, legal, or investment advice. Consult qualified entertainment 
           counsel and financial advisor before making deal decisions.
         </p>

--- a/src/components/calculator/StandardStepLayout.tsx
+++ b/src/components/calculator/StandardStepLayout.tsx
@@ -76,7 +76,7 @@ const StandardStepLayout = ({
                 )}
                 style={{ borderRadius: 'var(--radius-md)' }}
               >
-                <span className="text-sm font-bold uppercase tracking-wider">{nextLabel}</span>
+                <span className="text-sm font-semibold uppercase tracking-wider">{nextLabel}</span>
                 <ArrowRight className="w-4 h-4" />
               </button>
             </div>

--- a/src/components/calculator/WaterfallVisual.tsx
+++ b/src/components/calculator/WaterfallVisual.tsx
@@ -143,9 +143,9 @@ const WaterfallVisual = ({
           <p className="text-[9px] uppercase tracking-wider text-text-dim mb-1">
             GROSS REVENUE
           </p>
-          <p className="text-sm text-text-primary font-medium">Acquisition Price</p>
+          <p className="text-sm text-text-primary font-semibold">Acquisition Price</p>
         </div>
-        <p className="font-mono text-xl text-text-primary font-bold tabular-nums">
+        <p className="font-mono text-xl text-text-primary font-medium tabular-nums">
           {formatCompactCurrency(revenue)}
         </p>
       </div>
@@ -188,7 +188,7 @@ const WaterfallVisual = ({
                   {/* Phase Badge */}
                   <div
                     className={cn(
-                      "w-7 h-7 flex items-center justify-center text-[9px] font-mono font-bold",
+                      "w-7 h-7 flex items-center justify-center text-[9px] font-mono font-medium",
                       tier.status === "filled" && "bg-gold text-black",
                       tier.status === "partial" && "bg-gold/20 text-text-primary border border-gold/20",
                       tier.status === "empty" && "bg-bg-header text-text-dim border border-border-subtle"
@@ -205,7 +205,7 @@ const WaterfallVisual = ({
                     </p>
                     <p
                       className={cn(
-                        "text-sm font-medium",
+                        "text-sm font-semibold",
                         tier.status === "filled" && "text-text-primary",
                         tier.status === "partial" && "text-text-mid",
                         tier.status === "empty" && "text-text-dim"
@@ -270,7 +270,7 @@ const WaterfallVisual = ({
         )}
         <div className="relative flex items-center justify-between">
           <div>
-            <p className="text-[9px] uppercase tracking-wider text-text-dim mb-1 font-bold">
+            <p className="text-[9px] uppercase tracking-wider text-text-dim mb-1 font-semibold">
               REMAINING FOR SPLIT
             </p>
             <p className="text-xs text-text-dim">
@@ -279,7 +279,7 @@ const WaterfallVisual = ({
           </div>
           <p
             className={cn(
-              "font-mono text-2xl font-bold tabular-nums",
+              "font-mono text-2xl font-medium tabular-nums",
               profitPool > 0 ? "text-gold" : "text-text-dim"
             )}
             style={profitPool > 0 ? { textShadow: '0 0 20px rgba(212,175,55,0.4)' } : undefined}

--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -90,7 +90,7 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
         <div className="bg-bg-elevated border border-border-default rounded-lg p-5 transition-all focus-within:border-gold/50 focus-within:shadow-focus focus-within:bg-bg-surface">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+              <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
                 Total Budget (Negative Cost)
               </span>
               <TooltipProvider>
@@ -141,7 +141,7 @@ const BudgetInput = ({ inputs, onUpdateInput, onNext }: BudgetInputProps) => {
 
         {/* Quick Amounts */}
         <div className="p-4 border border-border-subtle bg-bg-surface rounded-lg">
-          <p className="text-xs text-text-dim mb-3 uppercase tracking-wide font-medium text-center">
+          <p className="text-xs text-text-dim mb-3 uppercase tracking-wide font-semibold text-center">
             Quick amounts
           </p>
           <div className="flex gap-2 flex-wrap justify-center">

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -67,7 +67,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
         <div className="bg-bg-elevated border border-border-default rounded-lg p-5 transition-all focus-within:border-gold/50 focus-within:shadow-focus focus-within:bg-bg-surface">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+              <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
                 Gross Acquisition Price
               </span>
                <TooltipProvider>
@@ -105,17 +105,17 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
         {/* 2. THE "FIRES" (Deductions Inputs) */}
         <div className="space-y-4">
            <div className="flex items-center gap-2 mb-2">
-             <h3 className="text-sm font-bold uppercase tracking-widest text-text-dim">Distribution Expenses</h3>
+             <h3 className="text-sm font-semibold uppercase tracking-widest text-text-dim">Distribution Expenses</h3>
              <div className="h-px flex-1 bg-border-subtle" />
            </div>
 
            {/* Sales Fee Slider */}
            <div className="bg-bg-surface border border-border-subtle rounded-lg p-4">
               <div className="flex items-center justify-between mb-4">
-                 <span className="text-xs uppercase tracking-wide text-text-dim font-bold flex items-center gap-2">
+                 <span className="text-xs uppercase tracking-wide text-text-dim font-semibold flex items-center gap-2">
                    Sales Agent Fee <Percent className="w-3 h-3 text-text-dim/50" />
                  </span>
-                 <span className="font-mono text-sm font-bold text-text-primary">
+                 <span className="font-mono text-sm font-medium text-text-primary">
                    {inputs.salesFee}%
                  </span>
               </div>
@@ -137,7 +137,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
            {/* Marketing Expenses */}
            <div className="bg-bg-surface border border-border-subtle rounded-lg p-4 flex items-center justify-between">
               <div className="flex flex-col gap-1">
-                 <span className="text-xs uppercase tracking-wide text-text-dim font-bold flex items-center gap-2">
+                 <span className="text-xs uppercase tracking-wide text-text-dim font-semibold flex items-center gap-2">
                    Sales Agent Marketing <DollarSign className="w-3 h-3 text-text-dim/50" />
                  </span>
                  <span className="text-[10px] text-text-dim/70">Expense Cap (Standard $75k)</span>
@@ -162,7 +162,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
           <div className="space-y-3 pt-2">
              <div className="flex items-center gap-2">
                <Calculator className="w-3 h-3 text-gold" />
-               <span className="text-xs font-bold uppercase tracking-widest text-gold">Live Assumptions</span>
+               <span className="text-xs font-semibold uppercase tracking-widest text-gold">Live Assumptions</span>
              </div>
              
              <div className="bg-bg-card border border-border-default rounded-lg overflow-hidden divide-y divide-border-subtle">
@@ -193,8 +193,8 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext }: DealIn
 
                 {/* Net to Waterfall */}
                 <div className="flex items-center justify-between p-3 bg-bg-elevated border-t border-border-default">
-                   <span className="text-xs font-bold text-white uppercase">Net to Waterfall</span>
-                   <span className="font-mono text-sm font-bold text-gold">{formatCompactCurrency(netRevenue)}</span>
+                   <span className="text-xs font-semibold text-white uppercase">Net to Waterfall</span>
+                   <span className="font-mono text-sm font-medium text-gold">{formatCompactCurrency(netRevenue)}</span>
                 </div>
              </div>
           </div>

--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -105,7 +105,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
         {/* Selection cards - Matte Look with Sparing Gold */}
         <div className="bg-bg-elevated border border-border-default rounded-lg overflow-hidden">
           <div className="px-5 py-3 border-b border-border-subtle flex items-center justify-between bg-bg-surface/50">
-            <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+            <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
               Select all that apply
             </span>
             {selectedCount > 0 && (
@@ -150,7 +150,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
                       <div className="flex items-center gap-2 mb-0.5">
                         <span
                           className={cn(
-                            "text-sm font-medium transition-colors",
+                            "text-sm font-semibold transition-colors",
                             isSelected ? "text-gold" : "text-text-mid" // Text turns gold when selected
                           )}
                         >

--- a/src/components/calculator/stack/StackInputCard.tsx
+++ b/src/components/calculator/stack/StackInputCard.tsx
@@ -102,7 +102,7 @@ const StackInputCard = ({
           {/* Section header */}
           <div className="px-5 py-3 border-b border-border-subtle flex items-center justify-between bg-bg-surface/50">
             <div className="flex items-center gap-2">
-              <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+              <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
                 {amountLabel}
               </span>
               {helpText && (
@@ -146,10 +146,10 @@ const StackInputCard = ({
           {rateConfig && hasAmount && (
             <div className="p-5 border-t border-border-subtle bg-bg-surface/30">
               <div className="flex items-center gap-3 mb-4">
-                <div className="w-6 h-6 flex items-center justify-center text-xs font-mono font-bold bg-gold text-black rounded-sm">
+                <div className="w-6 h-6 flex items-center justify-center text-xs font-mono font-medium bg-gold text-black rounded-sm">
                   %
                 </div>
-                <span className="text-xs uppercase tracking-widest text-gold font-bold">
+                <span className="text-xs uppercase tracking-widest text-gold font-semibold">
                   {rateConfig.label}
                 </span>
               </div>
@@ -216,7 +216,7 @@ const StackInputCard = ({
             )}
           >
             <ArrowLeft className="w-4 h-4" />
-            <span className="text-xs font-bold uppercase tracking-wider">Back</span>
+            <span className="text-xs font-semibold uppercase tracking-wider">Back</span>
           </button>
 
           {/* Skip (if no value) or Next (if has value) */}
@@ -231,7 +231,7 @@ const StackInputCard = ({
                 "rounded-md shadow-button"
               )}
             >
-              <span className="text-xs font-bold uppercase tracking-wider">Continue</span>
+              <span className="text-xs font-semibold uppercase tracking-wider">Continue</span>
               <ArrowRight className="w-4 h-4" />
             </button>
           ) : showSkip && onSkip ? (
@@ -245,7 +245,7 @@ const StackInputCard = ({
                 "rounded-md"
               )}
             >
-              <span className="text-xs font-medium uppercase tracking-wider">Skip This</span>
+              <span className="text-xs font-semibold uppercase tracking-wider">Skip This</span>
               <SkipForward className="w-4 h-4" />
             </button>
           ) : null}

--- a/src/components/calculator/stack/StackSummary.tsx
+++ b/src/components/calculator/stack/StackSummary.tsx
@@ -73,9 +73,9 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
               />
             )}
             <div className="relative flex items-center justify-between mb-2">
-              <span className="text-xs font-bold uppercase tracking-wider text-text-dim">Total Capital</span>
+              <span className="text-xs font-semibold uppercase tracking-wider text-text-dim">Total Capital</span>
               <span
-                className="font-mono text-lg font-bold text-gold"
+                className="font-mono text-lg font-medium text-gold"
                 style={isFullyFunded ? { textShadow: '0 0 12px rgba(212,175,55,0.4)' } : undefined}
               >
                 {formatCompactCurrency(totalCapital)}
@@ -98,7 +98,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             <div className="relative flex items-center justify-between">
               <span className="text-xs text-text-dim">Budget: {formatCompactCurrency(inputs.budget)}</span>
               <span className={cn(
-                "font-mono text-xs font-bold",
+                "font-mono text-xs font-medium",
                 gapPercent >= 100 ? "text-gold" : "text-gold/60"
               )}>
                 {gapPercent.toFixed(0)}% Funded
@@ -110,7 +110,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
         {/* Stack Breakdown - Matte Look */}
         <div className="bg-bg-elevated border border-border-default rounded-lg overflow-hidden">
           <div className="px-5 py-3 border-b border-border-subtle bg-bg-surface/50">
-            <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+            <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
               Capital Sources
             </span>
           </div>
@@ -128,7 +128,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
                       <div className={cn("w-1 h-8 rounded-full", item.color)} />
                       <Icon className="w-4 h-4 text-text-dim" />
                       <div>
-                        <span className="text-sm text-text-primary font-medium">{item.label}</span>
+                        <span className="text-sm text-text-primary font-semibold">{item.label}</span>
                         {item.rate !== undefined && (
                           <span className="text-xs text-text-dim ml-2">@ {item.rate}% {item.rateLabel}</span>
                         )}
@@ -162,7 +162,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             style={{ borderRadius: '0 var(--radius-md) var(--radius-md) 0' }}
           >
             <p className="text-xs text-text-mid leading-relaxed">
-              <span className="font-bold text-gold">Note:</span> Your stack doesn't fully cover the budget. 
+              <span className="font-semibold text-gold">Note:</span> Your stack doesn't fully cover the budget. 
               You can still proceed, but you may need additional financing.
             </p>
           </div>

--- a/src/components/calculator/tabs/BudgetTab.tsx
+++ b/src/components/calculator/tabs/BudgetTab.tsx
@@ -27,7 +27,7 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild, onAdvance }: 
         <div className="bg-bg-elevated border border-border-default rounded-lg overflow-hidden">
           <div className="px-5 py-3 border-b border-border-subtle flex items-center justify-between bg-bg-surface/50">
             <div className="flex items-center gap-2">
-              <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+              <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
                 Union Signatories
               </span>
               <TooltipProvider>
@@ -61,7 +61,7 @@ const BudgetTab = ({ inputs, guilds, onUpdateInput, onToggleGuild, onAdvance }: 
                 >
                   <div className="flex-1 min-w-0">
                     <span className={cn(
-                      "text-sm font-medium transition-colors",
+                      "text-sm font-semibold transition-colors",
                       isSelected ? "text-gold" : "text-text-mid"
                     )}>
                       {guild.label}

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -103,7 +103,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
             className="flex items-center gap-2 px-6 py-3 bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta rounded-md shadow-button hover:border-gold-cta transition-all active:scale-[0.98]"
           >
             <Play className="w-4 h-4 fill-current" />
-            <span className="text-sm font-bold uppercase tracking-wider">Run Demo Simulation</span>
+            <span className="text-sm font-semibold uppercase tracking-wider">Run Demo Simulation</span>
           </button>
         </div>
       </StandardStepLayout>
@@ -143,7 +143,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
             {/* Demo mode exit banner */}
             {isDemoMode && (
               <div className="flex items-center justify-between p-3 border border-border-default bg-gold/[0.04] rounded-lg">
-                <span className="text-xs text-gold uppercase tracking-wider font-bold">Demo Mode</span>
+                <span className="text-xs text-gold uppercase tracking-wider font-semibold">Demo Mode</span>
                 <button
                   onClick={() => setIsDemoMode(false)}
                   className="flex items-center gap-1 text-xs text-text-dim hover:text-text-primary transition-colors"
@@ -173,12 +173,12 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
                 >
                   <div className="flex items-center justify-between">
                     <span
-                      className="text-xs font-bold uppercase tracking-widest"
+                      className="text-xs font-semibold uppercase tracking-widest"
                       style={{ color: verdict.color }}
                     >
                       {verdict.label}
                     </span>
-                    <span className="font-mono text-lg font-bold" style={{ color: verdict.color }}>
+                    <span className="font-mono text-lg font-medium" style={{ color: verdict.color }}>
                       {formatMultiple(activeResult.multiple)}
                     </span>
                   </div>
@@ -202,7 +202,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
               <div className="border border-border-default bg-gold/[0.04] rounded-lg p-5 space-y-4">
                 <div className="flex items-center gap-2">
                   <Sparkles className="w-4 h-4 text-gold" />
-                  <span className="text-[10px] uppercase tracking-[0.2em] text-gold font-bold">
+                  <span className="text-[10px] uppercase tracking-[0.2em] text-gold font-semibold">
                     Ready to Share?
                   </span>
                 </div>
@@ -225,7 +225,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
                <CollapsibleTrigger className="flex items-center justify-between w-full p-4 hover:bg-bg-elevated transition-colors">
                   <div className="flex items-center gap-2 text-text-dim">
                      <AlertTriangle className="w-4 h-4" />
-                     <span className="text-xs font-bold uppercase tracking-widest">Legal Disclaimer</span>
+                     <span className="text-xs font-semibold uppercase tracking-widest">Legal Disclaimer</span>
                   </div>
                   {showDisclaimer ? <ChevronUp className="w-4 h-4 text-text-dim" /> : <ChevronDown className="w-4 h-4 text-text-dim" />}
                </CollapsibleTrigger>

--- a/src/components/shared/WikiSectionHeader.tsx
+++ b/src/components/shared/WikiSectionHeader.tsx
@@ -46,7 +46,7 @@ const WikiSectionHeader = ({
 
     {/* Title + Chevron */}
     <div className="flex items-center flex-1 px-4 py-4 justify-between">
-      <h2 className="font-bold text-xs uppercase tracking-widest text-text-primary">
+      <h2 className="font-semibold text-xs uppercase tracking-widest text-text-primary">
         {title}
       </h2>
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -28,7 +28,7 @@ Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h5 ref={ref} className={cn("mb-1 font-medium leading-none tracking-tight", className)} {...props} />
+    <h5 ref={ref} className={cn("mb-1 font-semibold leading-none tracking-tight", className)} {...props} />
   ),
 );
 AlertTitle.displayName = "AlertTitle";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-press",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold ring-offset-background transition-all duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-press",
   {
     variants: {
       variant: {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -16,7 +16,7 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
         caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
+        caption_label: "text-sm font-semibold",
         nav: "space-x-1 flex items-center",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -134,14 +134,14 @@ const ChartTooltipContent = React.forwardRef<
           : itemConfig?.label;
 
       if (labelFormatter) {
-        return <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>;
+        return <div className={cn("font-semibold", labelClassName)}>{labelFormatter(value, payload)}</div>;
       }
 
       if (!value) {
         return null;
       }
 
-      return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+      return <div className={cn("font-semibold", labelClassName)}>{value}</div>;
     }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
     if (!active || !payload?.length) {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -27,7 +27,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -81,7 +81,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:text-muted-foreground",
       className,
     )}
     {...props}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -118,7 +118,7 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
     }
 
     return (
-      <p ref={ref} id={formMessageId} className={cn("text-sm font-medium text-destructive", className)} {...props}>
+      <p ref={ref} id={formMessageId} className={cn("text-sm font-semibold text-destructive", className)} {...props}>
         {body}
       </p>
     );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-semibold file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-const labelVariants = cva("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
+const labelVariants = cva("text-sm font-semibold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,

--- a/src/components/ui/matte-card.tsx
+++ b/src/components/ui/matte-card.tsx
@@ -50,7 +50,7 @@ export const MatteCardHeader = ({
         className
       )}
     >
-      <span className="text-xs uppercase tracking-widest text-text-dim font-bold">
+      <span className="text-xs uppercase tracking-widest text-text-dim font-semibold">
         {children}
       </span>
       {rightElement}
@@ -231,7 +231,7 @@ export const LedgerRow = ({
         <span
           className={cn(
             "font-mono",
-            isTotal ? "text-xl text-gold font-bold" : "text-base text-text-mid"
+            isTotal ? "text-xl text-gold font-semibold" : "text-base text-text-mid"
           )}
         >
           {value}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -33,7 +33,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-semibold outline-none data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
       className,
     )}
     {...props}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -35,7 +35,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
 );
 
 const NavigationMenuTrigger = React.forwardRef<

--- a/src/components/ui/premium-input.tsx
+++ b/src/components/ui/premium-input.tsx
@@ -161,7 +161,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
               {stepNumber && (
                 <div
                   className={cn(
-                    "w-6 h-6 flex items-center justify-center text-xs font-mono font-bold transition-colors",
+                    "w-6 h-6 flex items-center justify-center text-xs font-mono font-medium transition-colors",
                     isCompleted
                       ? "bg-gold text-black"
                       : needsAttention
@@ -268,7 +268,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
             <div className="px-4 pb-4 animate-fade-in">
               <div className="flex items-center gap-2 text-gold">
                 <ChevronRight className="w-4 h-4 animate-bounce-right" />
-                <span className="text-xs font-medium tracking-wide">
+                <span className="text-xs font-semibold tracking-wide">
                   {actionHint || `Enter ${label?.toLowerCase() || 'value'} to continue`}
                 </span>
               </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -361,7 +361,7 @@ const SidebarGroupLabel = React.forwardRef<HTMLDivElement, React.ComponentProps<
         ref={ref}
         data-sidebar="group-label"
         className={cn(
-          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-semibold text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
           "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
           className,
         )}
@@ -412,7 +412,7 @@ const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<"li
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-semibold data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -511,7 +511,7 @@ const SidebarMenuBadge = React.forwardRef<HTMLDivElement, React.ComponentProps<"
       ref={ref}
       data-sidebar="menu-badge"
       className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-semibold tabular-nums text-sidebar-foreground",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",

--- a/src/components/ui/smart-cta.tsx
+++ b/src/components/ui/smart-cta.tsx
@@ -112,7 +112,7 @@ const SmartCTA = ({
           onMouseLeave={() => setIsPressed(false)}
           className={cn(
             "flex-1 h-14 relative overflow-hidden",
-            "font-black text-sm tracking-[0.15em] uppercase",
+            "font-semibold text-sm tracking-[0.15em] uppercase",
             "transition-all duration-200",
             showShake && "animate-shake",
             isPressed && canProceed && "scale-[0.98]",

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -25,7 +25,7 @@ TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
   ({ className, ...props }, ref) => (
-    <tfoot ref={ref} className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)} {...props} />
+    <tfoot ref={ref} className={cn("border-t bg-muted/50 font-semibold [&>tr]:last:border-b-0", className)} {...props} />
   ),
 );
 TableFooter.displayName = "TableFooter";
@@ -46,7 +46,7 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
     <th
       ref={ref}
       className={cn(
-        "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        "h-12 px-4 text-left align-middle font-semibold text-muted-foreground [&:has([role=checkbox])]:pr-0",
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-semibold ring-offset-background transition-all data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -52,7 +52,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors group-[.destructive]:border-muted/40 hover:bg-secondary group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 group-[.destructive]:focus:ring-destructive disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-semibold ring-offset-background transition-colors group-[.destructive]:border-muted/40 hover:bg-secondary group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 group-[.destructive]:focus:ring-destructive disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  "inline-flex items-center justify-center rounded-md text-sm font-semibold ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
   {
     variants: {
       variant: {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;900&family=Roboto+Mono:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600&family=Roboto+Mono:wght@500&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -278,7 +278,7 @@
     border-radius: var(--radius-md);
     font-family: 'Inter', sans-serif;
     font-size: 12px;
-    font-weight: 900;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1.5px;
     color: var(--gold-cta);
@@ -314,7 +314,7 @@
     border-radius: var(--radius-md);
     font-family: 'Inter', sans-serif;
     font-size: 12px;
-    font-weight: 900;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1.5px;
     color: var(--gold);
@@ -456,7 +456,7 @@
     padding: var(--space-sm) 0;
     font-family: 'Inter', sans-serif;
     font-size: 10px;
-    font-weight: 700;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--text-dim);
@@ -497,7 +497,7 @@
     border-radius: var(--radius-full);
     font-family: 'Inter', sans-serif;
     font-size: 11px;
-    font-weight: 900;
+    font-weight: 600;
     color: rgba(212, 175, 55, 0.7);
     background: rgba(212, 175, 55, 0.05);
     cursor: pointer;
@@ -555,7 +555,7 @@
     margin-bottom: var(--space-sm);
     font-family: 'Inter', sans-serif;
     font-size: 11px;
-    font-weight: 900;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-dim);
@@ -576,7 +576,7 @@
     border-radius: var(--radius-md);
     font-family: 'Inter', sans-serif;
     font-size: 11px;
-    font-weight: 900;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--gold-cta);
@@ -609,7 +609,7 @@
     border-radius: var(--radius-md);
     font-family: 'Inter', sans-serif;
     font-size: 11px;
-    font-weight: 900;
+    font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
     color: var(--text-primary);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -130,7 +130,7 @@ const Auth = () => {
                   <div>
                     <label
                       htmlFor="name"
-                      className="block text-xs uppercase tracking-[0.2em] text-text-dim font-medium mb-3"
+                      className="block text-xs uppercase tracking-[0.2em] text-text-dim font-semibold mb-3"
                     >
                       Name
                     </label>
@@ -158,7 +158,7 @@ const Auth = () => {
                   <div>
                     <label
                       htmlFor="email"
-                      className="block text-xs uppercase tracking-[0.2em] text-text-dim font-medium mb-3"
+                      className="block text-xs uppercase tracking-[0.2em] text-text-dim font-semibold mb-3"
                     >
                       Email
                     </label>
@@ -189,7 +189,7 @@ const Auth = () => {
                   <Button
                     type="submit"
                     disabled={loading || !email || !name.trim()}
-                    className="w-full min-h-[52px] rounded-[--radius-md] font-black text-xs uppercase tracking-[1.5px] bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
+                    className="w-full min-h-[52px] rounded-[--radius-md] font-semibold text-xs uppercase tracking-[1.5px] bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200"
                   >
                     {loading ? (
                       <Loader2 className="w-5 h-5 animate-spin" />
@@ -247,7 +247,7 @@ const Auth = () => {
                 <div className="space-y-6">
                   <button
                     onClick={() => setStep('email')}
-                    className="text-text-dim hover:text-text-mid text-sm font-medium transition-colors"
+                    className="text-text-dim hover:text-text-mid text-sm font-normal transition-colors"
                   >
                     Use different email
                   </button>

--- a/src/pages/BudgetInfo.tsx
+++ b/src/pages/BudgetInfo.tsx
@@ -42,7 +42,7 @@ const BudgetTierCard = ({ tier, range, description, accentColor }: BudgetTierCar
     >
       {tier}
     </span>
-    <p className="text-lg font-bold text-white mt-1 mb-2 font-mono">
+    <p className="text-lg font-medium text-white mt-1 mb-2 font-mono">
       {range}
     </p>
     <p className="text-xs leading-relaxed text-text-dim">

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -331,7 +331,7 @@ const Calculator = () => {
           )}
         >
           <ArrowLeft className="w-4 h-4" />
-          <span className="text-xs font-bold uppercase tracking-wider">Back</span>
+          <span className="text-xs font-semibold uppercase tracking-wider">Back</span>
         </button>
 
         <div className="relative w-11 h-11 flex items-center justify-center">
@@ -350,7 +350,7 @@ const Calculator = () => {
               style={{ filter: 'drop-shadow(0 0 4px rgba(212, 175, 55, 0.5))' }}
             />
           </svg>
-          <span className="relative z-10 font-mono text-[11px] font-bold text-gold">
+          <span className="relative z-10 font-mono text-[11px] font-medium text-gold">
             {progressPercent}%
           </span>
         </div>
@@ -365,7 +365,7 @@ const Calculator = () => {
               "active:scale-95 shadow-button"
             )}
           >
-            <span className="text-xs font-bold uppercase tracking-wider">Next</span>
+            <span className="text-xs font-semibold uppercase tracking-wider">Next</span>
             <ArrowRight className="w-4 h-4" />
           </button>
         )}

--- a/src/pages/Glossary.tsx
+++ b/src/pages/Glossary.tsx
@@ -221,7 +221,7 @@ const Glossary = () => {
           <div className="flex flex-col gap-6 border-b border-border-default pb-8">
             <div className="flex items-center gap-2 text-gold mb-2">
               <Book className="w-5 h-5" />
-              <span className="text-xs font-bold uppercase tracking-widest">The Black Book</span>
+              <span className="text-xs font-semibold uppercase tracking-widest">The Black Book</span>
             </div>
             
             <h1 className="text-5xl md:text-6xl font-bebas text-white tracking-wide">
@@ -261,7 +261,7 @@ const Glossary = () => {
                   className="group bg-bg-surface border border-border-default hover:border-border-active rounded-lg p-6 transition-all duration-200"
                 >
                   <div className="flex flex-col md:flex-row md:items-baseline gap-2 md:gap-4 mb-2">
-                    <h3 className="text-xl font-bold text-white group-hover:text-text-primary transition-colors">
+                    <h3 className="text-xl font-semibold text-white group-hover:text-text-primary transition-colors">
                       {item.term}
                     </h3>
                     <span className="text-[10px] uppercase tracking-wider text-text-dim bg-bg-elevated px-2 py-1 rounded w-fit">
@@ -281,7 +281,7 @@ const Glossary = () => {
             <div className="flex flex-col items-center gap-4 text-center">
               <div className="flex items-center gap-2 text-gold">
                 <Mail className="w-4 h-4" />
-                <span className="text-xs font-bold uppercase tracking-widest">Questions or Corrections?</span>
+                <span className="text-xs font-semibold uppercase tracking-widest">Questions or Corrections?</span>
               </div>
               <p className="text-sm text-text-mid max-w-md">
                 This glossary is a living document. If you spot an error or want to suggest a term, email us:
@@ -297,7 +297,7 @@ const Glossary = () => {
             <div className="flex justify-center pt-4">
               <button 
                 onClick={() => navigate('/')} 
-                className="flex items-center gap-2 text-text-dim hover:text-text-mid transition-colors uppercase tracking-widest text-xs font-bold"
+                className="flex items-center gap-2 text-text-dim hover:text-text-mid transition-colors uppercase tracking-widest text-xs font-semibold"
               >
                 <Home className="w-4 h-4" />
                 Return to Home

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -336,7 +336,7 @@ const Index = () => {
               {isReturningUser ? (
                 <div className="w-full max-w-[320px] mx-auto space-y-3">
                   <button onClick={handleContinueClick}
-                    className="w-full h-16 text-base font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                    className="w-full h-16 text-base font-semibold tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
                     CONTINUE SIMULATION
                   </button>
                   <p className="text-text-dim text-xs tracking-wider text-center">{formatCompactCurrency(savedState!.budget)} budget in progress</p>
@@ -348,7 +348,7 @@ const Index = () => {
               ) : (
                 <div className="w-full max-w-[320px] mx-auto">
                   <button onClick={handleStartClick}
-                    className="w-full h-16 text-base font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                    className="w-full h-16 text-base font-semibold tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
                     RUN THE NUMBERS
                   </button>
                   <p className="text-text-dim text-[13px] tracking-wider mt-3">No account required</p>
@@ -419,7 +419,7 @@ const Index = () => {
               {/* Mid-page CTA — catch fast deciders */}
               <div className="text-center mt-8">
                 <button onClick={handleStartClick}
-                  className="h-14 px-10 text-sm font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md border border-gold-cta-muted text-gold-cta hover:border-gold-cta hover:bg-gold/[0.06]">
+                  className="h-14 px-10 text-sm font-semibold tracking-[0.12em] transition-all active:scale-[0.96] rounded-md border border-gold-cta-muted text-gold-cta hover:border-gold-cta hover:bg-gold/[0.06]">
                   RUN THE NUMBERS — FREE
                 </button>
               </div>
@@ -441,7 +441,7 @@ const Index = () => {
                         <div className="w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center mb-3">
                           <Icon className="w-4 h-4 text-gold" />
                         </div>
-                        <p className="font-mono text-xl md:text-2xl font-bold text-text-primary line-through decoration-text-dim/30 mb-0.5">{item.cost}</p>
+                        <p className="font-mono text-xl md:text-2xl font-medium text-text-primary line-through decoration-text-dim/30 mb-0.5">{item.cost}</p>
                         <p className="text-text-dim text-xs tracking-wider uppercase">{item.label}</p>
                         <p className="text-text-dim text-[13px] mt-1">{item.note}</p>
                       </div>
@@ -523,7 +523,7 @@ const Index = () => {
               <div className="relative p-8 md:p-12 max-w-md mx-auto text-center">
                 <p className="text-gold text-xs tracking-[0.3em] uppercase font-semibold mb-5">Ready?</p>
                 <button onClick={handleStartClick}
-                  className="w-full max-w-[320px] h-16 text-base font-black tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
+                  className="w-full max-w-[320px] h-16 text-base font-semibold tracking-[0.12em] transition-all active:scale-[0.96] rounded-md bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta shadow-button hover:border-gold-cta">
                   SEE YOUR WATERFALL
                 </button>
                 <p className="text-text-dim text-[15px] tracking-wider mt-4">No account required. No credit card.</p>
@@ -567,7 +567,7 @@ const Index = () => {
                 <span className="font-bebas text-lg tracking-[0.2em] text-gold">
                   FILMMAKER<span className="text-white">.OG</span>
                 </span>
-                <span className="text-[10px] font-bold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
+                <span className="text-[10px] font-semibold tracking-[0.15em] text-gold border border-gold/40 rounded-full px-1.5 py-0.5 leading-none uppercase">
                   BETA
                 </span>
               </div>

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -123,7 +123,7 @@ const Store = () => {
                 <div key={item.label} className="py-2">
                   <p
                     className={cn(
-                      "font-mono text-lg font-bold",
+                      "font-mono text-lg font-medium",
                       item.highlight
                         ? "text-gold-cta"
                         : "text-text-dim line-through decoration-text-dim/40"
@@ -170,7 +170,7 @@ const Store = () => {
                   {isFeatured && (
                     <div className="flex items-center gap-1.5 mb-4">
                       <Star className="w-3 h-3 text-gold fill-gold" />
-                      <span className="text-gold text-[10px] tracking-[0.3em] uppercase font-bold">
+                      <span className="text-gold text-[10px] tracking-[0.3em] uppercase font-semibold">
                         Most Popular
                       </span>
                     </div>
@@ -212,7 +212,7 @@ const Store = () => {
                     )}
                     <span
                       className={cn(
-                        "font-mono text-3xl font-bold",
+                        "font-mono text-3xl font-medium",
                         isFeatured ? "text-gold-cta" : "text-gold"
                       )}
                     >

--- a/src/pages/StoreCompare.tsx
+++ b/src/pages/StoreCompare.tsx
@@ -76,7 +76,7 @@ const StoreCompare = () => {
                       )}
                       <span
                         className={cn(
-                          "font-mono font-bold",
+                          "font-mono font-medium",
                           p.featured ? "text-gold-cta text-base" : "text-text-primary"
                         )}
                       >
@@ -134,7 +134,7 @@ const StoreCompare = () => {
                     <Icon className={cn("w-4 h-4", product.featured ? "text-gold" : "text-text-dim")} />
                     <span className="font-bebas text-lg text-text-primary">{product.name.toUpperCase()}</span>
                   </div>
-                  <p className={cn("font-mono text-xl font-bold mb-2", product.featured ? "text-gold-cta" : "text-gold")}>
+                  <p className={cn("font-mono text-xl font-medium mb-2", product.featured ? "text-gold-cta" : "text-gold")}>
                     ${product.price.toLocaleString()}
                   </p>
                   <span className="flex items-center gap-1 text-text-dim text-[11px] hover:text-text-mid transition-colors">

--- a/src/pages/StorePackage.tsx
+++ b/src/pages/StorePackage.tsx
@@ -110,7 +110,7 @@ const StorePackage = () => {
           {isFeatured && (
             <div className="flex items-center gap-1.5 mb-4">
               <Star className="w-3 h-3 text-gold fill-gold" />
-              <span className="text-gold text-[10px] tracking-[0.3em] uppercase font-bold">
+              <span className="text-gold text-[10px] tracking-[0.3em] uppercase font-semibold">
                 Most Popular
               </span>
             </div>
@@ -144,7 +144,7 @@ const StorePackage = () => {
                 ${product.originalPrice.toLocaleString()}
               </span>
             )}
-            <span className={cn("font-mono text-4xl font-bold", isFeatured ? "text-gold-cta" : "text-gold")}>
+            <span className={cn("font-mono text-4xl font-medium", isFeatured ? "text-gold-cta" : "text-gold")}>
               ${product.price.toLocaleString()}
             </span>
           </div>

--- a/src/pages/WaterfallInfo.tsx
+++ b/src/pages/WaterfallInfo.tsx
@@ -83,7 +83,7 @@ const WaterfallInfo = () => {
               </p>
               <p>
                 If the flow of water stops, the buckets at the bottom stay dry. 
-                <span className="text-gold font-bold"> You (the Producer) are at the very bottom.</span>
+                <span className="text-gold font-semibold"> You (the Producer) are at the very bottom.</span>
               </p>
             </div>
           </div>
@@ -101,16 +101,16 @@ const WaterfallInfo = () => {
               <div className="grid grid-cols-[auto_1fr] gap-0 divide-y divide-border-subtle">
                 
                 {/* Row 1 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center min-w-[60px]">01</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center min-w-[60px]">01</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Collection Account Management (CAM)</h3>
+                  <h3 className="text-white font-semibold mb-1">Collection Account Management (CAM)</h3>
                   <p className="text-sm text-text-dim">Before anything happens, the CAM takes ~1% off the top to manage the money. This protects you from the distributor holding your cash.</p>
                 </div>
 
                 {/* Row 2 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center">02</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center">02</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Sales Fees & Expenses</h3>
+                  <h3 className="text-white font-semibold mb-1">Sales Fees & Expenses</h3>
                   <p className="text-sm text-text-dim">
                     The Sales Agent takes their commission (10-25%) and recoups capped expenses (marketing, festivals, deliverables).
                     <span className="block mt-1 text-gold text-xs font-semibold">TRAP: Ensure expenses are "Capped" in your contract.</span>
@@ -118,30 +118,30 @@ const WaterfallInfo = () => {
                 </div>
 
                 {/* Row 3 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center">03</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center">03</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Guild Residuals (Setup)</h3>
+                  <h3 className="text-white font-semibold mb-1">Guild Residuals (Setup)</h3>
                   <p className="text-sm text-text-dim">SAG-AFTRA, DGA, WGA deposits. If you don't pay these, they can shut you down.</p>
                 </div>
 
                 {/* Row 4 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center">04</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center">04</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Senior Debt (Banks)</h3>
+                  <h3 className="text-white font-semibold mb-1">Senior Debt (Banks)</h3>
                   <p className="text-sm text-text-dim">They took the least risk (often against tax credits), so they get paid first among lenders.</p>
                 </div>
 
                 {/* Row 5 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center">05</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center">05</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Gap / Mezzanine Debt</h3>
+                  <h3 className="text-white font-semibold mb-1">Gap / Mezzanine Debt</h3>
                   <p className="text-sm text-text-dim">Higher risk lenders. They charge higher interest because they sit behind the bank.</p>
                 </div>
 
                 {/* Row 6 */}
-                <div className="p-4 bg-bg-elevated text-gold font-mono font-bold border-r border-border-subtle flex items-center justify-center">06</div>
+                <div className="p-4 bg-bg-elevated text-gold font-mono font-medium border-r border-border-subtle flex items-center justify-center">06</div>
                 <div className="p-4">
-                  <h3 className="text-white font-bold mb-1">Equity Investors (Principal + Premium)</h3>
+                  <h3 className="text-white font-semibold mb-1">Equity Investors (Principal + Premium)</h3>
                   <p className="text-sm text-text-dim">Your investors get 100% of their money back, plus a premium (usually 20%). Only after they are 120% whole does the "Net Profit" split begin.</p>
                 </div>
               </div>
@@ -157,16 +157,16 @@ const WaterfallInfo = () => {
               </p>
               <ul className="space-y-3 mt-4">
                 <li className="flex items-start gap-3 bg-bg-surface p-3 rounded border border-border-subtle">
-                  <div className="w-6 h-6 rounded-full bg-blue-500/20 text-blue-400 flex items-center justify-center font-bold text-xs">A</div>
+                  <div className="w-6 h-6 rounded-full bg-blue-500/20 text-blue-400 flex items-center justify-center font-semibold text-xs">A</div>
                   <div>
-                    <span className="text-white font-bold block text-sm">Investor's Pool (50%)</span>
+                    <span className="text-white font-semibold block text-sm">Investor's Pool (50%)</span>
                     <span className="text-xs text-text-dim">Pro-rata share to equity financiers.</span>
                   </div>
                 </li>
                 <li className="flex items-start gap-3 bg-gold/10 p-3 rounded border border-border-default">
-                  <div className="w-6 h-6 rounded-full bg-gold text-black flex items-center justify-center font-bold text-xs">B</div>
+                  <div className="w-6 h-6 rounded-full bg-gold text-black flex items-center justify-center font-semibold text-xs">B</div>
                   <div>
-                    <span className="text-gold font-bold block text-sm">Producer's Pool (50%)</span>
+                    <span className="text-gold font-semibold block text-sm">Producer's Pool (50%)</span>
                     <span className="text-xs text-text-dim">This is where you, the director, and talent points come from.</span>
                   </div>
                 </li>
@@ -186,11 +186,11 @@ const WaterfallInfo = () => {
                   <div className="h-4 flex justify-center"><div className="w-0.5 h-full bg-gold" /></div>
                   <div className="flex gap-2">
                     <div className="h-20 flex-1 border-2 border-blue-500/30 bg-blue-500/5 rounded flex flex-col items-center justify-center text-center p-1">
-                      <span className="text-[10px] font-bold text-blue-200">Investors</span>
+                      <span className="text-[10px] font-semibold text-blue-200">Investors</span>
                       <span className="text-[10px] text-blue-200/50">50%</span>
                     </div>
                     <div className="h-20 flex-1 border-2 border-gold/50 bg-gold/10 rounded flex flex-col items-center justify-center text-center p-1 shadow-[0_0_15px_rgba(212,175,55,0.15)]">
-                      <span className="text-[10px] font-bold text-gold">Producers</span>
+                      <span className="text-[10px] font-semibold text-gold">Producers</span>
                       <span className="text-[10px] text-gold/70">50%</span>
                     </div>
                   </div>
@@ -202,19 +202,19 @@ const WaterfallInfo = () => {
           <div className="bg-gold/[0.04] border border-border-default rounded-lg p-6 space-y-4">
             <div className="flex items-center gap-2 mb-2">
               <ShieldAlert className="w-5 h-5 text-gold" />
-              <h2 className="text-lg font-bold text-gold uppercase tracking-widest">Common Traps</h2>
+              <h2 className="text-lg font-semibold text-gold uppercase tracking-widest">Common Traps</h2>
             </div>
 
             <div className="grid md:grid-cols-2 gap-6">
               <div>
-                <h3 className="text-white font-bold text-sm mb-1">Cross-Collateralization</h3>
+                <h3 className="text-white font-semibold text-sm mb-1">Cross-Collateralization</h3>
                 <p className="text-xs text-text-dim leading-relaxed">
                   When a distributor uses the profits from your film to pay for the losses of *another* film they bought.
                   <span className="block mt-1 text-gold font-semibold">Never allow this. Require "Single Picture Accounting".</span>
                 </p>
               </div>
               <div>
-                <h3 className="text-white font-bold text-sm mb-1">Overhead Fees</h3>
+                <h3 className="text-white font-semibold text-sm mb-1">Overhead Fees</h3>
                 <p className="text-xs text-text-dim leading-relaxed">
                   Distributors often charge a flat "Overhead" fee (10-15%) on top of their commission for "office expenses."
                   This is pure profit for them. Fight to cap or remove it.


### PR DESCRIPTION
Removed Inter weight 900 from Google Fonts import. Fixed all font-weight violations across 42 files:
- font-black (900) → font-semibold (600) on all CTA buttons
- font-bold (700) → font-semibold (600) on Inter labels/headings
- font-bold (700) → font-medium (500) on Roboto Mono values
- font-medium (500) → font-semibold (600) on Inter labels/UI
- Hardcoded font-weight 900/700 → 600 in index.css

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7