### PR TITLE
Extend hero spotlight glow + style FAQ triggers in gold Bebas Neue

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -28,7 +28,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       <span className="text-left pr-4">{children}</span>
-      <ChevronDown className="h-4 w-4 shrink-0 text-gold transition-transform duration-200 mt-1" />
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200 mt-1 text-gold/60" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -300,7 +300,7 @@ const Index = () => {
           {/* ── HERO ── */}
           <section id="hero" className="snap-section min-h-[70vh] flex flex-col justify-center relative overflow-hidden">
             <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none animate-spotlight-pulse"
-              style={{ width: '100vw', height: '75vh', background: `radial-gradient(ellipse 50% 40% at 50% 10%, rgba(212,175,55,0.1) 0%, rgba(212,175,55,0.04) 40%, transparent 70%)` }} />
+              style={{ width: '100vw', height: '100vh', background: `radial-gradient(ellipse 50% 50% at 50% 10%, rgba(212,175,55,0.1) 0%, rgba(212,175,55,0.04) 50%, transparent 80%)` }} />
             <div className="relative px-6 py-4 max-w-xl mx-auto text-center">
               <div className="mb-5 relative inline-block">
                 <div className="absolute inset-0 -m-7 animate-logo-breathe" style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.25) 0%, transparent 70%)', filter: 'blur(18px)' }} />
@@ -475,7 +475,7 @@ const Index = () => {
                 <Accordion type="single" collapsible className="w-full">
                   {faqs.map((faq, i) => (
                     <AccordionItem key={faq.q} value={`faq-${i}`} className="border-border-subtle">
-                      <AccordionTrigger className="text-text-primary hover:text-text-mid hover:no-underline text-base font-medium text-left">
+                      <AccordionTrigger className="font-bebas text-xl tracking-[0.06em] uppercase text-gold hover:text-gold/80 hover:no-underline text-left">
                         {faq.q}
                       </AccordionTrigger>
                       <AccordionContent className="text-text-dim text-sm leading-relaxed">


### PR DESCRIPTION
- Spotlight: 75vh→100vh, taller ellipse, longer gradient holds so gold glow carries past CTA into the Problem section
- FAQ triggers: Bebas Neue uppercase gold text matching card title pattern
- Chevron: text-gold/60 for intentional subdued arrow color

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7