### PR TITLE
Rebuild landing page to 7-section conversion architecture

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,11 @@ import {
   Film,
   Waves,
   Lock,
+  Award,
+  BarChart3,
+  BookOpen,
+  FileSpreadsheet,
+  Presentation,
 } from "lucide-react";
 import filmmakerLogo from "@/assets/filmmaker-logo.jpg";
 import Header from "@/components/Header";
@@ -41,27 +46,65 @@ const SHARE_TITLE = "FILMMAKER.OG — See Where Every Dollar Goes";
    PROBLEM CARDS — tighter copy, vertical layout
    ═══════════════════════════════════════════════════════════════════ */
 const problemCards = [
-  { icon: Receipt, title: "You're last in line.", body: "Fees and lenders recoup first; producers get what's left unless you structure the order." },
-  { icon: Gavel, title: "The rules exist. You just haven't seen them.", body: "Contracts hide recoupment behind jargon — waterfalls make the order visible." },
-  { icon: EyeOff, title: "Producers who close speak this language.", body: "If you can explain recoupment clearly, you negotiate from strength." },
+  { icon: Receipt, title: "There's a pecking order.", body: "Distributors take fees first. Lenders recoup next. Then equity. You're last in line — unless you understand the structure well enough to negotiate your position." },
+  { icon: Gavel, title: "The rules exist. Nobody shared them.", body: "Recoupment schedules, fee waterfalls, P&A overages — Hollywood has run this playbook for decades. It's complicated by design, not by accident." },
+  { icon: EyeOff, title: "Learn the language. Level the field.", body: "Capital stacks, waterfall structures, producer corridors — the filmmakers who close deals speak this language fluently. Now you can too." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    FAQ DATA
    ═══════════════════════════════════════════════════════════════════ */
 const faqs = [
-  { q: "Who is this for?", a: "Independent producers, directors, and investors. If you intend to sell your film for profit, you need to understand recoupment." },
-  { q: "What's free vs. paid?", a: "Free: full simulator, waterfall chart, glossary, unlimited scenarios. Paid: professional exports (Excel/PDF) from $197." },
-  { q: "What assumptions does this model use?", a: "Fees are applied to gross before recoupment; marketing is treated as a fixed cap; tax credits reduce what must be recouped." },
+  { q: "Who is this for?", a: "Independent producers, directors, and investors. Whether you're raising $50K or $5M, the mechanics of recoupment are the same. If you intend to sell your film for profit, you need this." },
+  { q: "How does the calculator work?", a: "Four steps: set your budget, build your capital stack, structure your deal, and track exactly where every dollar goes in the waterfall. Takes about 2 minutes." },
+  { q: "Is this financial or legal advice?", a: "No. This is a simulation tool for estimation and planning purposes only. Always consult a qualified entertainment attorney or accountant for final deal structures." },
+  { q: "Is the calculator free?", a: "Yes. The simulator, waterfall chart, glossary, and unlimited scenarios are completely free. Premium exports — the Excel workbook and investor-ready PDF — are paid add-ons." },
+  { q: "What's free vs. paid?", a: "Free: full waterfall simulation, visual chart, deal glossary, and unlimited scenario runs. Paid: downloadable Excel workbook and investor-ready PDF export. The simulation itself has no paywall." },
+  { q: "Do I need an account?", a: "No. You can use the calculator without signing up. If you want to save your work, we offer a simple magic link — no password required." },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
    HOW IT WORKS STEPS (static — not clickable)
    ═══════════════════════════════════════════════════════════════════ */
 const steps = [
-  { num: "01", title: "Set Your Budget", desc: "Your real cost basis.", icon: DollarSign },
-  { num: "02", title: "Build Your Capital Stack", desc: "Equity, debt, credits — who gets repaid.", icon: Layers },
-  { num: "03", title: "Run the Waterfall", desc: "Fees → debt → equity → profit split.", icon: Waves },
+  { num: "01", title: "Set Your Budget", desc: "Total production cost plus guild signatories. This is your baseline.", icon: DollarSign },
+  { num: "02", title: "Build Your Capital Stack", desc: "Equity, pre-sales, gap, tax incentives — where the money comes from and how each source gets paid back.", icon: Layers },
+  { num: "03", title: "Structure Your Deal", desc: "Acquisition price, distribution fees, P&A spend. See how much actually makes it back.", icon: Handshake },
+  { num: "04", title: "Track the Recoupment", desc: "Every dollar through the priority chain. Who gets paid first. What's left for you.", icon: Waves },
+];
+
+/* ═══════════════════════════════════════════════════════════════════
+   WATERFALL FLOW DIAGRAM STEPS
+   ═══════════════════════════════════════════════════════════════════ */
+const waterfallSteps = [
+  { icon: DollarSign, label: "Budget" },
+  { icon: Layers, label: "Stack" },
+  { icon: Handshake, label: "Deal" },
+  { icon: Waves, label: "Waterfall" },
+];
+
+/* ═══════════════════════════════════════════════════════════════════
+   INDUSTRY COSTS (price anchor)
+   ═══════════════════════════════════════════════════════════════════ */
+const industryCosts = [
+  { icon: Gavel, cost: "$5K–$15K", label: "Entertainment Lawyer", note: "Per deal analysis" },
+  { icon: Calculator, cost: "$10K–$30K", label: "Finance Consultant", note: "Financial modeling" },
+  { icon: Handshake, cost: "5–15%", label: "Producer's Rep", note: "Percentage of deal" },
+  { icon: Film, cost: "10–25%", label: "Sales Agent", note: "Of gross revenue" },
+];
+
+/* ═══════════════════════════════════════════════════════════════════
+   DELIVERABLES
+   ═══════════════════════════════════════════════════════════════════ */
+const freeDeliverables = [
+  { icon: BarChart3, line: "Visual waterfall chart — who gets paid, in what order" },
+  { icon: BookOpen, line: "Full glossary — every deal term in plain English" },
+  { icon: Waves, line: "Unlimited scenarios — adjust the variables, re-run as often as you want" },
+];
+
+const premiumDeliverables = [
+  { icon: FileSpreadsheet, line: "6-sheet Excel workbook — waterfall, capital stack, investor returns" },
+  { icon: Presentation, line: "Investor-ready PDF — plain language, zero jargon" },
 ];
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -156,8 +199,10 @@ const Index = () => {
 
   // One-shot reveal refs for each section
   const revealProblem = useReveal();
-  const reveal3 = useReveal();
-  const reveal6 = useReveal();
+  const revealWaterfall = useReveal();
+  const revealSteps = useReveal();
+  const revealPrice = useReveal();
+  const revealFaq = useReveal();
 
   const savedState = useMemo(() => {
     try {
@@ -272,19 +317,19 @@ const Index = () => {
                 <img src={filmmakerLogo} alt="Filmmaker.OG" className="relative w-[96px] h-[96px] object-contain rounded-xl"
                   style={{ filter: 'brightness(1.15) drop-shadow(0 0 28px rgba(212,175,55,0.45))' }} />
               </div>
-              <p className="text-text-dim text-sm tracking-[0.35em] uppercase mb-4 font-semibold">Free Film Finance Simulator</p>
+              <p className="text-text-dim text-sm tracking-[0.35em] uppercase mb-4 font-semibold">Demystifying Film Finance</p>
               <h1 className="font-bebas text-[clamp(2rem,7vw,3.2rem)] leading-[1.05] text-gold mb-4">
                 SEE WHERE EVERY<br /><span className="text-white">DOLLAR GOES</span>
               </h1>
-              <p className="text-text-mid text-sm font-medium leading-relaxed max-w-sm mx-auto mb-6">
-                Model your budget, capital stack, and recoupment waterfall in under 2 minutes. Free. No account required to start.
+              <p className="text-text-mid text-sm font-medium leading-relaxed max-w-[380px] mx-auto mb-6">
+                Know who gets paid first, in what order, and what's left for you. Understand the deal before you sign it.
               </p>
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
                 {[
-                  { t: "Break-even number", d: "Know the revenue your film needs before anyone profits." },
-                  { t: "Priority waterfall", d: "See who gets paid first — and what's left for producers." },
-                  { t: "Investor-ready language", d: "Walk into the room speaking the same language as the money." },
+                  { t: "Break-even clarity", d: "Know what your film must earn before investors recoup." },
+                  { t: "Recoupment order", d: "See who gets paid first, and what's left after fees + debt." },
+                  { t: "Investor-ready story", d: "Explain the math in plain English without losing confidence." },
                 ].map((b) => (
                   <div key={b.t} className="rounded-xl border border-border-subtle bg-bg-card p-4 text-left">
                     <div className="text-gold text-sm font-semibold tracking-wide">{b.t}</div>
@@ -320,7 +365,7 @@ const Index = () => {
           {/* section divider */}
           <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
 
-          {/* ── THE PROBLEM + PRICE ANCHOR ── */}
+          {/* ── § 2: THE PROBLEM ── */}
           <SectionFrame id="problem">
             <div ref={revealProblem.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealProblem.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
               <SectionHeader icon={Lock} eyebrow="The Problem" title={<>THE DEAL IS DESIGNED AGAINST <span className="text-white">YOU</span></>} />
@@ -341,34 +386,47 @@ const Index = () => {
                   );
                 })}
               </div>
+            </div>
+          </SectionFrame>
 
-              {/* Price anchor — merged inline */}
-              <div className="mt-6">
-                <p className="text-text-dim text-xs tracking-[0.2em] uppercase font-semibold mb-3">Industry rates</p>
-                <p className="text-text-mid text-sm leading-relaxed mb-4">This analysis is usually paid. Here you can run it free.</p>
-                <div className="grid grid-cols-2 gap-3 mb-4">
-                  {[
-                    { icon: Gavel, cost: "$5K–$15K", label: "Entertainment Lawyer" },
-                    { icon: Calculator, cost: "$10K–$30K", label: "Finance Consultant" },
-                    { icon: Handshake, cost: "5–15%", label: "Producer's Rep" },
-                    { icon: Film, cost: "10–25%", label: "Sales Agent" },
-                  ].map((item, i) => {
-                    const Icon = item.icon;
+          {/* section divider */}
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+
+          {/* ── § 3: THE WATERFALL EXPLAINER ── */}
+          <SectionFrame id="waterfall-explainer" alt>
+            <div ref={revealWaterfall.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealWaterfall.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+              <SectionHeader icon={Waves} eyebrow="What They Didn't Teach You In Film School" title={<>FROM FIRST MONEY IN TO LAST MONEY <span className="text-white">OUT</span></>} />
+
+              {/* Flow diagram */}
+              <div className="rounded-xl bg-gold/[0.06] border border-gold/20 p-6 mb-6">
+                <div className="relative flex justify-between items-start max-w-[300px] mx-auto">
+                  {/* Connecting line */}
+                  <div className="absolute left-[28px] right-[28px] top-[14px] h-[1px] bg-gradient-to-r from-gold/30 via-gold/50 to-gold/30" />
+                  {waterfallSteps.map((ws) => {
+                    const Icon = ws.icon;
                     return (
-                      <div key={item.label} className={cn("rounded-xl border border-border-subtle bg-bg-card p-4 text-center", staggerChild(revealProblem.visible))} style={staggerDelay(i + 3, revealProblem.visible)}>
-                        <div className="w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center mx-auto mb-2">
-                          <Icon className="w-4 h-4 text-gold" />
+                      <div key={ws.label} className="flex flex-col items-center gap-1.5 w-14 relative z-10">
+                        <div className="w-7 h-7 rounded-full bg-bg-card border border-gold/40 flex items-center justify-center">
+                          <Icon className="w-3 h-3 text-gold" />
                         </div>
-                        <p className="font-mono text-lg font-medium text-text-primary line-through decoration-text-dim/30">{item.cost}</p>
-                        <p className="text-text-dim text-xs tracking-wider uppercase mt-0.5">{item.label}</p>
+                        <span className="text-text-dim text-xs tracking-wider">{ws.label}</span>
                       </div>
                     );
                   })}
                 </div>
-                <div className="text-center px-6 py-4 rounded-xl bg-gold/[0.06] border border-gold/20 max-w-xs mx-auto">
-                  <p className="font-bebas text-4xl tracking-[0.1em] text-gold">FREE</p>
-                  <p className="text-text-dim text-sm tracking-wider mt-1">Premium exports available from $197.</p>
-                </div>
+              </div>
+
+              {/* Explanatory paragraph */}
+              <p className="text-text-mid text-sm leading-relaxed text-center max-w-[320px] mx-auto mb-5">
+                Most filmmakers have never seen one. The <span className="text-gold font-semibold">waterfall</span> determines who gets paid back, in what order, and how much. It's the key to package financing.
+              </p>
+
+              {/* Learn More link */}
+              <div className="text-center">
+                <button onClick={() => navigate("/waterfall-info")}
+                  className="text-gold/70 hover:text-gold text-sm font-semibold tracking-[0.15em] uppercase bg-gold/[0.04] border border-gold/25 rounded-md px-6 py-2.5 hover:bg-gold/[0.08] hover:border-gold/40 transition-all">
+                  LEARN MORE &rarr;
+                </button>
               </div>
             </div>
           </SectionFrame>
@@ -376,15 +434,15 @@ const Index = () => {
           {/* section divider */}
           <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" /></div>
 
-          {/* ── HOW IT WORKS ── */}
-          <SectionFrame id="how-it-works" alt>
-            <div ref={reveal3.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", reveal3.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
-              <SectionHeader icon={Film} eyebrow="How It Works" title={<>YOUR DEAL IN THREE <span className="text-white">STEPS</span></>} />
+          {/* ── § 4: HOW IT WORKS ── */}
+          <SectionFrame id="how-it-works">
+            <div ref={revealSteps.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealSteps.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+              <SectionHeader icon={Film} eyebrow="How It Works" title={<>YOUR DEAL IN FOUR <span className="text-white">STEPS</span></>} plainSubtitle subtitle="From budget to waterfall in under two minutes. No financial background required." />
               <div className="space-y-3">
                 {steps.map((step, i) => {
                   const Icon = step.icon;
                   return (
-                    <div key={step.num} className={staggerChild(reveal3.visible)} style={staggerDelay(i, reveal3.visible)}>
+                    <div key={step.num} className={staggerChild(revealSteps.visible)} style={staggerDelay(i, revealSteps.visible)}>
                       <div className="flex rounded-xl overflow-hidden border border-border-subtle hover:border-gold/20 transition-colors">
                         <div className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20" />
                         <div className="flex-1 bg-bg-card p-5">
@@ -406,9 +464,71 @@ const Index = () => {
           {/* section divider */}
           <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
 
-          {/* ── FAQ ── */}
+          {/* ── § 5: PRICE ANCHOR + DELIVERABLES ── */}
+          <SectionFrame id="price-anchor" alt>
+            <div ref={revealPrice.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealPrice.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+              <SectionHeader icon={Award} eyebrow="The Industry Standard" title={<>THIS KNOWLEDGE ISN'T CHEAP</>} plainSubtitle subtitle="You shouldn't need a $5,000 retainer from an entertainment attorney to understand your own deal." />
+
+              {/* Industry cost grid */}
+              <div className="grid grid-cols-2 gap-3 mb-5">
+                {industryCosts.map((item, i) => {
+                  const Icon = item.icon;
+                  return (
+                    <div key={item.label} className={cn("rounded-xl border border-border-subtle bg-bg-card p-5 text-center relative overflow-hidden", staggerChild(revealPrice.visible))} style={staggerDelay(i, revealPrice.visible)}>
+                      <div className="absolute top-0 right-0 w-8 h-8 pointer-events-none" style={{ background: 'radial-gradient(circle at top right, rgba(212,175,55,0.12) 0%, transparent 70%)', filter: 'blur(16px)' }} />
+                      <div className="w-9 h-9 rounded-lg bg-bg-elevated border border-border-subtle flex items-center justify-center mx-auto mb-3">
+                        <Icon className="w-4 h-4 text-gold" />
+                      </div>
+                      <p className="font-mono text-lg font-medium text-text-primary line-through decoration-text-dim/30">{item.cost}</p>
+                      <p className="text-text-dim text-xs tracking-wider uppercase mt-0.5">{item.label}</p>
+                      <p className="text-text-dim text-[13px] mt-1">{item.note}</p>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* FREE badge */}
+              <div className="text-center px-6 py-5 rounded-xl bg-gold/[0.06] border border-gold/20 max-w-[280px] mx-auto mb-6">
+                <p className="font-bebas text-4xl md:text-5xl tracking-[0.1em] text-gold">FREE</p>
+                <p className="text-text-dim text-[15px] tracking-wider mt-1">Premium exports available from $197.</p>
+              </div>
+
+              {/* Free tier deliverables */}
+              <p className="text-text-dim text-xs tracking-[0.2em] uppercase font-semibold mb-2">Free — always</p>
+              <div className="rounded-xl border border-border-subtle bg-bg-card divide-y divide-border-subtle mb-4">
+                {freeDeliverables.map((d) => {
+                  const Icon = d.icon;
+                  return (
+                    <div key={d.line} className="flex items-center gap-3 px-5 py-3.5">
+                      <Icon className="w-4 h-4 text-gold flex-shrink-0" />
+                      <span className="text-text-mid text-sm leading-snug">{d.line}</span>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Premium tier deliverables */}
+              <p className="text-text-dim text-xs tracking-[0.2em] uppercase font-semibold mb-2 mt-4">Premium exports</p>
+              <div className="rounded-xl border border-gold/20 bg-bg-card divide-y divide-border-subtle">
+                {premiumDeliverables.map((d) => {
+                  const Icon = d.icon;
+                  return (
+                    <div key={d.line} className="flex items-center gap-3 px-5 py-3.5">
+                      <Icon className="w-4 h-4 text-gold flex-shrink-0" />
+                      <span className="text-text-mid text-sm leading-snug">{d.line}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </SectionFrame>
+
+          {/* section divider */}
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+
+          {/* ── § 6: FAQ ── */}
           <SectionFrame id="faq">
-            <div ref={reveal6.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", reveal6.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
+            <div ref={revealFaq.ref} className={cn("max-w-2xl mx-auto transition-all duration-500 ease-out", revealFaq.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4")}>
               <SectionHeader icon={HelpCircle} eyebrow="Common Questions" title={<>WHAT FILMMAKERS <span className="text-white">ASK</span></>} />
               <div className="bg-bg-card rounded-xl px-5 border border-border-subtle">
                 <Accordion type="single" collapsible className="w-full">


### PR DESCRIPTION
Restructure Index.tsx from 5 sections to 7, following classic sales page framework: Hero → Problem → Waterfall Explainer → How It Works → Price Anchor + Deliverables → FAQ → Final CTA + Footer.

Key changes:
- Hero: eyebrow "Demystifying Film Finance", filmmaker-speak subhead
- Problem: single-purpose pain section, removed embedded price anchor
- NEW Waterfall Explainer: 4-icon flow diagram + educational paragraph
- How It Works: expanded from 3 to 4 steps matching calculator tabs
- NEW Price Anchor + Deliverables: industry costs grid, FREE badge, free/premium tier deliverable lists with gold border on premium
- FAQ: expanded from 3 to 6 questions covering key objections
- All new sections wired to IntersectionObserver reveal hooks

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7