### PR TITLE
v2: Kill horizontal scroll, restore vertical cards + Waterfall explainer

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,15 +43,12 @@ const SHARE_TEXT = "Free film finance simulator — model your deal structure, c
 const SHARE_TITLE = "FILMMAKER.OG — See Where Every Dollar Goes";
 
 /* ═══════════════════════════════════════════════════════════════════
-   HOLLYWOOD SCROLL CARDS — merged Problem + Waterfall + Industry Costs
+   PROBLEM CARDS — tighter copy, vertical layout
    ═══════════════════════════════════════════════════════════════════ */
-const hollywoodCards = [
-  { icon: Receipt, label: "The Pecking Order", text: "Distributors take fees first. Lenders recoup next. Then equity. You're last — unless you know the structure." },
-  { icon: Gavel, label: "The Hidden Playbook", text: "Recoupment schedules, fee waterfalls, P&A overages. Hollywood wrote the rules — and never shared them." },
-  { icon: Waves, label: "The Waterfall", text: "The financial structure that determines who gets paid, in what order, and how much. Most filmmakers have never seen one." },
-  { icon: Calculator, label: "Consultants: $10K–$30K", text: "That's what a finance consultant charges to build the model you're about to build yourself." },
-  { icon: Gavel, label: "Lawyers: $5K–$15K", text: "Entertainment attorneys charge this per deal analysis. Same math. Different invoice." },
-  { icon: EyeOff, label: "Free. Right Here.", text: "The same analysis, the same language, the same leverage — no gatekeepers, no invoices, no catch." },
+const problemCards = [
+  { icon: Receipt, title: "There's a pecking order.", body: "Distributors take fees first. Lenders recoup next. Then equity. You're last in line — unless you understand the structure well enough to negotiate your position." },
+  { icon: Gavel, title: "The rules exist. Nobody shared them.", body: "Recoupment schedules, fee waterfalls, P&A overages — Hollywood has run this playbook for decades. It's complicated by design, not by accident." },
+  { icon: EyeOff, title: "Learn the language. Level the field.", body: "Capital stacks, waterfall structures, producer corridors — the filmmakers who close deals speak this language fluently. Now you can too." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -166,8 +163,10 @@ const Index = () => {
   const [linkCopied, setLinkCopied] = useState(false);
 
   // One-shot reveal refs for each section
-  const revealHollywood = useReveal();
+  const revealProblem = useReveal();
+  const revealWaterfall = useReveal();
   const reveal3 = useReveal();
+  const revealCosts = useReveal();
   const reveal5 = useReveal();
   const reveal6 = useReveal();
 
@@ -319,50 +318,71 @@ const Index = () => {
           {/* section divider */}
           <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
 
-          {/* ── WHAT HOLLYWOOD DOESN'T WANT YOU TO KNOW (merged scroll) ── */}
-          <SectionFrame id="hollywood">
-            <div ref={revealHollywood.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealHollywood.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
-              <SectionHeader icon={Lock} eyebrow="What They Didn't Teach You In Film School" title={<>WHAT HOLLYWOOD DOESN&apos;T WANT YOU TO <span className="text-white">KNOW</span></>} />
-
-              {/* Horizontal scroll strip */}
-              <div className="overflow-x-auto scrollbar-hide -mx-2 px-2 pb-2">
-                <div className="flex gap-3" style={{ width: 'max-content' }}>
-                  {hollywoodCards.map((card, i) => {
-                    const Icon = card.icon;
-                    const isLast = i === hollywoodCards.length - 1;
-                    return (
-                      <div
-                        key={i}
-                        className={cn(
-                          "w-[240px] flex-shrink-0 rounded-xl border overflow-hidden transition-all duration-500",
-                          isLast
-                            ? "border-gold/30 bg-gold/[0.08]"
-                            : "border-border-subtle bg-bg-card",
-                          revealHollywood.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                        )}
-                        style={{ transitionDelay: revealHollywood.visible ? `${i * 80}ms` : "0ms" }}
-                      >
-                        <div className={cn("h-1", isLast ? "bg-gold" : "bg-gradient-to-r from-gold via-gold/60 to-gold/20")} />
-                        <div className="p-4 flex flex-col h-[160px]">
-                          <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center mb-3", isLast ? "bg-gold/20 border border-gold/40" : "bg-bg-elevated border border-border-subtle")}>
-                            <Icon className="w-4 h-4 text-gold" />
-                          </div>
-                          <p className={cn("font-bebas text-[17px] tracking-[0.06em] uppercase mb-2", isLast ? "text-gold" : "text-gold")}>{card.label}</p>
-                          <p className={cn("text-xs leading-relaxed flex-1", isLast ? "text-gold/80" : "text-text-dim")}>{card.text}</p>
+          {/* ── THE PROBLEM ── */}
+          <SectionFrame id="problem">
+            <div ref={revealProblem.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealProblem.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+              <SectionHeader icon={Lock} eyebrow="The Problem" title={<>WHAT HOLLYWOOD DOESN&apos;T WANT YOU TO <span className="text-white">KNOW</span></>} />
+              <div className="space-y-3">
+                {problemCards.map((card, i) => {
+                  const Icon = card.icon;
+                  return (
+                    <div key={i} className={cn("flex rounded-xl overflow-hidden border border-border-subtle hover:border-gold/20 transition-colors", staggerChild(revealProblem.visible))} style={staggerDelay(i, revealProblem.visible)}>
+                      <div className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20" />
+                      <div className="flex-1 bg-bg-card p-5">
+                        <div className="flex items-start gap-3 mb-2">
+                          <Icon className="w-4 h-4 text-gold flex-shrink-0 mt-1" />
+                          <h3 className="font-bebas text-[22px] tracking-[0.06em] uppercase text-gold">{card.title}</h3>
                         </div>
+                        <p className="text-text-mid text-sm leading-relaxed pl-7">{card.body}</p>
                       </div>
-                    );
-                  })}
-                </div>
+                    </div>
+                  );
+                })}
               </div>
-
-              {/* Scroll hint */}
-              <p className="text-text-dim/40 text-xs text-center mt-3 tracking-wider">SWIPE &rarr;</p>
             </div>
           </SectionFrame>
 
+          {/* ── THE WATERFALL (standalone) ── */}
+          <section id="waterfall-explainer" className="snap-section px-4 py-6">
+            <div className="flex rounded-2xl overflow-hidden border border-white/[0.06]">
+              <div className="w-1.5 flex-shrink-0 bg-gold" style={{ boxShadow: '0 0 14px rgba(212,175,55,0.35)' }} />
+              <div className="flex-1 min-w-0 bg-bg-elevated">
+                <div className="h-[2px] bg-gradient-to-r from-gold/40 via-gold/25 to-transparent" />
+                <div ref={revealWaterfall.ref} className={cn("p-6 md:p-8 max-w-2xl mx-auto transition-all duration-500 ease-out", revealWaterfall.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+                  <p className="font-bebas text-3xl md:text-4xl tracking-[0.1em] text-gold text-center mb-5">THE WATERFALL</p>
+                  <div className="relative flex items-start justify-between max-w-[300px] mx-auto mb-5">
+                    <div className="absolute top-[14px] left-[28px] right-[28px] h-[1px] bg-gradient-to-r from-gold/30 via-gold/50 to-gold/30" />
+                    {[
+                      { icon: DollarSign, label: "Budget" },
+                      { icon: Layers, label: "Stack" },
+                      { icon: Handshake, label: "Deal" },
+                      { icon: Waves, label: "Waterfall" },
+                    ].map((s) => {
+                      const StepIcon = s.icon;
+                      return (
+                        <div key={s.label} className="relative flex flex-col items-center gap-1.5 w-[56px]">
+                          <div className="w-7 h-7 rounded-full bg-bg-card border border-gold/40 flex items-center justify-center">
+                            <StepIcon className="w-3 h-3 text-gold" />
+                          </div>
+                          <span className="text-xs text-text-dim tracking-wider">{s.label}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <p className="text-text-mid text-sm leading-relaxed text-center max-w-xs mx-auto">
+                    Most filmmakers have never seen one. The <span className="text-gold font-semibold">waterfall</span> determines who gets paid back, in what order, and how much. It's the key to package financing.
+                  </p>
+                  <button onClick={() => navigate('/waterfall-info')}
+                    className="block mx-auto mt-5 px-6 py-2.5 text-sm font-semibold tracking-[0.15em] uppercase transition-all rounded-md bg-gold/[0.04] border border-gold/25 text-gold hover:bg-gold/[0.08] hover:border-gold/40 active:scale-[0.97]">
+                    LEARN MORE &rarr;
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
           {/* section divider */}
-          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" /></div>
 
           {/* ── HOW IT WORKS ── */}
           <SectionFrame id="how-it-works" alt>
@@ -395,6 +415,37 @@ const Index = () => {
                   className="h-16 px-10 text-base font-bold tracking-[0.14em] transition-all active:scale-[0.96] rounded-md bg-gold/[0.14] border-2 border-gold/40 text-gold shadow-[0_0_20px_rgba(212,175,55,0.25)] hover:shadow-[0_0_30px_rgba(212,175,55,0.4)] hover:border-gold/60 hover:bg-gold/[0.18]">
                   MODEL YOUR DEAL
                 </button>
+              </div>
+            </div>
+          </SectionFrame>
+
+          {/* section divider */}
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+
+          {/* ── KNOWLEDGE ISN'T CHEAP (compact) ── */}
+          <SectionFrame id="industry-charges">
+            <div ref={revealCosts.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealCosts.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+              <SectionHeader icon={Calculator} eyebrow="What They Didn't Teach You In Film School" title={<>KNOWLEDGE ISN&apos;T <span className="text-white">CHEAP</span></>} />
+              <div className="grid grid-cols-2 gap-3 mb-4">
+                {[
+                  { icon: Gavel, cost: "$5K–$15K", label: "Entertainment Lawyer" },
+                  { icon: Calculator, cost: "$10K–$30K", label: "Finance Consultant" },
+                ].map((item, i) => {
+                  const Icon = item.icon;
+                  return (
+                    <div key={item.label} className={cn("rounded-xl border border-border-subtle bg-bg-card p-4 text-center", staggerChild(revealCosts.visible))} style={staggerDelay(i, revealCosts.visible)}>
+                      <div className="w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center mx-auto mb-2">
+                        <Icon className="w-4 h-4 text-gold" />
+                      </div>
+                      <p className="font-mono text-lg font-medium text-text-primary line-through decoration-text-dim/30">{item.cost}</p>
+                      <p className="text-text-dim text-xs tracking-wider uppercase mt-0.5">{item.label}</p>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="text-center px-6 py-4 rounded-xl bg-gold/[0.06] border border-gold/20 max-w-xs mx-auto">
+                <p className="font-bebas text-4xl tracking-[0.1em] text-gold">FREE</p>
+                <p className="text-text-dim text-sm tracking-wider mt-1">The same analysis. No catch.</p>
               </div>
             </div>
           </SectionFrame>


### PR DESCRIPTION
- Replace horizontal scroll strip with 3 vertical problem cards (tighter copy)
- Restore standalone Waterfall explainer with step diagram + Learn More link
- Cost comparison down to 2 items (lawyer + consultant) from 4, compact layout
- "What they didn't teach you in film school" stays as cost section eyebrow
- Keep hero CTA pulse and tight deliverables receipt from v1

Flow: Hero → Problem → Waterfall → How It Works → Costs → Deliverables → FAQ → CTA

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7