### PR TITLE
Improve landing copy, fix waterfall tax credit bug, update SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <title>FILMMAKER.OG — See Where Every Dollar Goes</title>
-    <meta name="description" content="Free film finance simulator. Model your deal structure, capital stack, and revenue waterfall — the same analysis entertainment lawyers charge $5K–$15K to produce." />
+    <title>FILMMAKER.OG — Waterfall Calculator</title>
+    <meta name="description" content="See where every dollar goes. Model your film's recoupment waterfall and break-even in minutes—clean, mobile-first, producer-friendly." />
     <meta name="author" content="Filmmaker.OG" />
 
-    <meta property="og:title" content="FILMMAKER.OG — See Where Every Dollar Goes" />
-    <meta property="og:description" content="Free film finance simulator. Model your deal structure, capital stack, and revenue waterfall. Professional exports from $197." />
+    <meta property="og:title" content="FILMMAKER.OG — Waterfall Calculator" />
+    <meta property="og:description" content="See where every dollar goes. Model your recoupment waterfall + break-even in minutes." />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Filmmaker.OG" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="FILMMAKER.OG — See Where Every Dollar Goes" />
-    <meta name="twitter:description" content="Free film finance simulator. Model your deal structure, capital stack, and revenue waterfall." />
+    <meta name="twitter:title" content="FILMMAKER.OG — Waterfall Calculator" />
+    <meta name="twitter:description" content="Model your recoupment waterfall + break-even in minutes." />
   </head>
 
   <body>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -294,6 +294,19 @@ const Index = () => {
                 Know who gets paid first, in what order, and what's left for you. Understand the deal before you sign it.
               </p>
 
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+                {[
+                  { t: "Break-even clarity", d: "Know what your film must earn before investors recoup." },
+                  { t: "Recoupment order", d: "See who gets paid first, and what's left after fees + debt." },
+                  { t: "Investor-ready story", d: "Explain the math in plain English without losing confidence." },
+                ].map((b) => (
+                  <div key={b.t} className="rounded-xl border border-border-subtle bg-bg-card p-4 text-left">
+                    <div className="text-gold text-sm font-semibold tracking-wide">{b.t}</div>
+                    <div className="text-text-mid text-xs leading-relaxed mt-1">{b.d}</div>
+                  </div>
+                ))}
+              </div>
+
               {isReturningUser ? (
                 <div className="w-full max-w-[320px] mx-auto space-y-3">
                   <button onClick={handleContinueClick}
@@ -310,7 +323,7 @@ const Index = () => {
                 <div className="w-full max-w-[320px] mx-auto">
                   <button onClick={handleStartClick}
                     className="w-full h-16 text-base font-bold tracking-[0.14em] transition-all active:scale-[0.96] rounded-md bg-gold/[0.18] border-2 border-gold/50 text-gold animate-cta-glow-pulse hover:border-gold/70 hover:bg-gold/[0.22]">
-                    RUN YOUR FIRST SCENARIO
+                    RUN THE CALCULATOR
                   </button>
                 </div>
               )}
@@ -439,11 +452,20 @@ const Index = () => {
                 })}
               </div>
 
+              <div className="mt-5 rounded-xl bg-gold/[0.06] border border-gold/20 px-5 py-4">
+                <p className="text-gold text-xs tracking-[0.2em] uppercase font-semibold">Assumptions (plain English)</p>
+                <ul className="mt-3 space-y-2 text-text-mid text-sm leading-relaxed">
+                  <li>Percent fees are applied to gross revenue before recoupment.</li>
+                  <li>Marketing is treated as a fixed expense cap (not a percentage).</li>
+                  <li>Tax credits reduce the amount that must be recouped (they don't magically increase revenue).</li>
+                </ul>
+              </div>
+
               {/* Mid-page CTA — catch fast deciders */}
               <div className="text-center mt-5 -mb-2">
                 <button onClick={handleStartClick}
                   className="h-16 px-10 text-base font-bold tracking-[0.14em] transition-all active:scale-[0.96] rounded-md bg-gold/[0.14] border-2 border-gold/40 text-gold shadow-[0_0_20px_rgba(212,175,55,0.25)] hover:shadow-[0_0_30px_rgba(212,175,55,0.4)] hover:border-gold/60 hover:bg-gold/[0.18]">
-                  BUILD YOUR CAPITAL STACK
+                  RUN THE CALCULATOR
                 </button>
               </div>
             </div>
@@ -561,7 +583,7 @@ const Index = () => {
                   </p>
                   <button onClick={handleStartClick}
                     className="w-full max-w-[320px] h-16 text-base font-bold tracking-[0.14em] transition-all active:scale-[0.96] rounded-md bg-gold/[0.14] border-2 border-gold/40 text-gold shadow-[0_0_20px_rgba(212,175,55,0.25)] hover:shadow-[0_0_30px_rgba(212,175,55,0.4)] hover:border-gold/60 hover:bg-gold/[0.18]">
-                    SEE WHERE YOUR MONEY GOES
+                    RUN THE CALCULATOR
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Landing page (Index.tsx):
- Add benefits strip (break-even / recoupment / investor-ready) above Hero CTA for promise → proof → action flow
- Unify all CTA labels to "RUN THE CALCULATOR" for consistency
- Add plain-English assumptions block in How It Works section

SEO (index.html):
- Update title/OG/Twitter meta to "Waterfall Calculator" framing
- Align descriptions with actual landing page promise

Waterfall bug fix (waterfall.ts):
- Cap tax credits so totalHurdle can't go negative (was inflating profitPool beyond total revenue with large credits)
- Fix misleading "STANDARD $75K" marketing detail to just "EXPENSE CAP"

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7