### PR TITLE
Fix surface contrast, soften animations, improve divider visibility

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       <span className="text-left pr-4">{children}</span>
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200 mt-1" />
+      <ChevronDown className="h-4 w-4 shrink-0 text-gold transition-transform duration-200 mt-1" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));

--- a/src/index.css
+++ b/src/index.css
@@ -40,7 +40,7 @@
        Rule: Content always lives on --bg-card, never directly on --bg-void
        ═══════════════════════════════════════════════════════════════════ */
     --bg-void: #000000;
-    --bg-card: #070707;
+    --bg-card: #0F0F0F;
     --bg-surface: #111111;
     --bg-elevated: #0D0D0D;
     --bg-header: #0A0A0A;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,7 +177,7 @@ const staggerDelay = (index: number, visible: boolean): React.CSSProperties => (
 
 /** Class for stagger-animated child items */
 const staggerChild = (visible: boolean) =>
-  cn("transition-all duration-600 ease-out", visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5");
+  cn("transition-all duration-400 ease-out", visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2");
 
 /* ═══════════════════════════════════════════════════════════════════
    MAIN INDEX COMPONENT
@@ -340,7 +340,7 @@ const Index = () => {
           </section>
 
           {/* section divider */}
-          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/20 to-transparent" /></div>
 
           {/* ── § 2: THE PROBLEM ── */}
           <SectionFrame id="problem">
@@ -367,7 +367,7 @@ const Index = () => {
           </SectionFrame>
 
           {/* section divider */}
-          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/20 to-transparent" /></div>
 
           {/* ── § 3: HOW THE MONEY FLOWS (vertical cascade) ── */}
           <SectionFrame id="how-it-flows" alt>
@@ -404,7 +404,7 @@ const Index = () => {
           </SectionFrame>
 
           {/* section divider */}
-          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/20 to-transparent" /></div>
 
           {/* ── § 4: PRICE ANCHOR + DELIVERABLES ── */}
           <SectionFrame id="price-anchor">
@@ -429,7 +429,7 @@ const Index = () => {
               </div>
 
               {/* FREE badge */}
-              <div className="text-center px-6 py-5 rounded-xl bg-gold/[0.06] border border-gold/20 max-w-[280px] mx-auto mb-6">
+              <div className="text-center px-6 py-5 rounded-xl bg-gold/[0.06] border border-gold/20 max-w-[280px] mx-auto my-6">
                 <p className="font-bebas text-4xl md:text-5xl tracking-[0.1em] text-gold">FREE</p>
                 <p className="text-text-dim text-[15px] tracking-wider mt-1">Premium exports available from $197.</p>
               </div>
@@ -465,7 +465,7 @@ const Index = () => {
           </SectionFrame>
 
           {/* section divider */}
-          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/10 to-transparent" /></div>
+          <div className="px-8"><div className="h-[1px] bg-gradient-to-r from-transparent via-gold/20 to-transparent" /></div>
 
           {/* ── § 5: FAQ ── */}
           <SectionFrame id="faq">


### PR DESCRIPTION
- bg-card: #070707 → #0F0F0F — cards now read as surfaces on OLED, kills gold-on-void vibration
- staggerChild: translate-y-5 → translate-y-2, duration-600 → duration-400 — content fades in softly instead of jumping up to greet you
- Section dividers: via-gold/10 → via-gold/20 — visible whisper, not silent
- FREE badge: mb-6 → my-6 — breathing room above and below
- FAQ accordion chevron: explicit text-gold so expand affordance is clear

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7