### PR TITLE
Claude/design system review 3m fzu

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -123,7 +123,7 @@ const SectionFrame = ({ id, children, className, alt }: {
   <section id={id} className="snap-section px-4 py-6">
     <div className="flex rounded-2xl overflow-hidden border border-white/[0.06]">
       <div className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20" style={{ boxShadow: '0 0 12px rgba(212,175,55,0.25)' }} />
-      <div className={cn("flex-1", alt ? "bg-bg-surface" : "bg-bg-elevated", className)}>
+      <div className={cn("flex-1 min-w-0", alt ? "bg-bg-surface" : "bg-bg-elevated", className)}>
         <div className="h-[2px] bg-gradient-to-r from-transparent via-gold/25 to-transparent" />
         <div className="p-6 md:p-8">
           {children}
@@ -559,7 +559,7 @@ const Index = () => {
           <section id="final-cta" className="snap-section py-8 px-4">
             <div className="flex rounded-2xl overflow-hidden border border-white/[0.06]">
               <div className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20" style={{ boxShadow: '0 0 12px rgba(212,175,55,0.25)' }} />
-              <div className="bg-bg-elevated flex-1 overflow-hidden relative">
+              <div className="bg-bg-elevated flex-1 min-w-0 overflow-hidden relative">
                 <div className="h-[2px] bg-gradient-to-r from-transparent via-gold/25 to-transparent" />
                 <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
                   style={{ width: '100%', height: '100%', background: `radial-gradient(ellipse 60% 60% at 50% 10%, rgba(212,175,55,0.08) 0%, transparent 70%)` }} />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -320,13 +320,13 @@ const Index = () => {
               style={{ width: '100vw', height: '75vh', background: `radial-gradient(ellipse 50% 40% at 50% 10%, rgba(212,175,55,0.1) 0%, rgba(212,175,55,0.04) 40%, transparent 70%)` }} />
             <div className="relative px-6 py-4 max-w-xl mx-auto text-center">
               <div className="mb-5 relative inline-block">
-                <div className="absolute inset-0 -m-7" style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.2) 0%, transparent 70%)', filter: 'blur(18px)' }} />
-                <img src={filmmakerLogo} alt="Filmmaker.OG" className="relative w-24 h-24 object-contain rounded-xl"
+                <div className="absolute inset-0 -m-7 animate-logo-breathe" style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.25) 0%, transparent 70%)', filter: 'blur(18px)' }} />
+                <img src={filmmakerLogo} alt="Filmmaker.OG" className="relative w-[104px] h-[104px] object-contain rounded-xl"
                   style={{ filter: 'brightness(1.15) drop-shadow(0 0 28px rgba(212,175,55,0.45))' }} />
               </div>
               <p className="text-text-dim text-sm tracking-[0.35em] uppercase mb-4 font-semibold">Demystifying Film Finance</p>
               <h1 className="font-bebas text-[clamp(2rem,7vw,3.2rem)] leading-[1.05] text-gold mb-4">
-                SEE WHERE EVERY DOLLAR <span className="text-white">GOES</span>
+                SEE WHERE EVERY DOLLAR<br /><span className="text-white">GOES</span>
               </h1>
               <p className="text-text-mid text-sm font-medium leading-relaxed max-w-sm mx-auto mb-6">
                 Before you raise a dollar or sign a deal, know exactly who gets
@@ -540,18 +540,20 @@ const Index = () => {
           <SectionFrame id="faq">
             <div ref={reveal6.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", reveal6.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
               <SectionHeader icon={HelpCircle} eyebrow="Common Questions" title={<>WHAT FILMMAKERS <span className="text-white">ASK</span></>} subtitle="Straight answers. No jargon." plainSubtitle />
-              <Accordion type="single" collapsible className="w-full">
-                {faqs.map((faq, i) => (
-                  <AccordionItem key={faq.q} value={`faq-${i}`} className="border-border-subtle">
-                    <AccordionTrigger className="text-text-primary hover:text-text-mid hover:no-underline text-base font-medium text-left">
-                      {faq.q}
-                    </AccordionTrigger>
-                    <AccordionContent className="text-text-dim text-sm leading-relaxed">
-                      {faq.a}
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-              </Accordion>
+              <div className="bg-bg-card rounded-xl px-5 border border-border-subtle">
+                <Accordion type="single" collapsible className="w-full">
+                  {faqs.map((faq, i) => (
+                    <AccordionItem key={faq.q} value={`faq-${i}`} className="border-border-subtle">
+                      <AccordionTrigger className="text-text-primary hover:text-text-mid hover:no-underline text-base font-medium text-left">
+                        {faq.q}
+                      </AccordionTrigger>
+                      <AccordionContent className="text-text-dim text-sm leading-relaxed">
+                        {faq.a}
+                      </AccordionContent>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
+              </div>
             </div>
           </SectionFrame>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,6 +87,10 @@ export default {
           "0%": { width: "0%" },
           "100%": { width: "100%" },
         },
+        "logo-breathe": {
+          "0%, 100%": { opacity: "0.15" },
+          "50%": { opacity: "0.3" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -96,6 +100,7 @@ export default {
         "spotlight-beam": "spotlight-beam 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards",
         "focal-pulse": "focal-pulse 4s ease-in-out infinite",
         "progress-draw": "progress-draw 1.5s cubic-bezier(0.22, 1, 0.36, 1) forwards",
+        "logo-breathe": "logo-breathe 3.5s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
Design System Review — Full Changelog
16 commits | 46 files changed | 557 additions, 476 deletions
Strategy & Foundation
Landing page strategy document — Added LANDING_PAGE_STRATEGY.md outlining the conversion-focused restructure: lead with pain, prove value, remove friction
Font weight enforcement — Locked Inter to 400/600, Roboto Mono to 500 only. Swapped body font to DM Sans for readability
Design system token cleanup — Tightened src/lib/design-system.ts and src/index.css (40 lines of CSS variable refinements)
Landing Page (Index.tsx) — Complete Overhaul
The landing page was rewritten from scratch across multiple passes:

Layout & Structure

Hero: reduced from 85vh to 70vh, centered vertically, removed excessive whitespace
Logo: sized up to 104px with a slow breathing gold glow pulse animation (logo-breathe keyframe, 3.5s cycle)
Headline: "SEE WHERE EVERY DOLLAR / GOES" — GOES on its own line in white, rest in gold
Killed scroll-snap behavior for smoother mobile scrolling
Added SectionFrame component — every section gets a gold left-border accent, alternating bg-bg-elevated / bg-bg-surface backgrounds, top gradient line
Fixed flex overflow clipping bug (min-w-0 on flex children) that was cutting off all section content on the right
Scroll Reveal

Removed the progressive blur reveal (didn't work well on mobile)
Replaced with clean one-shot slide-up animation using IntersectionObserver (threshold 0.15)
Staggered child animations within each section (120ms delay per item)
Copy Rewrites

Eyebrow: "Free Film Finance Simulator" → "Demystifying Film Finance"
Problem section title: "What Hollywood Doesn't Want You to Know"
Industry title: "Knowledge Isn't Cheap" / subtitle: "What they didn't teach you in film school"
Step 4: renamed to "Track the Recoupment"
Final CTA: "Stop Guessing. Start Closing." / button: "START NOW"
Every section title has one white accent word (KNOW, OUT, CHEAP, WITH, ASK, CLOSING)
Eliminated repetition of "accessible" across sections
Component Changes

"What You Get" section: converted from accordion to stacked cards with gold left-borders (accordion kept only for FAQ)
Problem cards: horizontal swipe with chevron nav + index counter (1/3)
Waterfall explainer: embedded mini-diagram with icon progression
Industry cost cards: gold left-border treatment matching the section frame style
FAQ: wrapped accordion in bg-bg-card inner card for visual containment
Learn More button: upgraded to ghost-gold button style
All CTAs unified: same h-16, bg-gold-cta-subtle, border-gold-cta-muted, shadow-button
Hamburger Menu (MobileMenu.tsx)
Briefly changed to 2x2 grid, then reverted back to standard 3-line animated hamburger per user request
Other Pages & Components (minor token updates)
~30 UI components and pages received small cn() class name updates to align with the refined design token system (border colors, text colors, background tokens)
WaterfallInfo.tsx: 44 lines of styling adjustments for consistency
Calculator components: minor token alignment across Budget, Deal, Stack, and Waterfall tabs
Tailwind Config
Added logo-breathe keyframe + animation (3.5s ease-in-out infinite, opacity 0.15→0.3)
Existing keyframes: focal-pulse, spotlight-beam, progress-draw, fade-in, pulse-subtle