### PR TITLE
Add Finance Plan Builder: guided intake form, new product architectur…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Calculator from "./pages/Calculator";
 import Store from "./pages/Store";
 import StorePackage from "./pages/StorePackage";
 import StoreCompare from "./pages/StoreCompare";
+import BuildYourPlan from "./pages/BuildYourPlan";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -36,6 +37,7 @@ const App = () => (
           <Route path="/store" element={<Store />} />
           <Route path="/store/compare" element={<StoreCompare />} />
           <Route path="/store/:slug" element={<StorePackage />} />
+          <Route path="/build-your-plan" element={<BuildYourPlan />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/intake/IntakeStep1.tsx
+++ b/src/components/intake/IntakeStep1.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  GENRE_OPTIONS,
+  type IntakeFormData,
+} from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  updateFormData: (updates: Partial<IntakeFormData>) => void;
+  onNext: () => void;
+}
+
+const IntakeStep1 = ({ formData, updateFormData, onNext }: Props) => {
+  const [showCustomGenre, setShowCustomGenre] = useState(
+    formData.genre !== "" && !GENRE_OPTIONS.slice(0, -1).includes(formData.genre)
+  );
+
+  const canProceed =
+    formData.project_title.trim().length >= 2 &&
+    formData.production_company.trim().length >= 2 &&
+    formData.genre.trim().length > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          TELL US ABOUT YOUR PROJECT
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          This information appears on the cover page of your finance plan. Use
+          your working title — you can always update it later.
+        </p>
+      </div>
+
+      {/* Fields */}
+      <div className="space-y-5">
+        {/* Project Title */}
+        <div>
+          <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+            Project Title <span className="text-gold">*</span>
+          </label>
+          <Input
+            value={formData.project_title}
+            onChange={(e) => updateFormData({ project_title: e.target.value })}
+            placeholder="Enter your project's working title"
+            className="bg-bg-elevated border-border-subtle text-text-primary h-12"
+          />
+        </div>
+
+        {/* Production Company */}
+        <div>
+          <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+            Production Company <span className="text-gold">*</span>
+          </label>
+          <Input
+            value={formData.production_company}
+            onChange={(e) =>
+              updateFormData({ production_company: e.target.value })
+            }
+            placeholder="Your production company name"
+            className="bg-bg-elevated border-border-subtle text-text-primary h-12"
+          />
+        </div>
+
+        {/* Genre */}
+        <div>
+          <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+            Genre <span className="text-gold">*</span>
+          </label>
+          <select
+            value={
+              showCustomGenre
+                ? "Other"
+                : GENRE_OPTIONS.includes(formData.genre)
+                  ? formData.genre
+                  : ""
+            }
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val === "Other") {
+                setShowCustomGenre(true);
+                updateFormData({ genre: "" });
+              } else {
+                setShowCustomGenre(false);
+                updateFormData({ genre: val });
+              }
+            }}
+            className="w-full h-12 px-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-sm appearance-none cursor-pointer focus:outline-none focus:border-gold/50"
+          >
+            <option value="" disabled>
+              Select genre
+            </option>
+            {GENRE_OPTIONS.map((g) => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+          {showCustomGenre && (
+            <Input
+              value={formData.genre}
+              onChange={(e) => updateFormData({ genre: e.target.value })}
+              placeholder="Enter your genre"
+              className="bg-bg-elevated border-border-subtle text-text-primary h-12 mt-3"
+            />
+          )}
+          <p className="text-text-dim text-[11px] mt-2 leading-relaxed">
+            Genre determines which comparable films we reference in your finance
+            plan. Pick the closest match — hybrid genres are common, choose the
+            primary market category.
+          </p>
+        </div>
+
+        {/* Logline */}
+        <div>
+          <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+            Logline{" "}
+            <span className="text-text-dim/60 normal-case">(optional)</span>
+          </label>
+          <textarea
+            value={formData.logline}
+            onChange={(e) => {
+              if (e.target.value.length <= 300) {
+                updateFormData({ logline: e.target.value });
+              }
+            }}
+            placeholder="One or two sentences describing your project"
+            rows={3}
+            className="w-full px-3 py-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-sm resize-none focus:outline-none focus:border-gold/50"
+          />
+          <p className="text-text-dim text-[11px] text-right">
+            {formData.logline.length}/300
+          </p>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-end pt-4">
+        <button
+          onClick={onNext}
+          disabled={!canProceed}
+          className={cn(
+            "flex items-center gap-2 h-14 px-8 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-sm",
+            "hover:border-gold/80 hover:bg-gold/[0.28]",
+            "disabled:opacity-30 disabled:cursor-not-allowed"
+          )}
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep1;

--- a/src/components/intake/IntakeStep2.tsx
+++ b/src/components/intake/IntakeStep2.tsx
@@ -1,0 +1,125 @@
+import { ArrowRight, ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { IntakeFormData } from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  updateFormData: (updates: Partial<IntakeFormData>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const formatCurrency = (value: number | null): string => {
+  if (value === null || value === 0) return "";
+  return value.toLocaleString("en-US");
+};
+
+const parseCurrency = (str: string): number | null => {
+  const cleaned = str.replace(/[^0-9]/g, "");
+  if (!cleaned) return null;
+  return parseInt(cleaned, 10);
+};
+
+const getBudgetContext = (budget: number | null): string | null => {
+  if (!budget) return null;
+  if (budget < 500_000)
+    return "Micro-budget range. At this level, deferments and tax credits will be critical to your capital stack. Most financing at this range comes from private equity and personal investment.";
+  if (budget <= 2_000_000)
+    return "Low-budget independent range. This is where smart packaging and tax credit stacking can create significant arbitrage between production cost and market value.";
+  if (budget <= 5_000_000)
+    return "Core independent range. Most streamer acquisitions in this range. You'll likely need a mixed capital stack: equity + tax credits + potentially gap financing.";
+  if (budget <= 10_000_000)
+    return "Upper independent range. At this budget level, presales and/or a bankable cast package become important for closing the financing gap. Institutional lenders may participate.";
+  return "Studio-independent range. This budget typically requires completion bonding, institutional debt, and significant presale commitments. Our models are optimized for the $1M\u2013$10M range \u2014 results above $10M should be validated with your finance team.";
+};
+
+const IntakeStep2 = ({ formData, updateFormData, onNext, onBack }: Props) => {
+  const canProceed =
+    formData.total_budget !== null &&
+    formData.total_budget >= 100_000 &&
+    formData.total_budget <= 50_000_000;
+
+  const contextCopy = getBudgetContext(formData.total_budget);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          WHAT'S YOUR PRODUCTION BUDGET?
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          This is your total production budget — everything from development
+          through delivery. If you've already modeled this in the free
+          calculator, enter that number here.
+        </p>
+      </div>
+
+      {/* Budget field */}
+      <div>
+        <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+          Total Production Budget <span className="text-gold">*</span>
+        </label>
+        <div className="relative">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-text-dim text-lg font-mono">
+            $
+          </span>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={formatCurrency(formData.total_budget)}
+            onChange={(e) => {
+              const val = parseCurrency(e.target.value);
+              updateFormData({ total_budget: val });
+            }}
+            placeholder="0"
+            className="w-full h-14 pl-8 pr-4 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-2xl font-mono focus:outline-none focus:border-gold/50"
+          />
+        </div>
+        {formData.total_budget !== null && formData.total_budget < 100_000 && (
+          <p className="text-yellow-500/80 text-xs mt-2">
+            Minimum budget: $100,000
+          </p>
+        )}
+        {formData.total_budget !== null && formData.total_budget > 50_000_000 && (
+          <p className="text-yellow-500/80 text-xs mt-2">
+            Maximum budget: $50,000,000
+          </p>
+        )}
+      </div>
+
+      {/* Contextual teaching copy */}
+      {contextCopy && (
+        <div className="p-4 rounded-xl bg-gold/[0.04] border border-gold/15">
+          <p className="text-text-mid text-sm leading-relaxed">{contextCopy}</p>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-text-dim text-sm hover:text-text-mid transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!canProceed}
+          className={cn(
+            "flex items-center gap-2 h-14 px-8 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-sm",
+            "hover:border-gold/80 hover:bg-gold/[0.28]",
+            "disabled:opacity-30 disabled:cursor-not-allowed"
+          )}
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep2;

--- a/src/components/intake/IntakeStep3.tsx
+++ b/src/components/intake/IntakeStep3.tsx
@@ -1,0 +1,874 @@
+import { ArrowRight, ArrowLeft, Plus, X, Info, ChevronDown, ChevronUp } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import {
+  PRIORITY_OPTIONS,
+  SECURITY_TYPE_OPTIONS,
+  SOFT_MONEY_TYPE_OPTIONS,
+  DEFERMENT_ROLE_OPTIONS,
+  DEFERMENT_TRIGGER_OPTIONS,
+  type IntakeFormData,
+  type EquityInvestor,
+  type DebtTranche,
+  type SoftMoney,
+  type Deferment,
+} from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  updateFormData: (updates: Partial<IntakeFormData>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+/* ─── helpers ─── */
+const fmt = (v: number | null): string =>
+  v === null || v === 0 ? "" : v.toLocaleString("en-US");
+const parse$ = (s: string): number | null => {
+  const n = parseInt(s.replace(/[^0-9]/g, ""), 10);
+  return isNaN(n) ? null : n;
+};
+const fmtPct = (n: number) => `${n}%`;
+
+const Tooltip = ({ text }: { text: string }) => (
+  <div className="group relative inline-flex ml-1.5">
+    <Info className="w-3.5 h-3.5 text-text-dim/60 cursor-help" />
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-3 rounded-lg bg-[#1A1A1A] border border-white/10 text-text-mid text-[11px] leading-relaxed opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-50">
+      {text}
+    </div>
+  </div>
+);
+
+const DefaultBadge = ({ show }: { show: boolean }) =>
+  show ? (
+    <span className="ml-2 px-1.5 py-0.5 text-[8px] tracking-[0.1em] uppercase font-bold text-text-dim/50 border border-white/10 rounded">
+      Industry Default
+    </span>
+  ) : null;
+
+const CurrencyInput = ({
+  value,
+  onChange,
+  placeholder = "0",
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  placeholder?: string;
+}) => (
+  <div className="relative">
+    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-text-dim font-mono text-sm">
+      $
+    </span>
+    <input
+      type="text"
+      inputMode="numeric"
+      value={fmt(value)}
+      onChange={(e) => onChange(parse$(e.target.value))}
+      placeholder={placeholder}
+      className="w-full h-11 pl-7 pr-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary font-mono text-sm focus:outline-none focus:border-gold/50"
+    />
+  </div>
+);
+
+const PercentInput = ({
+  value,
+  onChange,
+  isDefault,
+  onEdit,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  isDefault: boolean;
+  onEdit: () => void;
+}) => (
+  <div className="relative">
+    <input
+      type="number"
+      step="0.1"
+      value={value}
+      onChange={(e) => {
+        onChange(parseFloat(e.target.value) || 0);
+        onEdit();
+      }}
+      className="w-full h-11 px-3 pr-8 rounded-md bg-bg-elevated border border-border-subtle text-text-primary font-mono text-sm focus:outline-none focus:border-gold/50"
+    />
+    <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-dim text-sm">
+      %
+    </span>
+  </div>
+);
+
+const SelectField = ({
+  value,
+  onChange,
+  options,
+  placeholder = "Select...",
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+}) => (
+  <select
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    className="w-full h-11 px-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-sm appearance-none cursor-pointer focus:outline-none focus:border-gold/50"
+  >
+    <option value="" disabled>
+      {placeholder}
+    </option>
+    {options.map((o) => (
+      <option key={o.value} value={o.value}>
+        {o.label}
+      </option>
+    ))}
+  </select>
+);
+
+/* ─── Section ─── */
+const CollapsibleSection = ({
+  title,
+  description,
+  children,
+  defaultOpen = true,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="rounded-xl border border-[#2A2A2A] bg-[#141414] overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between p-5 text-left"
+      >
+        <div>
+          <h3 className="font-bebas text-lg tracking-[0.06em] text-white">
+            {title}
+          </h3>
+          <p className="text-text-dim text-[11px] leading-relaxed mt-1">
+            {description}
+          </p>
+        </div>
+        {open ? (
+          <ChevronUp className="w-4 h-4 text-text-dim flex-shrink-0" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-text-dim flex-shrink-0" />
+        )}
+      </button>
+      {open && <div className="px-5 pb-5 space-y-4">{children}</div>}
+    </div>
+  );
+};
+
+/* ═══════════════════════════════════════════════════════════════════
+   STEP 3 MAIN
+   ═══════════════════════════════════════════════════════════════════ */
+const IntakeStep3 = ({ formData, updateFormData, onNext, onBack }: Props) => {
+  const budget = formData.total_budget || 0;
+
+  // Helpers for updating nested arrays
+  const updateInvestor = (idx: number, patch: Partial<EquityInvestor>) => {
+    const next = formData.equity_investors.map((inv, i) =>
+      i === idx ? { ...inv, ...patch } : inv
+    );
+    updateFormData({ equity_investors: next });
+  };
+
+  const addInvestor = () => {
+    if (formData.equity_investors.length >= 5) return;
+    updateFormData({
+      equity_investors: [
+        ...formData.equity_investors,
+        {
+          label: `Equity Investor ${formData.equity_investors.length + 1}`,
+          amount: null,
+          priority: "first_position",
+          preferred_return_pct: 120,
+          profit_participation_pct: 50,
+          is_default: true,
+        },
+      ],
+    });
+  };
+
+  const removeInvestor = (idx: number) => {
+    if (formData.equity_investors.length <= 1) return;
+    updateFormData({
+      equity_investors: formData.equity_investors.filter((_, i) => i !== idx),
+    });
+  };
+
+  const updateDebt = (idx: number, patch: Partial<DebtTranche>) => {
+    const next = formData.debt_tranches.map((d, i) =>
+      i === idx ? { ...d, ...patch } : d
+    );
+    updateFormData({ debt_tranches: next });
+  };
+
+  const addDebt = () => {
+    if (formData.debt_tranches.length >= 3) return;
+    updateFormData({
+      debt_tranches: [
+        ...formData.debt_tranches,
+        {
+          label: `Debt Tranche ${formData.debt_tranches.length + 1}`,
+          principal: null,
+          interest_rate_pct: 10,
+          security_type: "",
+          priority: "first_position",
+          is_default: true,
+        },
+      ],
+    });
+  };
+
+  const removeDebt = (idx: number) => {
+    if (formData.debt_tranches.length <= 1) return;
+    updateFormData({
+      debt_tranches: formData.debt_tranches.filter((_, i) => i !== idx),
+    });
+  };
+
+  const updateSoftMoney = (idx: number, patch: Partial<SoftMoney>) => {
+    const next = formData.soft_money.map((s, i) =>
+      i === idx ? { ...s, ...patch } : s
+    );
+    updateFormData({ soft_money: next });
+  };
+
+  const addSoftMoney = () => {
+    if (formData.soft_money.length >= 5) return;
+    updateFormData({
+      soft_money: [
+        ...formData.soft_money,
+        {
+          label: `Source ${formData.soft_money.length + 1}`,
+          type: "",
+          amount: null,
+          is_default: true,
+        },
+      ],
+    });
+  };
+
+  const removeSoftMoney = (idx: number) => {
+    if (formData.soft_money.length <= 1) return;
+    updateFormData({
+      soft_money: formData.soft_money.filter((_, i) => i !== idx),
+    });
+  };
+
+  const updateDeferment = (idx: number, patch: Partial<Deferment>) => {
+    const next = formData.deferments.map((d, i) =>
+      i === idx ? { ...d, ...patch } : d
+    );
+    updateFormData({ deferments: next });
+  };
+
+  const addDeferment = () => {
+    if (formData.deferments.length >= 5) return;
+    updateFormData({
+      deferments: [
+        ...formData.deferments,
+        {
+          role: "",
+          amount: null,
+          triggers_at: "after_equity_recoupment",
+          is_default: true,
+        },
+      ],
+    });
+  };
+
+  const removeDeferment = (idx: number) => {
+    if (formData.deferments.length <= 1) return;
+    updateFormData({
+      deferments: formData.deferments.filter((_, i) => i !== idx),
+    });
+  };
+
+  // Capital stack summary
+  const totalEquity = formData.equity_investors.reduce(
+    (sum, inv) => sum + (inv.amount || 0),
+    0
+  );
+  const totalDebt = formData.has_debt
+    ? formData.debt_tranches.reduce((sum, d) => sum + (d.principal || 0), 0)
+    : 0;
+  const totalSoftMoney = formData.soft_money.reduce(
+    (sum, s) => sum + (s.amount || 0),
+    0
+  );
+  const totalDeferments = formData.has_deferments
+    ? formData.deferments.reduce((sum, d) => sum + (d.amount || 0), 0)
+    : 0;
+  const totalCovered = totalEquity + totalDebt + totalSoftMoney + totalDeferments;
+  const gap = budget - totalCovered;
+  const gapPct = budget > 0 ? (gap / budget) * 100 : 0;
+  const pctOf = (n: number) =>
+    budget > 0 ? `${Math.round((n / budget) * 100)}%` : "—";
+
+  const getGapStatus = () => {
+    if (budget === 0) return null;
+    if (totalCovered > budget * 1.05)
+      return {
+        color: "text-yellow-500/80",
+        text: `Your funding sources exceed your budget by $${(totalCovered - budget).toLocaleString()}. This may be intentional (contingency buffer) or an error.`,
+      };
+    if (totalCovered < budget * 0.8)
+      return {
+        color: "text-yellow-500/80",
+        text: `Your capital stack covers ${Math.round((totalCovered / budget) * 100)}% of your budget. You'll need additional funding sources to close the gap.`,
+      };
+    if (Math.abs(gap) <= budget * 0.05)
+      return {
+        color: "text-green-400/80",
+        text: "Your capital stack is fully funded.",
+      };
+    return null;
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          HOW ARE YOU FINANCING THIS FILM?
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          Build your capital stack — the combination of funding sources that add
+          up to your budget. We've started with a common structure. Adjust to
+          match your plan, or accept the defaults if you're still figuring it
+          out.
+        </p>
+      </div>
+
+      {/* 3A: EQUITY */}
+      <CollapsibleSection
+        title="EQUITY INVESTMENT"
+        description="Private investors who put in cash and receive a share of profits. They sit behind any debt in the recoupment waterfall — higher risk, higher potential return."
+      >
+        {formData.equity_investors.map((inv, idx) => (
+          <div
+            key={idx}
+            className="p-4 rounded-lg bg-bg-elevated border border-border-subtle space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <Input
+                value={inv.label}
+                onChange={(e) =>
+                  updateInvestor(idx, { label: e.target.value })
+                }
+                className="bg-transparent border-none text-white font-semibold text-sm p-0 h-auto focus-visible:ring-0"
+              />
+              {formData.equity_investors.length > 1 && (
+                <button
+                  onClick={() => removeInvestor(idx)}
+                  className="text-text-dim hover:text-red-400 transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Amount <span className="text-gold">*</span>
+                </label>
+                <CurrencyInput
+                  value={inv.amount}
+                  onChange={(v) => updateInvestor(idx, { amount: v })}
+                />
+              </div>
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Priority Position
+                </label>
+                <SelectField
+                  value={inv.priority}
+                  onChange={(v) => updateInvestor(idx, { priority: v })}
+                  options={PRIORITY_OPTIONS}
+                />
+              </div>
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Preferred Return
+                  <Tooltip text="Industry standard: 120% (investor gets back 100% of principal + 20% premium before profit split). Range: 110%–130%." />
+                  <DefaultBadge show={inv.is_default} />
+                </label>
+                <PercentInput
+                  value={inv.preferred_return_pct}
+                  onChange={(v) =>
+                    updateInvestor(idx, { preferred_return_pct: v })
+                  }
+                  isDefault={inv.is_default}
+                  onEdit={() => updateInvestor(idx, { is_default: false })}
+                />
+              </div>
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Profit Participation
+                  <Tooltip text="Industry standard: 50/50 split of net profits between investor pool and producer pool after recoupment. Range: 40%–60%." />
+                  <DefaultBadge show={inv.is_default} />
+                </label>
+                <PercentInput
+                  value={inv.profit_participation_pct}
+                  onChange={(v) =>
+                    updateInvestor(idx, { profit_participation_pct: v })
+                  }
+                  isDefault={inv.is_default}
+                  onEdit={() => updateInvestor(idx, { is_default: false })}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {formData.equity_investors.length < 5 && (
+          <button
+            onClick={addInvestor}
+            className="flex items-center gap-2 text-gold text-sm font-semibold hover:text-gold/80 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add Another Investor
+          </button>
+        )}
+
+        <div className="text-sm font-mono">
+          <span className="text-text-dim">Total Equity: </span>
+          <span className="text-white">
+            ${totalEquity.toLocaleString()}
+          </span>
+          {budget > 0 && (
+            <span
+              className={cn(
+                "ml-2",
+                totalEquity / budget >= 0.3 && totalEquity / budget <= 0.7
+                  ? "text-green-400/80"
+                  : "text-yellow-500/80"
+              )}
+            >
+              ({pctOf(totalEquity)} of budget)
+            </span>
+          )}
+        </div>
+      </CollapsibleSection>
+
+      {/* 3B: DEBT */}
+      <CollapsibleSection
+        title="DEBT FINANCING"
+        description="Loans that get repaid with interest before equity investors see returns. Lower cost of capital, but requires collateral (presales, tax credits, completion bond)."
+        defaultOpen={formData.has_debt}
+      >
+        <div className="flex items-center gap-3 mb-2">
+          <label className="text-text-mid text-sm">
+            Does your plan include debt financing?
+          </label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => updateFormData({ has_debt: true })}
+              className={cn(
+                "px-3 py-1 rounded text-xs font-bold tracking-wider uppercase transition-all",
+                formData.has_debt
+                  ? "bg-gold/20 border border-gold/50 text-gold"
+                  : "bg-bg-elevated border border-border-subtle text-text-dim"
+              )}
+            >
+              Yes
+            </button>
+            <button
+              onClick={() => updateFormData({ has_debt: false })}
+              className={cn(
+                "px-3 py-1 rounded text-xs font-bold tracking-wider uppercase transition-all",
+                !formData.has_debt
+                  ? "bg-gold/20 border border-gold/50 text-gold"
+                  : "bg-bg-elevated border border-border-subtle text-text-dim"
+              )}
+            >
+              No
+            </button>
+          </div>
+        </div>
+
+        {formData.has_debt && (
+          <>
+            {formData.debt_tranches.map((tranche, idx) => (
+              <div
+                key={idx}
+                className="p-4 rounded-lg bg-bg-elevated border border-border-subtle space-y-3"
+              >
+                <div className="flex items-center justify-between">
+                  <Input
+                    value={tranche.label}
+                    onChange={(e) =>
+                      updateDebt(idx, { label: e.target.value })
+                    }
+                    className="bg-transparent border-none text-white font-semibold text-sm p-0 h-auto focus-visible:ring-0"
+                  />
+                  {formData.debt_tranches.length > 1 && (
+                    <button
+                      onClick={() => removeDebt(idx)}
+                      className="text-text-dim hover:text-red-400 transition-colors"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Principal <span className="text-gold">*</span>
+                    </label>
+                    <CurrencyInput
+                      value={tranche.principal}
+                      onChange={(v) => updateDebt(idx, { principal: v })}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Interest Rate
+                      <Tooltip text="Industry standard for senior debt secured by tax credits or presales: 8%–12%. Gap/mezzanine debt: 12%–20%." />
+                      <DefaultBadge show={tranche.is_default} />
+                    </label>
+                    <PercentInput
+                      value={tranche.interest_rate_pct}
+                      onChange={(v) =>
+                        updateDebt(idx, { interest_rate_pct: v })
+                      }
+                      isDefault={tranche.is_default}
+                      onEdit={() => updateDebt(idx, { is_default: false })}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Security Type
+                    </label>
+                    <SelectField
+                      value={tranche.security_type}
+                      onChange={(v) =>
+                        updateDebt(idx, { security_type: v })
+                      }
+                      options={SECURITY_TYPE_OPTIONS}
+                      placeholder="Select security type"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Priority
+                    </label>
+                    <SelectField
+                      value={tranche.priority}
+                      onChange={(v) => updateDebt(idx, { priority: v })}
+                      options={PRIORITY_OPTIONS.slice(0, 2)}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+            {formData.debt_tranches.length < 3 && (
+              <button
+                onClick={addDebt}
+                className="flex items-center gap-2 text-gold text-sm font-semibold hover:text-gold/80 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Add Another Debt Tranche
+              </button>
+            )}
+          </>
+        )}
+      </CollapsibleSection>
+
+      {/* 3C: SOFT MONEY */}
+      <CollapsibleSection
+        title="TAX CREDITS & SOFT MONEY"
+        description="Government incentives, grants, and rebates that reduce your cash requirement. In 2025, most viable independent films have 20-40% of their budget covered by soft money."
+      >
+        {formData.soft_money.map((source, idx) => (
+          <div
+            key={idx}
+            className="p-4 rounded-lg bg-bg-elevated border border-border-subtle space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <Input
+                value={source.label}
+                onChange={(e) =>
+                  updateSoftMoney(idx, { label: e.target.value })
+                }
+                className="bg-transparent border-none text-white font-semibold text-sm p-0 h-auto focus-visible:ring-0"
+              />
+              {formData.soft_money.length > 1 && (
+                <button
+                  onClick={() => removeSoftMoney(idx)}
+                  className="text-text-dim hover:text-red-400 transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Type
+                </label>
+                <SelectField
+                  value={source.type}
+                  onChange={(v) => updateSoftMoney(idx, { type: v })}
+                  options={SOFT_MONEY_TYPE_OPTIONS}
+                  placeholder="Select type"
+                />
+              </div>
+              <div>
+                <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                  Amount <span className="text-gold">*</span>
+                </label>
+                <CurrencyInput
+                  value={source.amount}
+                  onChange={(v) => updateSoftMoney(idx, { amount: v })}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+        {formData.soft_money.length < 5 && (
+          <button
+            onClick={addSoftMoney}
+            className="flex items-center gap-2 text-gold text-sm font-semibold hover:text-gold/80 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add Another Source
+          </button>
+        )}
+        <p className="text-text-dim text-[11px] leading-relaxed">
+          Tax credits typically cover 20-30% of qualified local expenditure. If
+          you don't yet know your tax credit amount, estimate 25% of your budget
+          as a starting point — your production accountant will refine this.
+        </p>
+      </CollapsibleSection>
+
+      {/* 3D: DEFERMENTS */}
+      <CollapsibleSection
+        title="DEFERRED COMPENSATION"
+        description="Key team members who accept reduced upfront pay in exchange for payment from the waterfall after investors are recouped. Deferments lower your cash basis — the core Artists Equity principle."
+        defaultOpen={formData.has_deferments}
+      >
+        <div className="flex items-center gap-3 mb-2">
+          <label className="text-text-mid text-sm">
+            Does your plan include deferred compensation?
+          </label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => updateFormData({ has_deferments: true })}
+              className={cn(
+                "px-3 py-1 rounded text-xs font-bold tracking-wider uppercase transition-all",
+                formData.has_deferments
+                  ? "bg-gold/20 border border-gold/50 text-gold"
+                  : "bg-bg-elevated border border-border-subtle text-text-dim"
+              )}
+            >
+              Yes
+            </button>
+            <button
+              onClick={() => updateFormData({ has_deferments: false })}
+              className={cn(
+                "px-3 py-1 rounded text-xs font-bold tracking-wider uppercase transition-all",
+                !formData.has_deferments
+                  ? "bg-gold/20 border border-gold/50 text-gold"
+                  : "bg-bg-elevated border border-border-subtle text-text-dim"
+              )}
+            >
+              No
+            </button>
+          </div>
+        </div>
+
+        {formData.has_deferments && (
+          <>
+            {formData.deferments.map((def, idx) => (
+              <div
+                key={idx}
+                className="p-4 rounded-lg bg-bg-elevated border border-border-subtle space-y-3"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-white font-semibold text-sm">
+                    Deferment {idx + 1}
+                  </span>
+                  {formData.deferments.length > 1 && (
+                    <button
+                      onClick={() => removeDeferment(idx)}
+                      className="text-text-dim hover:text-red-400 transition-colors"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Role
+                    </label>
+                    <SelectField
+                      value={def.role}
+                      onChange={(v) => updateDeferment(idx, { role: v })}
+                      options={DEFERMENT_ROLE_OPTIONS}
+                      placeholder="Select role"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Amount Deferred <span className="text-gold">*</span>
+                    </label>
+                    <CurrencyInput
+                      value={def.amount}
+                      onChange={(v) => updateDeferment(idx, { amount: v })}
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                      Triggers At
+                      <DefaultBadge show={def.is_default} />
+                    </label>
+                    <SelectField
+                      value={def.triggers_at}
+                      onChange={(v) => {
+                        updateDeferment(idx, {
+                          triggers_at: v,
+                          is_default: false,
+                        });
+                      }}
+                      options={DEFERMENT_TRIGGER_OPTIONS}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+            {formData.deferments.length < 5 && (
+              <button
+                onClick={addDeferment}
+                className="flex items-center gap-2 text-gold text-sm font-semibold hover:text-gold/80 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Add Another Deferment
+              </button>
+            )}
+          </>
+        )}
+      </CollapsibleSection>
+
+      {/* CAPITAL STACK SUMMARY */}
+      <div className="rounded-xl border border-gold/20 bg-gold/[0.03] p-5">
+        <h3 className="font-bebas text-lg tracking-[0.06em] text-gold mb-4">
+          YOUR CAPITAL STACK
+        </h3>
+        <div className="space-y-2 font-mono text-sm">
+          <div className="flex justify-between text-text-dim">
+            <span>Total Budget:</span>
+            <span className="text-white">${budget.toLocaleString()}</span>
+          </div>
+          <div className="h-px bg-white/10 my-2" />
+          {totalEquity > 0 && (
+            <div className="flex justify-between">
+              <span className="text-text-dim">Equity:</span>
+              <span className="text-white">
+                ${totalEquity.toLocaleString()}{" "}
+                <span className="text-text-dim text-xs">{pctOf(totalEquity)}</span>
+              </span>
+            </div>
+          )}
+          {totalSoftMoney > 0 && (
+            <div className="flex justify-between">
+              <span className="text-text-dim">Tax Credits / Soft Money:</span>
+              <span className="text-white">
+                ${totalSoftMoney.toLocaleString()}{" "}
+                <span className="text-text-dim text-xs">{pctOf(totalSoftMoney)}</span>
+              </span>
+            </div>
+          )}
+          {totalDebt > 0 && (
+            <div className="flex justify-between">
+              <span className="text-text-dim">Debt:</span>
+              <span className="text-white">
+                ${totalDebt.toLocaleString()}{" "}
+                <span className="text-text-dim text-xs">{pctOf(totalDebt)}</span>
+              </span>
+            </div>
+          )}
+          {totalDeferments > 0 && (
+            <div className="flex justify-between">
+              <span className="text-text-dim">Deferments:</span>
+              <span className="text-white">
+                ${totalDeferments.toLocaleString()}{" "}
+                <span className="text-text-dim text-xs">{pctOf(totalDeferments)}</span>
+              </span>
+            </div>
+          )}
+          <div className="h-px bg-white/10 my-2" />
+          <div className="flex justify-between">
+            <span className="text-text-dim">Total Covered:</span>
+            <span className="text-white">
+              ${totalCovered.toLocaleString()}{" "}
+              <span className="text-text-dim text-xs">
+                {budget > 0
+                  ? `${Math.round((totalCovered / budget) * 100)}%`
+                  : "—"}
+              </span>
+            </span>
+          </div>
+          {budget > 0 && (
+            <div className="flex justify-between">
+              <span className="text-text-dim">Gap:</span>
+              <span
+                className={cn(
+                  gap <= 0 ? "text-green-400/80" : "text-yellow-500/80"
+                )}
+              >
+                ${Math.abs(gap).toLocaleString()}{" "}
+                <span className="text-xs">
+                  {Math.abs(Math.round(gapPct))}%
+                </span>
+              </span>
+            </div>
+          )}
+        </div>
+        {getGapStatus() && (
+          <p
+            className={cn(
+              "text-xs mt-3 leading-relaxed",
+              getGapStatus()!.color
+            )}
+          >
+            {getGapStatus()!.text}
+          </p>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-text-dim text-sm hover:text-text-mid transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button
+          onClick={onNext}
+          className={cn(
+            "flex items-center gap-2 h-14 px-8 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-sm",
+            "hover:border-gold/80 hover:bg-gold/[0.28]"
+          )}
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep3;

--- a/src/components/intake/IntakeStep4.tsx
+++ b/src/components/intake/IntakeStep4.tsx
@@ -1,0 +1,378 @@
+import { ArrowRight, ArrowLeft, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  PLATFORM_OPTIONS,
+  DEAL_TYPE_OPTIONS,
+  type IntakeFormData,
+} from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  updateFormData: (updates: Partial<IntakeFormData>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const Tooltip = ({ text }: { text: string }) => (
+  <div className="group relative inline-flex ml-1.5">
+    <Info className="w-3.5 h-3.5 text-text-dim/60 cursor-help" />
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-3 rounded-lg bg-[#1A1A1A] border border-white/10 text-text-mid text-[11px] leading-relaxed opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity z-50">
+      {text}
+    </div>
+  </div>
+);
+
+const DefaultBadge = ({ show }: { show: boolean }) =>
+  show ? (
+    <span className="ml-2 px-1.5 py-0.5 text-[8px] tracking-[0.1em] uppercase font-bold text-text-dim/50 border border-white/10 rounded">
+      Industry Default
+    </span>
+  ) : null;
+
+const PercentField = ({
+  label,
+  value,
+  onChange,
+  isDefault,
+  onEdit,
+  tooltip,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  isDefault: boolean;
+  onEdit: () => void;
+  tooltip: string;
+}) => (
+  <div>
+    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+      {label}
+      <Tooltip text={tooltip} />
+      <DefaultBadge show={isDefault} />
+    </label>
+    <div className="relative">
+      <input
+        type="number"
+        step="0.1"
+        value={value}
+        onChange={(e) => {
+          onChange(parseFloat(e.target.value) || 0);
+          onEdit();
+        }}
+        className="w-full h-11 px-3 pr-8 rounded-md bg-bg-elevated border border-border-subtle text-text-primary font-mono text-sm focus:outline-none focus:border-gold/50"
+      />
+      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-dim text-sm">
+        %
+      </span>
+    </div>
+  </div>
+);
+
+const CurrencyField = ({
+  label,
+  value,
+  onChange,
+  isDefault,
+  onEdit,
+  tooltip,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  isDefault: boolean;
+  onEdit: () => void;
+  tooltip: string;
+}) => (
+  <div>
+    <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+      {label}
+      <Tooltip text={tooltip} />
+      <DefaultBadge show={isDefault} />
+    </label>
+    <div className="relative">
+      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-text-dim font-mono text-sm">
+        $
+      </span>
+      <input
+        type="text"
+        inputMode="numeric"
+        value={value ? value.toLocaleString("en-US") : ""}
+        onChange={(e) => {
+          const cleaned = e.target.value.replace(/[^0-9]/g, "");
+          onChange(parseInt(cleaned, 10) || 0);
+          onEdit();
+        }}
+        className="w-full h-11 pl-7 pr-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary font-mono text-sm focus:outline-none focus:border-gold/50"
+      />
+    </div>
+  </div>
+);
+
+const IntakeStep4 = ({ formData, updateFormData, onNext, onBack }: Props) => {
+  const canProceed = formData.distribution_model !== "";
+
+  const selectedDealType = DEAL_TYPE_OPTIONS.find(
+    (d) => d.value === formData.dp_deal_type
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          HOW DO YOU PLAN TO SELL THIS FILM?
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          Your distribution strategy determines which fees are deducted from
+          gross revenue before your investors see a dollar. This is where most
+          producers underestimate the cost of getting paid.
+        </p>
+      </div>
+
+      {/* Model Selection Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <button
+          onClick={() => updateFormData({ distribution_model: "sales_agent" })}
+          className={cn(
+            "p-5 rounded-xl text-left transition-all",
+            formData.distribution_model === "sales_agent"
+              ? "border-2 border-gold bg-gold/[0.06]"
+              : "border border-[#2A2A2A] bg-[#141414] hover:border-gold/30"
+          )}
+        >
+          <h3 className="font-bebas text-lg tracking-[0.06em] text-white mb-2">
+            SALES AGENT
+          </h3>
+          <p className="text-text-dim text-[11px] leading-relaxed mb-3">
+            Territory-by-territory sales through an international agent
+          </p>
+          <p className="text-text-dim/60 text-[10px] leading-relaxed">
+            Best for: Films with international appeal, festival strategy,
+            presale potential
+          </p>
+        </button>
+
+        <button
+          onClick={() =>
+            updateFormData({ distribution_model: "direct_platform" })
+          }
+          className={cn(
+            "p-5 rounded-xl text-left transition-all",
+            formData.distribution_model === "direct_platform"
+              ? "border-2 border-gold bg-gold/[0.06]"
+              : "border border-[#2A2A2A] bg-[#141414] hover:border-gold/30"
+          )}
+        >
+          <h3 className="font-bebas text-lg tracking-[0.06em] text-white mb-2">
+            DIRECT PLATFORM
+          </h3>
+          <p className="text-text-dim text-[11px] leading-relaxed mb-3">
+            Single buyer acquires all or most rights directly
+          </p>
+          <p className="text-text-dim/60 text-[10px] leading-relaxed">
+            Best for: Genre films with clear platform fit, cost-plus deals,
+            negative pickups
+          </p>
+        </button>
+      </div>
+
+      {/* SALES AGENT FIELDS */}
+      {formData.distribution_model === "sales_agent" && (
+        <div className="rounded-xl border border-[#2A2A2A] bg-[#141414] p-5 space-y-4">
+          <h3 className="font-bebas text-lg tracking-[0.06em] text-gold">
+            SALES AGENT TERMS
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <PercentField
+              label="Domestic Sales Commission"
+              value={formData.sa_domestic_commission_pct}
+              onChange={(v) =>
+                updateFormData({ sa_domestic_commission_pct: v })
+              }
+              isDefault={formData.sa_domestic_commission_is_default}
+              onEdit={() =>
+                updateFormData({ sa_domestic_commission_is_default: false })
+              }
+              tooltip="Standard: 10%–15%. Domestic agents take a lower rate because the market is a single buyer (US theatrical + streaming)."
+            />
+            <PercentField
+              label="International Sales Commission"
+              value={formData.sa_international_commission_pct}
+              onChange={(v) =>
+                updateFormData({ sa_international_commission_pct: v })
+              }
+              isDefault={formData.sa_international_commission_is_default}
+              onEdit={() =>
+                updateFormData({
+                  sa_international_commission_is_default: false,
+                })
+              }
+              tooltip="Standard: 20%–25%. International agents sell territory by territory, justifying a higher commission for more complex work."
+            />
+            <CurrencyField
+              label="Sales Agent Expense Cap"
+              value={formData.sa_expense_cap}
+              onChange={(v) => updateFormData({ sa_expense_cap: v })}
+              isDefault={formData.sa_expense_cap_is_default}
+              onEdit={() =>
+                updateFormData({ sa_expense_cap_is_default: false })
+              }
+              tooltip="Standard: $35K–$100K. This caps what the agent can spend on markets, screenings, and deliverables before seeking your approval. ALWAYS negotiate a hard cap."
+            />
+            <PercentField
+              label="CAM Fee"
+              value={formData.cam_fee_pct}
+              onChange={(v) => updateFormData({ cam_fee_pct: v })}
+              isDefault={formData.cam_fee_is_default}
+              onEdit={() => updateFormData({ cam_fee_is_default: false })}
+              tooltip="Standard: 0.5%–1%. The Collection Account Manager receives gross receipts directly and distributes per the waterfall. Non-negotiable for budgets over $1M."
+            />
+            <PercentField
+              label="Distribution Fee (Domestic)"
+              value={formData.distribution_fee_domestic_pct}
+              onChange={(v) =>
+                updateFormData({ distribution_fee_domestic_pct: v })
+              }
+              isDefault={formData.distribution_fee_domestic_is_default}
+              onEdit={() =>
+                updateFormData({
+                  distribution_fee_domestic_is_default: false,
+                })
+              }
+              tooltip="Standard: 20%–35%. The distributor's commission on domestic revenues after the sales agent takes their cut."
+            />
+            <PercentField
+              label="Distribution Fee (International)"
+              value={formData.distribution_fee_international_pct}
+              onChange={(v) =>
+                updateFormData({ distribution_fee_international_pct: v })
+              }
+              isDefault={formData.distribution_fee_international_is_default}
+              onEdit={() =>
+                updateFormData({
+                  distribution_fee_international_is_default: false,
+                })
+              }
+              tooltip="Standard: 30%–40%. Higher than domestic due to complexity of international markets, dubbing, and localization."
+            />
+          </div>
+        </div>
+      )}
+
+      {/* DIRECT PLATFORM FIELDS */}
+      {formData.distribution_model === "direct_platform" && (
+        <div className="rounded-xl border border-[#2A2A2A] bg-[#141414] p-5 space-y-4">
+          <h3 className="font-bebas text-lg tracking-[0.06em] text-gold">
+            PLATFORM DEAL TERMS
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                Target Platform <span className="text-gold">*</span>
+              </label>
+              <select
+                value={formData.dp_target_platform}
+                onChange={(e) =>
+                  updateFormData({ dp_target_platform: e.target.value })
+                }
+                className="w-full h-11 px-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-sm appearance-none cursor-pointer focus:outline-none focus:border-gold/50"
+              >
+                <option value="" disabled>
+                  Select platform
+                </option>
+                {PLATFORM_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-text-dim text-[9px] tracking-[0.12em] uppercase block mb-1">
+                Deal Type <span className="text-gold">*</span>
+              </label>
+              <select
+                value={formData.dp_deal_type}
+                onChange={(e) =>
+                  updateFormData({ dp_deal_type: e.target.value })
+                }
+                className="w-full h-11 px-3 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-sm appearance-none cursor-pointer focus:outline-none focus:border-gold/50"
+              >
+                <option value="" disabled>
+                  Select deal type
+                </option>
+                {DEAL_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="sm:col-span-2">
+              <PercentField
+                label="CAM Fee"
+                value={formData.cam_fee_pct}
+                onChange={(v) => updateFormData({ cam_fee_pct: v })}
+                isDefault={formData.cam_fee_is_default}
+                onEdit={() => updateFormData({ cam_fee_is_default: false })}
+                tooltip="Standard: 0.5%–1%. The Collection Account Manager receives gross receipts directly and distributes per the waterfall. Non-negotiable for budgets over $1M."
+              />
+            </div>
+          </div>
+
+          {/* Deal type explanation */}
+          {selectedDealType && (
+            <div className="p-4 rounded-lg bg-gold/[0.04] border border-gold/15">
+              <p className="text-text-mid text-[11px] leading-relaxed">
+                <span className="text-gold font-semibold">
+                  {selectedDealType.label}:
+                </span>{" "}
+                {selectedDealType.description}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Teaching Copy */}
+      {formData.distribution_model && (
+        <div className="p-4 rounded-xl bg-gold/[0.04] border border-gold/15">
+          <p className="text-text-mid text-[11px] leading-relaxed">
+            Your distribution model is the single biggest variable in your
+            waterfall. A sales agent adds 2-3 layers of fees before your
+            investors see revenue. A direct platform sale eliminates those layers
+            but may cap your total upside. Neither is universally better — the
+            right choice depends on your film's market positioning and your risk
+            tolerance.
+          </p>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-text-dim text-sm hover:text-text-mid transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!canProceed}
+          className={cn(
+            "flex items-center gap-2 h-14 px-8 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-sm",
+            "hover:border-gold/80 hover:bg-gold/[0.28]",
+            "disabled:opacity-30 disabled:cursor-not-allowed"
+          )}
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep4;

--- a/src/components/intake/IntakeStep5.tsx
+++ b/src/components/intake/IntakeStep5.tsx
@@ -1,0 +1,203 @@
+import { ArrowRight, ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { IntakeFormData } from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  updateFormData: (updates: Partial<IntakeFormData>) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const fmt = (v: number | null): string =>
+  v === null || v === 0 ? "" : v.toLocaleString("en-US");
+const parse$ = (s: string): number | null => {
+  const n = parseInt(s.replace(/[^0-9]/g, ""), 10);
+  return isNaN(n) ? null : n;
+};
+
+const CurrencyInput = ({
+  label,
+  value,
+  onChange,
+  required,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  required?: boolean;
+}) => (
+  <div>
+    <label className="text-text-dim text-[10px] tracking-[0.15em] uppercase font-semibold block mb-2">
+      {label} {required && <span className="text-gold">*</span>}
+    </label>
+    <div className="relative">
+      <span className="absolute left-4 top-1/2 -translate-y-1/2 text-text-dim text-lg font-mono">
+        $
+      </span>
+      <input
+        type="text"
+        inputMode="numeric"
+        value={fmt(value)}
+        onChange={(e) => onChange(parse$(e.target.value))}
+        placeholder="0"
+        className="w-full h-14 pl-8 pr-4 rounded-md bg-bg-elevated border border-border-subtle text-text-primary text-xl font-mono focus:outline-none focus:border-gold/50"
+      />
+    </div>
+  </div>
+);
+
+const getTargetContext = (
+  budget: number | null,
+  target: number | null
+): { color: string; text: string } | null => {
+  if (!budget || !target) return null;
+  if (target < budget)
+    return {
+      color: "text-yellow-500/80",
+      text: "Your target scenario is below your production budget. This means investors may not fully recoup even in your expected case. Consider whether your budget can be reduced or your revenue assumptions are too conservative.",
+    };
+  const ratio = target / budget;
+  if (ratio <= 1.1)
+    return {
+      color: "text-yellow-500/80",
+      text: "Your target scenario roughly matches your budget. After waterfall deductions (agent fees, distribution costs, CAM), investors will likely recoup 60-80% of principal at this revenue level. The arbitrage opportunity is thin.",
+    };
+  if (ratio <= 1.5)
+    return {
+      color: "text-green-400/80",
+      text: "Healthy margin. If your revenue assumptions are based on real comparables, this gives investors a credible path to full recoupment plus premium.",
+    };
+  return {
+    color: "text-gold",
+    text: "Strong upside scenario. Make sure your comparable films data supports this valuation \u2014 overestimating acquisition prices is the most common mistake in indie film financial projections.",
+  };
+};
+
+const IntakeStep5 = ({ formData, updateFormData, onNext, onBack }: Props) => {
+  const { scenario_conservative, scenario_target, scenario_optimistic } =
+    formData;
+
+  // Validation
+  const errors: string[] = [];
+  if (
+    scenario_conservative &&
+    scenario_target &&
+    scenario_conservative >= scenario_target
+  ) {
+    errors.push("Conservative scenario must be less than Target.");
+  }
+  if (
+    scenario_target &&
+    scenario_optimistic &&
+    scenario_target >= scenario_optimistic
+  ) {
+    errors.push("Target scenario must be less than Optimistic.");
+  }
+
+  const canProceed =
+    scenario_conservative !== null &&
+    scenario_conservative > 0 &&
+    scenario_target !== null &&
+    scenario_target > 0 &&
+    scenario_optimistic !== null &&
+    scenario_optimistic > 0 &&
+    errors.length === 0;
+
+  const targetContext = getTargetContext(formData.total_budget, scenario_target);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          MODEL YOUR REVENUE SCENARIOS
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          Enter three acquisition price points. Your finance plan will show
+          exactly how revenue flows through the waterfall — and what each
+          investor gets back — at each scenario.
+        </p>
+      </div>
+
+      {/* Teaching Copy */}
+      <div className="p-4 rounded-xl bg-gold/[0.04] border border-gold/15">
+        <p className="text-text-mid text-[11px] leading-relaxed">
+          Think of these as: <strong>Conservative</strong> = "what if the market
+          is cold and we take the best available deal." <strong>Target</strong> =
+          "what comparable films in our genre/budget range actually sold for."{" "}
+          <strong>Optimistic</strong> = "what happens if we over-deliver —
+          festival buzz, bidding war, breakout cast performance."
+        </p>
+      </div>
+
+      {/* Scenario Fields */}
+      <div className="space-y-5">
+        <CurrencyInput
+          label="Conservative Scenario"
+          value={scenario_conservative}
+          onChange={(v) => updateFormData({ scenario_conservative: v })}
+          required
+        />
+        <CurrencyInput
+          label="Target Scenario"
+          value={scenario_target}
+          onChange={(v) => updateFormData({ scenario_target: v })}
+          required
+        />
+        <CurrencyInput
+          label="Optimistic Scenario"
+          value={scenario_optimistic}
+          onChange={(v) => updateFormData({ scenario_optimistic: v })}
+          required
+        />
+      </div>
+
+      {/* Validation errors */}
+      {errors.length > 0 && (
+        <div className="space-y-1">
+          {errors.map((err) => (
+            <p key={err} className="text-red-400/80 text-xs">
+              {err}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Contextual guidance */}
+      {targetContext && (
+        <div className="p-4 rounded-xl bg-gold/[0.04] border border-gold/15">
+          <p className={cn("text-[11px] leading-relaxed", targetContext.color)}>
+            {targetContext.text}
+          </p>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-text-dim text-sm hover:text-text-mid transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!canProceed}
+          className={cn(
+            "flex items-center gap-2 h-14 px-8 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-sm",
+            "hover:border-gold/80 hover:bg-gold/[0.28]",
+            "disabled:opacity-30 disabled:cursor-not-allowed"
+          )}
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep5;

--- a/src/components/intake/IntakeStep6.tsx
+++ b/src/components/intake/IntakeStep6.tsx
@@ -1,0 +1,408 @@
+import { useState } from "react";
+import { ArrowLeft, Pencil } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  GENRE_OPTIONS,
+  PRIORITY_OPTIONS,
+  SECURITY_TYPE_OPTIONS,
+  SOFT_MONEY_TYPE_OPTIONS,
+  DEFERMENT_ROLE_OPTIONS,
+  DEFERMENT_TRIGGER_OPTIONS,
+  PLATFORM_OPTIONS,
+  DEAL_TYPE_OPTIONS,
+  type IntakeFormData,
+} from "@/lib/intake-types";
+
+interface Props {
+  formData: IntakeFormData;
+  tier: string;
+  includesWorkingModel: boolean;
+  email: string;
+  onEdit: (step: number) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+}
+
+const fmt$ = (v: number | null) =>
+  v ? `$${v.toLocaleString("en-US")}` : "—";
+
+const getLabel = (
+  value: string,
+  options: { value: string; label: string }[]
+) => options.find((o) => o.value === value)?.label || value || "—";
+
+const SummaryCard = ({
+  title,
+  stepNum,
+  onEdit,
+  children,
+}: {
+  title: string;
+  stepNum: number;
+  onEdit: (step: number) => void;
+  children: React.ReactNode;
+}) => (
+  <div className="rounded-xl border border-[#2A2A2A] bg-[#141414] overflow-hidden">
+    <div className="flex items-center justify-between p-5 pb-0">
+      <h3 className="font-bebas text-lg tracking-[0.06em] text-gold">
+        {title}
+      </h3>
+      <button
+        onClick={() => onEdit(stepNum)}
+        className="flex items-center gap-1.5 text-text-dim text-[11px] hover:text-gold transition-colors"
+      >
+        <Pencil className="w-3 h-3" />
+        Edit
+      </button>
+    </div>
+    <div className="p-5 space-y-2 text-sm">{children}</div>
+  </div>
+);
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex justify-between">
+    <span className="text-text-dim">{label}</span>
+    <span className="text-text-primary text-right max-w-[60%]">{value}</span>
+  </div>
+);
+
+const IntakeStep6 = ({
+  formData,
+  tier,
+  includesWorkingModel,
+  email,
+  onEdit,
+  onSubmit,
+  onBack,
+}: Props) => {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    await onSubmit();
+    setSubmitting(false);
+  };
+
+  const tierLabel =
+    tier === "the-pitch-package" ? "The Pitch Package" : "The Blueprint";
+
+  // Collect defaults
+  const defaults: { field: string; value: string; range: string }[] = [];
+  formData.equity_investors.forEach((inv) => {
+    if (inv.is_default) {
+      defaults.push({
+        field: `${inv.label} — Preferred Return`,
+        value: `${inv.preferred_return_pct}%`,
+        range: "110%–130%",
+      });
+      defaults.push({
+        field: `${inv.label} — Profit Participation`,
+        value: `${inv.profit_participation_pct}%`,
+        range: "40%–60%",
+      });
+    }
+  });
+  if (formData.has_debt) {
+    formData.debt_tranches.forEach((d) => {
+      if (d.is_default) {
+        defaults.push({
+          field: `${d.label} — Interest Rate`,
+          value: `${d.interest_rate_pct}%`,
+          range: "8%–20%",
+        });
+      }
+    });
+  }
+  if (formData.distribution_model === "sales_agent") {
+    if (formData.sa_domestic_commission_is_default)
+      defaults.push({
+        field: "Domestic Sales Commission",
+        value: `${formData.sa_domestic_commission_pct}%`,
+        range: "10%–15%",
+      });
+    if (formData.sa_international_commission_is_default)
+      defaults.push({
+        field: "International Sales Commission",
+        value: `${formData.sa_international_commission_pct}%`,
+        range: "20%–25%",
+      });
+    if (formData.sa_expense_cap_is_default)
+      defaults.push({
+        field: "Sales Agent Expense Cap",
+        value: fmt$(formData.sa_expense_cap),
+        range: "$35K–$100K",
+      });
+    if (formData.distribution_fee_domestic_is_default)
+      defaults.push({
+        field: "Distribution Fee (Domestic)",
+        value: `${formData.distribution_fee_domestic_pct}%`,
+        range: "20%–35%",
+      });
+    if (formData.distribution_fee_international_is_default)
+      defaults.push({
+        field: "Distribution Fee (International)",
+        value: `${formData.distribution_fee_international_pct}%`,
+        range: "30%–40%",
+      });
+  }
+  if (formData.cam_fee_is_default)
+    defaults.push({
+      field: "CAM Fee",
+      value: `${formData.cam_fee_pct}%`,
+      range: "0.5%–1%",
+    });
+
+  // Capital stack summary
+  const totalEquity = formData.equity_investors.reduce(
+    (s, i) => s + (i.amount || 0),
+    0
+  );
+  const totalDebt = formData.has_debt
+    ? formData.debt_tranches.reduce((s, d) => s + (d.principal || 0), 0)
+    : 0;
+  const totalSoftMoney = formData.soft_money.reduce(
+    (s, m) => s + (m.amount || 0),
+    0
+  );
+  const totalDeferments = formData.has_deferments
+    ? formData.deferments.reduce((s, d) => s + (d.amount || 0), 0)
+    : 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+          REVIEW YOUR FINANCE PLAN
+        </h2>
+        <p className="text-text-dim text-sm leading-relaxed">
+          Here's everything you entered. Review each section — click "Edit" to
+          jump back to any step. When you're satisfied, submit and we'll
+          generate your deliverables within 24 hours.
+        </p>
+      </div>
+
+      {/* PROJECT */}
+      <SummaryCard title="PROJECT" stepNum={1} onEdit={onEdit}>
+        <Row label="Title" value={formData.project_title || "—"} />
+        <Row label="Company" value={formData.production_company || "—"} />
+        <Row label="Genre" value={formData.genre || "—"} />
+        <Row label="Logline" value={formData.logline || "Not provided"} />
+      </SummaryCard>
+
+      {/* BUDGET */}
+      <SummaryCard title="BUDGET" stepNum={2} onEdit={onEdit}>
+        <Row
+          label="Total Production Budget"
+          value={fmt$(formData.total_budget)}
+        />
+      </SummaryCard>
+
+      {/* CAPITAL STACK */}
+      <SummaryCard title="CAPITAL STACK" stepNum={3} onEdit={onEdit}>
+        {formData.equity_investors.map((inv, i) => (
+          <Row
+            key={i}
+            label={inv.label}
+            value={`${fmt$(inv.amount)} — ${inv.preferred_return_pct}% pref, ${inv.profit_participation_pct}% profit`}
+          />
+        ))}
+        {totalEquity > 0 && (
+          <Row label="Total Equity" value={fmt$(totalEquity)} />
+        )}
+        {formData.has_debt &&
+          formData.debt_tranches.map((d, i) => (
+            <Row
+              key={i}
+              label={d.label}
+              value={`${fmt$(d.principal)} — ${d.interest_rate_pct}%`}
+            />
+          ))}
+        {totalDebt > 0 && <Row label="Total Debt" value={fmt$(totalDebt)} />}
+        {formData.soft_money.map((s, i) => (
+          <Row
+            key={i}
+            label={s.label}
+            value={fmt$(s.amount)}
+          />
+        ))}
+        {totalSoftMoney > 0 && (
+          <Row label="Total Soft Money" value={fmt$(totalSoftMoney)} />
+        )}
+        {formData.has_deferments &&
+          formData.deferments.map((d, i) => (
+            <Row
+              key={i}
+              label={getLabel(d.role, DEFERMENT_ROLE_OPTIONS)}
+              value={`${fmt$(d.amount)} — ${getLabel(d.triggers_at, DEFERMENT_TRIGGER_OPTIONS)}`}
+            />
+          ))}
+        {totalDeferments > 0 && (
+          <Row label="Total Deferments" value={fmt$(totalDeferments)} />
+        )}
+      </SummaryCard>
+
+      {/* DEAL STRUCTURE */}
+      <SummaryCard title="DEAL STRUCTURE" stepNum={4} onEdit={onEdit}>
+        <Row
+          label="Model"
+          value={
+            formData.distribution_model === "sales_agent"
+              ? "Sales Agent"
+              : formData.distribution_model === "direct_platform"
+                ? "Direct Platform"
+                : "—"
+          }
+        />
+        {formData.distribution_model === "sales_agent" && (
+          <>
+            <Row
+              label="Domestic Commission"
+              value={`${formData.sa_domestic_commission_pct}%`}
+            />
+            <Row
+              label="International Commission"
+              value={`${formData.sa_international_commission_pct}%`}
+            />
+            <Row
+              label="Expense Cap"
+              value={fmt$(formData.sa_expense_cap)}
+            />
+            <Row
+              label="Distribution Fee (Dom)"
+              value={`${formData.distribution_fee_domestic_pct}%`}
+            />
+            <Row
+              label="Distribution Fee (Intl)"
+              value={`${formData.distribution_fee_international_pct}%`}
+            />
+          </>
+        )}
+        {formData.distribution_model === "direct_platform" && (
+          <>
+            <Row
+              label="Target Platform"
+              value={getLabel(
+                formData.dp_target_platform,
+                PLATFORM_OPTIONS
+              )}
+            />
+            <Row
+              label="Deal Type"
+              value={getLabel(formData.dp_deal_type, DEAL_TYPE_OPTIONS)}
+            />
+          </>
+        )}
+        <Row label="CAM Fee" value={`${formData.cam_fee_pct}%`} />
+      </SummaryCard>
+
+      {/* SCENARIOS */}
+      <SummaryCard title="SCENARIOS" stepNum={5} onEdit={onEdit}>
+        <Row
+          label="Conservative"
+          value={fmt$(formData.scenario_conservative)}
+        />
+        <Row label="Target" value={fmt$(formData.scenario_target)} />
+        <Row
+          label="Optimistic"
+          value={fmt$(formData.scenario_optimistic)}
+        />
+      </SummaryCard>
+
+      {/* DEFAULTS DISCLOSURE */}
+      {defaults.length > 0 && (
+        <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/[0.04] p-5">
+          <p className="text-text-mid text-[11px] leading-relaxed mb-3">
+            The following assumptions use industry standard values. Your attorney
+            should review these before you present to investors:
+          </p>
+          <div className="space-y-1.5">
+            {defaults.map((d, i) => (
+              <div
+                key={i}
+                className="flex justify-between text-[11px] font-mono"
+              >
+                <span className="text-text-dim">{d.field}</span>
+                <span className="text-text-primary">
+                  {d.value}{" "}
+                  <span className="text-text-dim/50">(range: {d.range})</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* YOUR PACKAGE */}
+      <div className="rounded-xl border border-gold/20 bg-gold/[0.04] p-5">
+        <h3 className="font-bebas text-lg tracking-[0.06em] text-gold mb-3">
+          YOUR PACKAGE
+        </h3>
+        <div className="space-y-1.5 text-sm">
+          <p className="text-text-primary">
+            {tierLabel} —{" "}
+            {tier === "the-pitch-package"
+              ? "Full Investor Materials"
+              : "Finance Plan PDF"}
+          </p>
+          {tier === "the-blueprint" && (
+            <ul className="text-text-dim text-xs space-y-1 pl-4">
+              <li>Finance Plan Summary PDF</li>
+              <li>Capital Stack Breakdown</li>
+              <li>Scenario Comparison Sheet</li>
+              <li>Assumptions Reference</li>
+            </ul>
+          )}
+          {tier === "the-pitch-package" && (
+            <ul className="text-text-dim text-xs space-y-1 pl-4">
+              <li>Everything in The Blueprint</li>
+              <li>Individual Investor Return Profiles</li>
+              <li>Pitch Deck (PowerPoint)</li>
+              <li>One-Page Executive Summary</li>
+              <li>Deal Terms Summary</li>
+            </ul>
+          )}
+          {includesWorkingModel && (
+            <p className="text-gold text-xs mt-2">
+              + The Working Model — Live Excel Engine
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* DELIVERY TIMELINE */}
+      <div className="p-4 rounded-xl bg-bg-elevated border border-border-subtle">
+        <p className="text-text-mid text-sm leading-relaxed">
+          Your deliverables will be ready within 24 hours. We'll email you at{" "}
+          <span className="text-white font-semibold">{email}</span> when
+          they're ready for download.
+        </p>
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-text-dim text-sm hover:text-text-mid transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className={cn(
+            "h-14 px-10 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
+            "bg-gold/[0.22] border-2 border-gold/60 text-gold text-base",
+            "animate-cta-glow-soft hover:border-gold/80 hover:bg-gold/[0.28]",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {submitting ? "SUBMITTING..." : "SUBMIT YOUR FINANCE PLAN"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default IntakeStep6;

--- a/src/hooks/useIntakeAutoSave.ts
+++ b/src/hooks/useIntakeAutoSave.ts
@@ -1,0 +1,47 @@
+import { useCallback, useRef, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { IntakeFormData } from "@/lib/intake-types";
+
+export function useIntakeAutoSave(submissionId: string | null) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestDataRef = useRef<Partial<IntakeFormData> | null>(null);
+
+  const saveToSupabase = useCallback(
+    async (data: Record<string, unknown>) => {
+      if (!submissionId) return;
+      const { error } = await supabase
+        .from("intake_submissions")
+        .update({ ...data, updated_at: new Date().toISOString() })
+        .eq("id", submissionId);
+      if (error) console.error("Auto-save error:", error);
+    },
+    [submissionId]
+  );
+
+  const debouncedSave = useCallback(
+    (data: Record<string, unknown>) => {
+      latestDataRef.current = data as Partial<IntakeFormData>;
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        saveToSupabase(data);
+      }, 2000);
+    },
+    [saveToSupabase]
+  );
+
+  const saveNow = useCallback(
+    async (data: Record<string, unknown>) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      await saveToSupabase(data);
+    },
+    [saveToSupabase]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return { debouncedSave, saveNow };
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,140 @@ export type Database = {
   }
   public: {
     Tables: {
+      intake_submissions: {
+        Row: {
+          id: string
+          purchase_id: string | null
+          user_id: string | null
+          email: string
+          tier: string
+          includes_working_model: boolean
+          status: string
+          project_title: string | null
+          production_company: string | null
+          genre: string | null
+          logline: string | null
+          total_budget: number | null
+          budget_currency: string
+          equity_investors: Json
+          debt_tranches: Json
+          soft_money: Json
+          deferments: Json
+          distribution_model: string | null
+          sa_domestic_commission_pct: number
+          sa_international_commission_pct: number
+          sa_expense_cap: number
+          sa_domestic_commission_is_default: boolean
+          sa_international_commission_is_default: boolean
+          sa_expense_cap_is_default: boolean
+          dp_target_platform: string | null
+          dp_deal_type: string | null
+          cam_fee_pct: number
+          cam_fee_is_default: boolean
+          distribution_fee_domestic_pct: number
+          distribution_fee_international_pct: number
+          distribution_fee_domestic_is_default: boolean
+          distribution_fee_international_is_default: boolean
+          scenario_conservative: number | null
+          scenario_target: number | null
+          scenario_optimistic: number | null
+          current_step: number
+          completed_at: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          purchase_id?: string | null
+          user_id?: string | null
+          email: string
+          tier: string
+          includes_working_model?: boolean
+          status?: string
+          project_title?: string | null
+          production_company?: string | null
+          genre?: string | null
+          logline?: string | null
+          total_budget?: number | null
+          budget_currency?: string
+          equity_investors?: Json
+          debt_tranches?: Json
+          soft_money?: Json
+          deferments?: Json
+          distribution_model?: string | null
+          sa_domestic_commission_pct?: number
+          sa_international_commission_pct?: number
+          sa_expense_cap?: number
+          sa_domestic_commission_is_default?: boolean
+          sa_international_commission_is_default?: boolean
+          sa_expense_cap_is_default?: boolean
+          dp_target_platform?: string | null
+          dp_deal_type?: string | null
+          cam_fee_pct?: number
+          cam_fee_is_default?: boolean
+          distribution_fee_domestic_pct?: number
+          distribution_fee_international_pct?: number
+          distribution_fee_domestic_is_default?: boolean
+          distribution_fee_international_is_default?: boolean
+          scenario_conservative?: number | null
+          scenario_target?: number | null
+          scenario_optimistic?: number | null
+          current_step?: number
+          completed_at?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          purchase_id?: string | null
+          user_id?: string | null
+          email?: string
+          tier?: string
+          includes_working_model?: boolean
+          status?: string
+          project_title?: string | null
+          production_company?: string | null
+          genre?: string | null
+          logline?: string | null
+          total_budget?: number | null
+          budget_currency?: string
+          equity_investors?: Json
+          debt_tranches?: Json
+          soft_money?: Json
+          deferments?: Json
+          distribution_model?: string | null
+          sa_domestic_commission_pct?: number
+          sa_international_commission_pct?: number
+          sa_expense_cap?: number
+          sa_domestic_commission_is_default?: boolean
+          sa_international_commission_is_default?: boolean
+          sa_expense_cap_is_default?: boolean
+          dp_target_platform?: string | null
+          dp_deal_type?: string | null
+          cam_fee_pct?: number
+          cam_fee_is_default?: boolean
+          distribution_fee_domestic_pct?: number
+          distribution_fee_international_pct?: number
+          distribution_fee_domestic_is_default?: boolean
+          distribution_fee_international_is_default?: boolean
+          scenario_conservative?: number | null
+          scenario_target?: number | null
+          scenario_optimistic?: number | null
+          current_step?: number
+          completed_at?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "intake_submissions_purchase_id_fkey"
+            columns: ["purchase_id"]
+            isOneToOne: false
+            referencedRelation: "purchases"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       exports: {
         Row: {
           calculator_inputs: Json

--- a/src/lib/intake-types.ts
+++ b/src/lib/intake-types.ts
@@ -1,0 +1,230 @@
+/* ═══════════════════════════════════════════════════════════════════
+   INTAKE FORM TYPES — Finance Plan Builder
+   ═══════════════════════════════════════════════════════════════════ */
+
+export interface EquityInvestor {
+  label: string;
+  amount: number | null;
+  priority: string;
+  preferred_return_pct: number;
+  profit_participation_pct: number;
+  is_default: boolean;
+}
+
+export interface DebtTranche {
+  label: string;
+  principal: number | null;
+  interest_rate_pct: number;
+  security_type: string;
+  priority: string;
+  is_default: boolean;
+}
+
+export interface SoftMoney {
+  label: string;
+  type: string;
+  amount: number | null;
+  is_default: boolean;
+}
+
+export interface Deferment {
+  role: string;
+  amount: number | null;
+  triggers_at: string;
+  is_default: boolean;
+}
+
+export interface IntakeFormData {
+  // Step 1: Project Identity
+  project_title: string;
+  production_company: string;
+  genre: string;
+  logline: string;
+
+  // Step 2: Budget
+  total_budget: number | null;
+
+  // Step 3: Capital Stack
+  equity_investors: EquityInvestor[];
+  has_debt: boolean;
+  debt_tranches: DebtTranche[];
+  soft_money: SoftMoney[];
+  has_deferments: boolean;
+  deferments: Deferment[];
+
+  // Step 4: Deal Structure
+  distribution_model: string;
+  sa_domestic_commission_pct: number;
+  sa_international_commission_pct: number;
+  sa_expense_cap: number;
+  sa_domestic_commission_is_default: boolean;
+  sa_international_commission_is_default: boolean;
+  sa_expense_cap_is_default: boolean;
+  dp_target_platform: string;
+  dp_deal_type: string;
+  cam_fee_pct: number;
+  cam_fee_is_default: boolean;
+  distribution_fee_domestic_pct: number;
+  distribution_fee_international_pct: number;
+  distribution_fee_domestic_is_default: boolean;
+  distribution_fee_international_is_default: boolean;
+
+  // Step 5: Scenarios
+  scenario_conservative: number | null;
+  scenario_target: number | null;
+  scenario_optimistic: number | null;
+}
+
+export const INITIAL_FORM_DATA: IntakeFormData = {
+  project_title: "",
+  production_company: "",
+  genre: "",
+  logline: "",
+  total_budget: null,
+  equity_investors: [
+    {
+      label: "Equity Investor 1",
+      amount: null,
+      priority: "first_position",
+      preferred_return_pct: 120,
+      profit_participation_pct: 50,
+      is_default: true,
+    },
+  ],
+  has_debt: false,
+  debt_tranches: [
+    {
+      label: "Senior Debt",
+      principal: null,
+      interest_rate_pct: 10,
+      security_type: "",
+      priority: "first_position",
+      is_default: true,
+    },
+  ],
+  soft_money: [
+    {
+      label: "State/Country Tax Credit",
+      type: "",
+      amount: null,
+      is_default: true,
+    },
+  ],
+  has_deferments: false,
+  deferments: [
+    {
+      role: "",
+      amount: null,
+      triggers_at: "after_equity_recoupment",
+      is_default: true,
+    },
+  ],
+  distribution_model: "",
+  sa_domestic_commission_pct: 12.5,
+  sa_international_commission_pct: 22.5,
+  sa_expense_cap: 75000,
+  sa_domestic_commission_is_default: true,
+  sa_international_commission_is_default: true,
+  sa_expense_cap_is_default: true,
+  dp_target_platform: "",
+  dp_deal_type: "",
+  cam_fee_pct: 0.75,
+  cam_fee_is_default: true,
+  distribution_fee_domestic_pct: 25,
+  distribution_fee_international_pct: 35,
+  distribution_fee_domestic_is_default: true,
+  distribution_fee_international_is_default: true,
+  scenario_conservative: null,
+  scenario_target: null,
+  scenario_optimistic: null,
+};
+
+export const GENRE_OPTIONS = [
+  "Action / Thriller",
+  "Comedy",
+  "Drama",
+  "Horror",
+  "Sci-Fi / Fantasy",
+  "Romance",
+  "Documentary",
+  "Animation",
+  "Crime / Mystery",
+  "Family / Kids",
+  "Other",
+];
+
+export const PRIORITY_OPTIONS = [
+  { value: "first_position", label: "First Position" },
+  { value: "second_position", label: "Second Position" },
+  { value: "pari_passu", label: "Pari Passu" },
+];
+
+export const SECURITY_TYPE_OPTIONS = [
+  { value: "tax_credits", label: "Secured by Tax Credits" },
+  { value: "presales", label: "Secured by Presales/MGs" },
+  { value: "completion_bond", label: "Secured by Completion Bond" },
+  { value: "gap_mezzanine", label: "Gap/Mezzanine (Unsold Territories)" },
+  { value: "unsecured", label: "Unsecured" },
+];
+
+export const SOFT_MONEY_TYPE_OPTIONS = [
+  { value: "tax_credit_refundable", label: "Tax Credit (Refundable)" },
+  { value: "tax_credit_transferable", label: "Tax Credit (Transferable)" },
+  { value: "tax_rebate", label: "Tax Rebate" },
+  { value: "grant", label: "Grant (Non-Recoupable)" },
+  { value: "presale", label: "Presale / Minimum Guarantee" },
+];
+
+export const DEFERMENT_ROLE_OPTIONS = [
+  { value: "producer_fee", label: "Producer Fee" },
+  { value: "director_fee", label: "Director Fee" },
+  { value: "lead_actors", label: "Lead Actor(s)" },
+  { value: "writer", label: "Writer" },
+  { value: "key_crew", label: "Key Crew" },
+  { value: "other", label: "Other" },
+];
+
+export const DEFERMENT_TRIGGER_OPTIONS = [
+  { value: "after_equity_recoupment", label: "After Equity Recoupment" },
+  { value: "after_debt_equity_recoupment", label: "After Debt + Equity Recoupment" },
+  { value: "first_day_pp", label: "First Day of Principal Photography" },
+  { value: "from_net_profits", label: "From Net Profits" },
+];
+
+export const PLATFORM_OPTIONS = [
+  { value: "netflix", label: "Netflix" },
+  { value: "amazon", label: "Amazon/MGM" },
+  { value: "apple", label: "Apple TV+" },
+  { value: "hulu", label: "Hulu" },
+  { value: "tubi", label: "Tubi/Fox" },
+  { value: "lionsgate", label: "Lionsgate" },
+  { value: "a24_neon", label: "A24/Neon" },
+  { value: "other", label: "Other" },
+];
+
+export const DEAL_TYPE_OPTIONS = [
+  {
+    value: "cost_plus",
+    label: "Cost-Plus",
+    description: "The platform pays your full budget plus a premium (typically 10-20%). You get guaranteed return but zero upside. All rights transfer to the buyer. This is the Netflix Original model.",
+  },
+  {
+    value: "acquisition",
+    label: "Acquisition / All-Rights",
+    description: "The platform buys the finished film at market value. Price is negotiated based on comparable acquisitions in your genre/budget range. You finance independently, sell after completion.",
+  },
+  {
+    value: "negative_pickup",
+    label: "Negative Pickup",
+    description: "The platform commits to buy the film before production, contingent on delivery requirements. Functions like a presale that covers a significant portion of budget. Reduces investor risk substantially.",
+  },
+];
+
+export const STEP_LABELS = [
+  "Project",
+  "Budget",
+  "Capital Stack",
+  "Deal Structure",
+  "Scenarios",
+  "Review",
+];

--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -1,5 +1,5 @@
 /* ═══════════════════════════════════════════════════════════════════
-   PRODUCT DATA — Phase 1: Store UI + Copy + Stripe Configuration
+   PRODUCT DATA — Phase 2: Finance Plan Builder Architecture
    ═══════════════════════════════════════════════════════════════════ */
 
 export interface Product {
@@ -10,6 +10,8 @@ export interface Product {
   originalPrice: number | null;
   badge: string | null;
   featured: boolean;
+  isAddOn?: boolean;
+  requiresBase?: string[];
   shortDescription: string;
   fullDescription: string;
   features: string[];
@@ -21,48 +23,48 @@ export interface Product {
 
 export const products: Product[] = [
   {
-    id: "the-export",
-    slug: "the-export",
-    name: "The Export",
-    price: 97,
+    id: "the-blueprint",
+    slug: "the-blueprint",
+    name: "The Blueprint",
+    price: 197,
     originalPrice: null,
     badge: null,
     featured: false,
-    shortDescription: "Your complete financial model as a clean, professional PDF.",
+    shortDescription: "Your complete finance plan, documented.",
     fullDescription:
-      "Your complete waterfall model exported as a clean, professional PDF — white-labeled with your production company name and project title.\n\nEvery section of your financial model formatted for clarity: budget breakdown, capital stack structure, deal terms, full waterfall cascade, and scenario analysis. Clean design, standard professional formatting, ready to reference, print, or attach to an email.\n\nThis is the document you send when someone asks \"can you walk me through the numbers?\"",
+      "Your complete finance plan — documented, structured, and ready to reference.\n\nWe take your project details, budget, capital stack, and deal structure and build a professional finance plan PDF. Every assumption explained, every number sourced, every waterfall tier documented. This is the document your attorney reviews, your accountant references, and your co-producers align around.\n\nTell us about your project. We build the plan.",
     features: [
-      "Complete multi-page PDF",
-      "White-labeled with your company name",
-      "Budget, Stack, Deal, Waterfall, Scenarios",
-      "Clean professional formatting",
+      "Finance Plan Summary PDF",
+      "Capital Stack Breakdown",
+      "Scenario Comparison Sheet",
+      "Assumptions Reference",
     ],
     whatsIncluded: [
       {
-        title: "Complete Multi-Page PDF",
-        body: "Your full financial model across all sections — Budget, Capital Stack, Deal Terms, Waterfall Breakdown, and Scenario Analysis — formatted as a single professional document.",
+        title: "Finance Plan Summary PDF",
+        body: "Your complete financial model across all sections — Budget, Capital Stack, Deal Terms, Waterfall Breakdown, and Scenario Analysis — formatted as a single professional document.",
       },
       {
-        title: "White-Labeled With Your Identity",
-        body: "Your production company name and project title on the cover and headers. No filmmaker.og branding anywhere in the document.",
+        title: "Capital Stack Breakdown",
+        body: "Detailed breakdown of every funding source, priority positions, and recoupment structure. Shows exactly who gets paid and in what order.",
       },
       {
-        title: "Clean Professional Formatting",
-        body: "White background, standard professional typography, well-organized tables and data layouts. Readable, presentable, print-ready.",
+        title: "Scenario Comparison Sheet",
+        body: "Three revenue scenarios showing investor returns at conservative, target, and optimistic acquisition prices.",
       },
       {
-        title: "All Calculator Sections Included",
-        body: "Every input and output from your model: budget totals, funding source breakdown, deal term assumptions, complete waterfall tier-by-tier flow, and all scenario comparisons.",
+        title: "Assumptions Reference",
+        body: "Every default value, industry standard, and assumption documented with source and range — so your attorney knows exactly what to review.",
       },
     ],
     whoItsFor:
-      "Producers who need a clean reference document of their financial model. Use it for internal planning, co-producer discussions, or as a supporting attachment when investors ask for the numbers behind your pitch.",
+      "Producers who need a clear, professional record of their project's financial structure. Use it for internal planning, co-producer alignment, or as the foundation document when investors ask for the numbers.",
     whatYoullBuild:
-      "A complete financial overview of your project showing exactly how money flows — from gross receipts through sales agent commissions, distribution fees, debt service, equity recoupment, and profit splits — formatted for anyone to read and understand.",
+      "A complete financial plan showing exactly how money flows — from gross receipts through sales agent commissions, distribution fees, debt service, equity recoupment, and profit splits — formatted for anyone to read and understand.",
     upgradePrompt: {
       title: "WANT THE FULL TREATMENT?",
-      body: "The Pitch Package adds premium cinematic design, an investor-ready PowerPoint deck, a static Excel workbook, and a one-page executive summary — everything you need to walk into a meeting fully prepared.",
-      cta: "Upgrade for $150 more →",
+      body: "The Pitch Package adds a presentation-ready PowerPoint deck, individual investor return profiles, a one-page executive summary, and deal terms summary — everything you need to walk into the room.",
+      cta: "Upgrade to The Pitch Package →",
       link: "/store/the-pitch-package",
     },
   },
@@ -70,66 +72,63 @@ export const products: Product[] = [
     id: "the-pitch-package",
     slug: "the-pitch-package",
     name: "The Pitch Package",
-    price: 247,
-    originalPrice: 347,
-    badge: "MOST POPULAR · SAVE $100",
+    price: 497,
+    originalPrice: 697,
+    badge: "RECOMMENDED · SAVE $200",
     featured: true,
-    shortDescription: "Walk into any meeting with institutional-grade materials.",
+    shortDescription: "Your finance plan, presentation-ready for the room.",
     fullDescription:
-      "Everything in The Export, plus the full premium treatment.\n\nYour financial model redesigned with the same visual standard used by finance boutiques and institutional advisors — dark cinematic layouts, data visualizations, professional charts, and infographic-style waterfall breakdowns. The kind of document that makes investors take you seriously before you say a word.\n\nPlus a ready-to-present PowerPoint deck that turns your numbers into a 10-slide investor pitch with built-in speaker notes. Plus a static Excel workbook for due diligence follow-up. Plus a one-page executive summary designed as the leave-behind document investors keep after the meeting.\n\nFour files. One purchase. You walk into the room prepared.",
+      "Everything in The Blueprint, plus the full investor-facing treatment.\n\nYour finance plan redesigned for the room — a presentation-ready PowerPoint deck, individual investor return profiles, a one-page executive summary leave-behind, and a deal terms summary. The kind of materials that make investors take you seriously before you say a word.\n\nFour additional deliverables on top of your complete finance plan. One purchase. You walk into the room prepared.",
     features: [
-      "Everything in The Export",
-      "Premium cinematic PDF design",
-      "Static Excel reference workbook",
-      "PowerPoint investor pitch deck (10 slides)",
-      "One-page executive summary leave-behind",
+      "Everything in The Blueprint",
+      "Individual Investor Return Profiles",
+      "Pitch Deck (PowerPoint)",
+      "One-Page Executive Summary",
+      "Deal Terms Summary",
     ],
     whatsIncluded: [
       {
-        title: "Premium-Designed PDF",
-        body: "Full cinematic visual treatment — black backgrounds, gold accents, professional charts, infographic-style waterfall cascade, scenario comparison spreads. This is the document that looks like a $10,000 finance boutique produced it.",
+        title: "Everything in The Blueprint",
+        body: "Finance Plan Summary PDF, Capital Stack Breakdown, Scenario Comparison Sheet, and Assumptions Reference — all included.",
       },
       {
-        title: "Static Excel Reference Workbook",
-        body: "All your numbers laid out in clean rows and columns with professional formatting. When an investor's business manager asks \"can you send me the underlying numbers?\" — this is what you send. Values are hard-coded for reference; this is a data document, not a modeling tool.",
+        title: "Individual Investor Return Profiles",
+        body: "Per-investor documents showing their specific investment amount, priority position, preferred return, profit participation, and projected returns across all three scenarios.",
       },
       {
-        title: "PowerPoint Investor Pitch Deck",
-        body: "10 slides built from your actual project data. Title slide, budget overview, capital structure, deal terms, waterfall flow, scenario analysis, investor returns, and executive summary. Speaker notes included on every slide telling you exactly what to say and why.",
+        title: "Pitch Deck (PowerPoint)",
+        body: "10 slides built from your actual project data. Title slide, budget overview, capital structure, deal terms, waterfall flow, scenario analysis, investor returns, and executive summary. Speaker notes included on every slide.",
       },
       {
         title: "One-Page Executive Summary",
-        body: "The leave-behind. A single-page document with your project's key financials — budget, acquisition target, capital structure, investor return projections — designed to sit on an investor's desk after the meeting ends. This is the document that keeps your project in the conversation.",
+        body: "The leave-behind. A single-page document with your project's key financials — budget, acquisition target, capital structure, investor return projections — designed to sit on an investor's desk after the meeting ends.",
       },
       {
-        title: "White-Labeled Across All Files",
-        body: "Your production company name and project title on every document. No filmmaker.og branding. These are your materials.",
+        title: "Deal Terms Summary",
+        body: "A clean, structured summary of all deal terms — distribution model, commission rates, fee structures, and recoupment waterfall — formatted for attorney review and investor due diligence.",
       },
     ],
     whoItsFor:
       "Producers preparing to sit in front of investors, equity partners, or co-financiers. You have a meeting coming up — or you want to be ready when one lands. This package gives you the complete set of materials that institutional capital expects to see.",
     whatYoullBuild:
-      "A professional capital-raise package showing your project's complete financial architecture — how the money comes in, how it flows through the waterfall, and what investors can expect in return — presented across four coordinated documents that cover every moment from the pitch to the follow-up.",
-    upgradePrompt: {
-      title: "WANT THE REUSABLE MODEL?",
-      body: "The Working Model adds a live formula-driven Excel workbook where changing any input recalculates everything downstream. Use it on this project, your next project, and every project after that.",
-      cta: "Upgrade for $150 more →",
-      link: "/store/the-working-model",
-    },
+      "A professional capital-raise package showing your project's complete financial architecture — how the money comes in, how it flows through the waterfall, and what investors can expect in return — presented across coordinated documents that cover every moment from the pitch to the follow-up.",
+    upgradePrompt: null,
   },
   {
     id: "the-working-model",
     slug: "the-working-model",
     name: "The Working Model",
-    price: 397,
+    price: 99,
     originalPrice: null,
-    badge: null,
+    badge: "ADD-ON",
     featured: false,
-    shortDescription: "The financial engine. Not just this project — every project.",
+    isAddOn: true,
+    requiresBase: ["the-blueprint", "the-pitch-package"],
+    shortDescription:
+      "The live Excel engine behind your finance plan. Reuse on every project.",
     fullDescription:
-      "Everything in The Pitch Package, plus the engine behind it.\n\nThe Working Model includes a live formula-driven Excel workbook where every output is connected to every input. Change your budget — the waterfall recalculates. Adjust the sales agent commission from 15% to 20% — every downstream tier updates. Swap your equity split — investor returns recompute instantly.\n\nThis isn't a snapshot of one deal. It's a financial modeling tool you'll use for years.\n\nThe Pitch Package gives you the documents for this deal. The Working Model gives you the machine for every deal going forward.",
+      "The formula-driven Excel engine behind your finance plan.\n\nEvery output cell is connected to every input. Change your budget — the waterfall recalculates. Adjust the sales agent commission — every downstream tier updates. Swap your equity split — investor returns recompute instantly.\n\nThis isn't a snapshot of one deal. It's a financial modeling tool you'll use for years. Buy it once, use it on every project going forward.",
     features: [
-      "Everything in The Pitch Package",
       "Live formula-driven Excel model",
       "Change any input — everything recalculates",
       "Full formula documentation",
@@ -137,16 +136,12 @@ export const products: Product[] = [
     ],
     whatsIncluded: [
       {
-        title: "Everything in The Pitch Package",
-        body: "Premium PDF, static Excel reference, PowerPoint pitch deck, and executive summary — all white-labeled with your project details.",
-      },
-      {
         title: "Live Formula-Driven Excel Workbook",
-        body: "Every output cell is driven by formulas. Change any input — budget, revenue projections, fee percentages, capital structure, profit splits — and watch every downstream number recalculate in real time. Model unlimited scenarios without rebuilding anything.",
+        body: "Every output cell is driven by formulas. Change any input — budget, revenue projections, fee percentages, capital structure, profit splits — and watch every downstream number recalculate in real time.",
       },
       {
         title: "Full Formula Documentation",
-        body: "Every formula is documented. A companion reference explaining what each calculation does, why it's structured that way, and what assumptions it relies on. You'll understand the model, not just use it.",
+        body: "Every formula is documented. A companion reference explaining what each calculation does, why it's structured that way, and what assumptions it relies on.",
       },
       {
         title: "Reusable Across Unlimited Projects",
@@ -154,12 +149,18 @@ export const products: Product[] = [
       },
     ],
     whoItsFor:
-      "Producers and production companies who model multiple projects, want to stress-test deal structures before committing, or need a reusable financial tool they can bring to every negotiation. If you're building a slate — not just a single film — this is the tool that scales with you.",
+      "Producers and production companies who model multiple projects, want to stress-test deal structures before committing, or need a reusable financial tool they can bring to every negotiation.",
     whatYoullBuild:
-      "A complete, living financial model that lets you test any combination of budget, capital structure, deal terms, and revenue scenarios — and instantly see how every change affects investor returns, producer profits, and recoupment timelines. The same tool institutional finance teams use, formatted for independent production.",
+      "A complete, living financial model that lets you test any combination of budget, capital structure, deal terms, and revenue scenarios — and instantly see how every change affects investor returns and recoupment timelines.",
     upgradePrompt: null,
   },
 ];
+
+/** Get the two main (non-add-on) products */
+export const mainProducts: Product[] = products.filter((p) => !p.isAddOn);
+
+/** Get the add-on product */
+export const addOnProduct: Product | undefined = products.find((p) => p.isAddOn);
 
 export const getProduct = (slug: string): Product | undefined =>
   products.find((p) => p.slug === slug);
@@ -174,9 +175,8 @@ export interface ComparisonSection {
   title: string;
   features: {
     label: string;
-    theExport: FeatureValue;
+    theBlueprint: FeatureValue;
     thePitchPackage: FeatureValue;
-    theWorkingModel: FeatureValue;
   }[];
 }
 
@@ -184,38 +184,35 @@ export const comparisonSections: ComparisonSection[] = [
   {
     title: "Documents",
     features: [
-      { label: "Professional PDF (clean format)", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Premium Cinematic PDF (dark design, charts, infographics)", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Static Excel Reference Workbook", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "PowerPoint Investor Pitch Deck (10 slides + speaker notes)", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "One-Page Executive Summary Leave-Behind", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Live Formula-Driven Excel Model", theExport: false, thePitchPackage: false, theWorkingModel: true },
+      { label: "Finance Plan Summary PDF", theBlueprint: true, thePitchPackage: true },
+      { label: "Capital Stack Breakdown", theBlueprint: true, thePitchPackage: true },
+      { label: "Scenario Comparison Sheet", theBlueprint: true, thePitchPackage: true },
+      { label: "Assumptions Reference", theBlueprint: true, thePitchPackage: true },
+      { label: "Individual Investor Return Profiles", theBlueprint: false, thePitchPackage: true },
+      { label: "Pitch Deck (PowerPoint)", theBlueprint: false, thePitchPackage: true },
+      { label: "One-Page Executive Summary", theBlueprint: false, thePitchPackage: true },
+      { label: "Deal Terms Summary", theBlueprint: false, thePitchPackage: true },
     ],
   },
   {
     title: "Features",
     features: [
-      { label: "White-labeled with your company/project", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Budget breakdown", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Capital stack structure", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Deal terms summary", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Waterfall cascade (full tier-by-tier)", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Scenario comparison (Low/Base/High)", theExport: true, thePitchPackage: true, theWorkingModel: true },
-      { label: "Data visualizations and charts", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Infographic-style waterfall visual", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Investor return calculations", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Speaker notes for pitch presentation", theExport: false, thePitchPackage: true, theWorkingModel: true },
-      { label: "Live recalculation (change inputs → outputs update)", theExport: false, thePitchPackage: false, theWorkingModel: true },
-      { label: "Formula documentation", theExport: false, thePitchPackage: false, theWorkingModel: true },
-      { label: "Reusable across unlimited projects", theExport: false, thePitchPackage: false, theWorkingModel: true },
+      { label: "White-labeled with your company/project", theBlueprint: true, thePitchPackage: true },
+      { label: "Budget breakdown", theBlueprint: true, thePitchPackage: true },
+      { label: "Capital stack structure", theBlueprint: true, thePitchPackage: true },
+      { label: "Deal terms summary", theBlueprint: true, thePitchPackage: true },
+      { label: "Waterfall cascade (full tier-by-tier)", theBlueprint: true, thePitchPackage: true },
+      { label: "Scenario comparison (Conservative/Target/Optimistic)", theBlueprint: true, thePitchPackage: true },
+      { label: "Per-investor return profiles", theBlueprint: false, thePitchPackage: true },
+      { label: "Speaker notes for pitch presentation", theBlueprint: false, thePitchPackage: true },
     ],
   },
   {
     title: "Use Case",
     features: [
-      { label: "Best for", theExport: "Reference & planning", thePitchPackage: "Investor meetings", theWorkingModel: "Ongoing deal modeling" },
-      { label: "You need this when", theExport: "You want a clean record of your financial model", thePitchPackage: "You're preparing to pitch investors or co-financiers", theWorkingModel: "You model multiple projects or need to stress-test scenarios" },
-      { label: "Files delivered", theExport: "1 (PDF)", thePitchPackage: "4 (PDF + Excel + PPTX + Summary)", theWorkingModel: "5 (PDF + Excel + PPTX + Summary + Live Model)" },
+      { label: "Best for", theBlueprint: "Internal planning & documentation", thePitchPackage: "Investor meetings & capital raises" },
+      { label: "You need this when", theBlueprint: "You want a professional finance plan for your project", thePitchPackage: "You're preparing to pitch investors or co-financiers" },
+      { label: "Deliverables", theBlueprint: "4 documents", thePitchPackage: "8 documents" },
     ],
   },
 ];

--- a/src/pages/BuildYourPlan.tsx
+++ b/src/pages/BuildYourPlan.tsx
@@ -1,0 +1,477 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+import {
+  INITIAL_FORM_DATA,
+  STEP_LABELS,
+  type IntakeFormData,
+} from "@/lib/intake-types";
+import { useIntakeAutoSave } from "@/hooks/useIntakeAutoSave";
+import IntakeStep1 from "@/components/intake/IntakeStep1";
+import IntakeStep2 from "@/components/intake/IntakeStep2";
+import IntakeStep3 from "@/components/intake/IntakeStep3";
+import IntakeStep4 from "@/components/intake/IntakeStep4";
+import IntakeStep5 from "@/components/intake/IntakeStep5";
+import IntakeStep6 from "@/components/intake/IntakeStep6";
+
+/* ═══════════════════════════════════════════════════════════════════
+   PROGRESS BAR
+   ═══════════════════════════════════════════════════════════════════ */
+const ProgressBar = ({
+  currentStep,
+  onStepClick,
+}: {
+  currentStep: number;
+  onStepClick: (step: number) => void;
+}) => (
+  <div className="flex items-center justify-center gap-0 mb-8">
+    {STEP_LABELS.map((label, i) => {
+      const stepNum = i + 1;
+      const isCompleted = stepNum < currentStep;
+      const isCurrent = stepNum === currentStep;
+      const isFuture = stepNum > currentStep;
+      return (
+        <div key={label} className="flex items-center">
+          {/* Connector line (before each step except first) */}
+          {i > 0 && (
+            <div
+              className={cn(
+                "w-6 sm:w-10 h-[2px] transition-colors",
+                isCompleted ? "bg-gold" : "bg-white/10"
+              )}
+            />
+          )}
+          {/* Step circle + label */}
+          <button
+            onClick={() => stepNum <= currentStep && onStepClick(stepNum)}
+            disabled={isFuture}
+            className="flex flex-col items-center gap-1.5 group"
+          >
+            <div
+              className={cn(
+                "w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-mono font-bold transition-all",
+                isCompleted &&
+                  "bg-gold text-black",
+                isCurrent &&
+                  "border-2 border-gold text-gold bg-transparent",
+                isFuture &&
+                  "border border-white/15 text-white/25 bg-transparent cursor-not-allowed"
+              )}
+            >
+              {isCompleted ? (
+                <Check className="w-3.5 h-3.5" />
+              ) : (
+                stepNum
+              )}
+            </div>
+            <span
+              className={cn(
+                "text-[9px] tracking-[0.12em] uppercase font-semibold hidden sm:block",
+                isCompleted && "text-gold",
+                isCurrent && "text-gold",
+                isFuture && "text-white/25"
+              )}
+            >
+              {label}
+            </span>
+          </button>
+        </div>
+      );
+    })}
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════════════════
+   CONFIRMATION SCREEN
+   ═══════════════════════════════════════════════════════════════════ */
+const ConfirmationScreen = ({ email }: { email: string }) => (
+  <div className="min-h-screen bg-bg-void flex flex-col items-center justify-center px-6 animate-fade-in">
+    <div className="text-center max-w-md">
+      <div className="w-20 h-20 border-2 border-gold mx-auto mb-6 rounded-lg flex items-center justify-center">
+        <Check className="w-10 h-10 text-gold" />
+      </div>
+      <h1 className="font-bebas text-4xl text-text-primary mb-4">
+        YOUR FINANCE PLAN HAS BEEN SUBMITTED
+      </h1>
+      <p className="text-text-mid text-sm leading-relaxed mb-2">
+        We're building your deliverables now.
+      </p>
+      <p className="text-text-mid text-sm leading-relaxed mb-6">
+        You'll receive an email at{" "}
+        <span className="text-white font-semibold">{email}</span> within 24
+        hours.
+      </p>
+      <p className="text-text-dim text-xs leading-relaxed">
+        Questions? Email{" "}
+        <a
+          href="mailto:thefilmmaker.og@gmail.com"
+          className="text-gold hover:text-gold/80 transition-colors"
+        >
+          thefilmmaker.og@gmail.com
+        </a>
+      </p>
+    </div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════════════════
+   MAIN BUILD YOUR PLAN PAGE
+   ═══════════════════════════════════════════════════════════════════ */
+const BuildYourPlan = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session_id");
+
+  // State
+  const [loading, setLoading] = useState(true);
+  const [purchaseId, setPurchaseId] = useState<string | null>(null);
+  const [submissionId, setSubmissionId] = useState<string | null>(null);
+  const [tier, setTier] = useState<string>("the-blueprint");
+  const [includesWorkingModel, setIncludesWorkingModel] = useState(false);
+  const [email, setEmail] = useState("");
+  const [userId, setUserId] = useState<string | null>(null);
+  const [currentStep, setCurrentStep] = useState(1);
+  const [formData, setFormData] = useState<IntakeFormData>(INITIAL_FORM_DATA);
+  const [submitted, setSubmitted] = useState(false);
+
+  const { debouncedSave, saveNow } = useIntakeAutoSave(submissionId);
+
+  // Validate purchase on mount
+  useEffect(() => {
+    const validatePurchase = async () => {
+      try {
+        // Check auth
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) setUserId(user.id);
+
+        let purchase: any = null;
+
+        // Method 1: session_id from URL
+        if (sessionId) {
+          const { data } = await supabase
+            .from("purchases")
+            .select("*")
+            .eq("stripe_session_id", sessionId)
+            .eq("status", "completed")
+            .maybeSingle();
+          purchase = data;
+        }
+
+        // Method 2: authenticated user's most recent purchase (if no session_id)
+        if (!purchase && user) {
+          const { data } = await supabase
+            .from("purchases")
+            .select("*")
+            .eq("user_id", user.id)
+            .eq("status", "completed")
+            .in("product_id", [
+              "the-blueprint",
+              "the-pitch-package",
+              "the-blueprint,the-working-model-discount",
+              "the-pitch-package,the-working-model-discount",
+              "the-blueprint,the-working-model",
+              "the-pitch-package,the-working-model",
+            ])
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          purchase = data;
+        }
+
+        if (!purchase) {
+          toast.error("No valid purchase found. Please complete checkout first.");
+          navigate("/store");
+          return;
+        }
+
+        setPurchaseId(purchase.id);
+        setEmail(purchase.email);
+
+        // Determine tier from product_id
+        const productIds = (purchase.product_id as string).split(",");
+        const baseTier = productIds.find(
+          (id: string) => id === "the-blueprint" || id === "the-pitch-package"
+        ) || "the-blueprint";
+        setTier(baseTier);
+        setIncludesWorkingModel(
+          productIds.some(
+            (id: string) =>
+              id === "the-working-model" ||
+              id === "the-working-model-discount"
+          )
+        );
+
+        // Check for existing submission
+        const { data: existingSub } = await supabase
+          .from("intake_submissions")
+          .select("*")
+          .eq("purchase_id", purchase.id)
+          .maybeSingle();
+
+        if (existingSub) {
+          // Resume existing submission
+          setSubmissionId(existingSub.id);
+          setCurrentStep(existingSub.current_step || 1);
+          if (existingSub.status === "submitted") {
+            setSubmitted(true);
+            setLoading(false);
+            return;
+          }
+          // Populate form data from existing submission
+          setFormData((prev) => ({
+            ...prev,
+            project_title: existingSub.project_title || "",
+            production_company: existingSub.production_company || "",
+            genre: existingSub.genre || "",
+            logline: existingSub.logline || "",
+            total_budget: existingSub.total_budget,
+            equity_investors:
+              Array.isArray(existingSub.equity_investors) && existingSub.equity_investors.length > 0
+                ? existingSub.equity_investors as any
+                : prev.equity_investors,
+            has_debt:
+              Array.isArray(existingSub.debt_tranches) && existingSub.debt_tranches.length > 0 && (existingSub.debt_tranches as any[])[0]?.principal != null,
+            debt_tranches:
+              Array.isArray(existingSub.debt_tranches) && existingSub.debt_tranches.length > 0
+                ? existingSub.debt_tranches as any
+                : prev.debt_tranches,
+            soft_money:
+              Array.isArray(existingSub.soft_money) && existingSub.soft_money.length > 0
+                ? existingSub.soft_money as any
+                : prev.soft_money,
+            has_deferments:
+              Array.isArray(existingSub.deferments) && existingSub.deferments.length > 0 && (existingSub.deferments as any[])[0]?.role !== "",
+            deferments:
+              Array.isArray(existingSub.deferments) && existingSub.deferments.length > 0
+                ? existingSub.deferments as any
+                : prev.deferments,
+            distribution_model: existingSub.distribution_model || "",
+            sa_domestic_commission_pct: existingSub.sa_domestic_commission_pct ?? 12.5,
+            sa_international_commission_pct: existingSub.sa_international_commission_pct ?? 22.5,
+            sa_expense_cap: existingSub.sa_expense_cap ?? 75000,
+            sa_domestic_commission_is_default: existingSub.sa_domestic_commission_is_default ?? true,
+            sa_international_commission_is_default: existingSub.sa_international_commission_is_default ?? true,
+            sa_expense_cap_is_default: existingSub.sa_expense_cap_is_default ?? true,
+            dp_target_platform: existingSub.dp_target_platform || "",
+            dp_deal_type: existingSub.dp_deal_type || "",
+            cam_fee_pct: existingSub.cam_fee_pct ?? 0.75,
+            cam_fee_is_default: existingSub.cam_fee_is_default ?? true,
+            distribution_fee_domestic_pct: existingSub.distribution_fee_domestic_pct ?? 25,
+            distribution_fee_international_pct: existingSub.distribution_fee_international_pct ?? 35,
+            distribution_fee_domestic_is_default: existingSub.distribution_fee_domestic_is_default ?? true,
+            distribution_fee_international_is_default: existingSub.distribution_fee_international_is_default ?? true,
+            scenario_conservative: existingSub.scenario_conservative,
+            scenario_target: existingSub.scenario_target,
+            scenario_optimistic: existingSub.scenario_optimistic,
+          }));
+        } else {
+          // Create new submission
+          const { data: newSub, error } = await supabase
+            .from("intake_submissions")
+            .insert({
+              purchase_id: purchase.id,
+              user_id: user?.id || null,
+              email: purchase.email,
+              tier: baseTier,
+              includes_working_model: productIds.some(
+                (id: string) =>
+                  id === "the-working-model" ||
+                  id === "the-working-model-discount"
+              ),
+            })
+            .select("id")
+            .single();
+
+          if (error) {
+            console.error("Failed to create submission:", error);
+            toast.error("Failed to initialize your plan. Please try again.");
+            navigate("/store");
+            return;
+          }
+          setSubmissionId(newSub.id);
+        }
+      } catch (err) {
+        console.error("Purchase validation error:", err);
+        toast.error("Something went wrong. Please try again.");
+        navigate("/store");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    validatePurchase();
+  }, [sessionId, navigate]);
+
+  // Update form data and auto-save
+  const updateFormData = useCallback(
+    (updates: Partial<IntakeFormData>) => {
+      setFormData((prev) => {
+        const next = { ...prev, ...updates };
+        // Build the DB-compatible save payload
+        const savePayload: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(updates)) {
+          if (key === "has_debt" || key === "has_deferments") continue; // UI-only fields
+          savePayload[key] = value;
+        }
+        if (Object.keys(savePayload).length > 0) {
+          debouncedSave(savePayload);
+        }
+        return next;
+      });
+    },
+    [debouncedSave]
+  );
+
+  // Step navigation
+  const goToStep = useCallback(
+    async (step: number) => {
+      setCurrentStep(step);
+      await saveNow({ current_step: step });
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    },
+    [saveNow]
+  );
+
+  const handleNext = useCallback(() => {
+    if (currentStep < 6) goToStep(currentStep + 1);
+  }, [currentStep, goToStep]);
+
+  const handleBack = useCallback(() => {
+    if (currentStep > 1) goToStep(currentStep - 1);
+  }, [currentStep, goToStep]);
+
+  // Submit
+  const handleSubmit = useCallback(async () => {
+    if (!submissionId) return;
+    try {
+      const { error } = await supabase
+        .from("intake_submissions")
+        .update({
+          status: "submitted",
+          completed_at: new Date().toISOString(),
+          current_step: 6,
+        })
+        .eq("id", submissionId);
+
+      if (error) throw error;
+      setSubmitted(true);
+    } catch (err) {
+      console.error("Submit error:", err);
+      toast.error("Failed to submit. Please try again.");
+    }
+  }, [submissionId]);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-bg-void flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-gold border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-text-dim text-sm">Loading your plan...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Submitted confirmation
+  if (submitted) {
+    return <ConfirmationScreen email={email} />;
+  }
+
+  const tierLabel =
+    tier === "the-pitch-package" ? "The Pitch Package" : "The Blueprint";
+
+  return (
+    <div className="min-h-screen bg-bg-void flex flex-col">
+      {/* Header */}
+      <header className="sticky top-0 z-50 bg-bg-header/95 backdrop-blur-sm border-b border-white/[0.06]">
+        <div className="max-w-[640px] mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <span className="font-bebas text-lg tracking-[0.2em] text-gold">
+              FILMMAKER<span className="text-white">.OG</span>
+            </span>
+            <span className="text-text-dim text-[10px] tracking-[0.12em] uppercase">
+              Auto-saved
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 animate-fade-in">
+        <div className="max-w-[640px] mx-auto px-6 pt-8 pb-16">
+          {/* Title */}
+          <div className="text-center mb-6">
+            <h1 className="font-bebas text-3xl md:text-4xl tracking-[0.08em] text-gold mb-1">
+              BUILD YOUR FINANCE PLAN
+            </h1>
+            <p className="text-text-dim text-xs tracking-[0.15em] uppercase">
+              {tierLabel}
+            </p>
+          </div>
+
+          {/* Progress Bar */}
+          <ProgressBar currentStep={currentStep} onStepClick={goToStep} />
+
+          {/* Step Content */}
+          {currentStep === 1 && (
+            <IntakeStep1
+              formData={formData}
+              updateFormData={updateFormData}
+              onNext={handleNext}
+            />
+          )}
+          {currentStep === 2 && (
+            <IntakeStep2
+              formData={formData}
+              updateFormData={updateFormData}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
+          )}
+          {currentStep === 3 && (
+            <IntakeStep3
+              formData={formData}
+              updateFormData={updateFormData}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
+          )}
+          {currentStep === 4 && (
+            <IntakeStep4
+              formData={formData}
+              updateFormData={updateFormData}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
+          )}
+          {currentStep === 5 && (
+            <IntakeStep5
+              formData={formData}
+              updateFormData={updateFormData}
+              onNext={handleNext}
+              onBack={handleBack}
+            />
+          )}
+          {currentStep === 6 && (
+            <IntakeStep6
+              formData={formData}
+              tier={tier}
+              includesWorkingModel={includesWorkingModel}
+              email={email}
+              onEdit={goToStep}
+              onSubmit={handleSubmit}
+              onBack={handleBack}
+            />
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default BuildYourPlan;

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -14,10 +14,16 @@ import {
   Share2,
   Link2,
   ChevronDown,
+  X,
 } from "lucide-react";
 import Header from "@/components/Header";
 import { cn } from "@/lib/utils";
-import { products, comparisonSections, type Product } from "@/lib/store-products";
+import {
+  mainProducts,
+  addOnProduct,
+  comparisonSections,
+  type Product,
+} from "@/lib/store-products";
 import {
   Accordion,
   AccordionContent,
@@ -38,20 +44,20 @@ const SHARE_TITLE = "FILMMAKER.OG — See Where Every Dollar Goes";
    ═══════════════════════════════════════════════════════════════════ */
 const storeFaqs = [
   {
-    q: "How fast do I get my files?",
-    a: "Your files are generated instantly after purchase. Download immediately from your confirmation page.",
+    q: "How does it work?",
+    a: "After purchase, you'll be guided through a short intake form where you enter your project details, budget, capital stack, and deal structure. We use that information to build your finance plan and deliverables — delivered to your email within 24 hours.",
   },
   {
-    q: "Can I use these for multiple projects?",
-    a: "The Export and Pitch Package are generated from your current calculator inputs — one project per purchase. The Working Model includes a reusable Excel template you can use across unlimited future projects.",
+    q: "What's the difference between The Blueprint and The Pitch Package?",
+    a: "The Blueprint gives you the complete finance plan documentation (PDF, capital stack breakdown, scenario analysis, assumptions reference). The Pitch Package adds investor-facing materials: a PowerPoint pitch deck, individual investor return profiles, an executive summary leave-behind, and a deal terms summary.",
   },
   {
-    q: "What if I want to upgrade later?",
+    q: "What is The Working Model?",
+    a: "It's a live, formula-driven Excel workbook. Change any input and every downstream calculation updates instantly. It's the engine behind your finance plan — reusable across unlimited future projects.",
+  },
+  {
+    q: "Can I upgrade later?",
     a: "Contact us and we'll apply what you've already paid toward the higher tier.",
-  },
-  {
-    q: "Do I need to re-enter my data?",
-    a: "No. Your exports are generated directly from the financial model you already built in the calculator. Every number carries over automatically.",
   },
 ];
 
@@ -75,9 +81,9 @@ const trustColumns = [
   },
   {
     icon: Check,
-    cost: "$97–$397",
+    cost: "$197–$497",
     label: "filmmaker.og",
-    desc: "Instant. Professional. Yours.",
+    desc: "Professional. 24-hour delivery.",
     featured: true,
   },
 ];
@@ -208,6 +214,73 @@ const staggerChild = (visible: boolean) =>
   );
 
 /* ═══════════════════════════════════════════════════════════════════
+   WORKING MODEL POPUP
+   ═══════════════════════════════════════════════════════════════════ */
+const WorkingModelPopup = ({
+  baseProduct,
+  onAccept,
+  onDecline,
+  onClose,
+}: {
+  baseProduct: Product;
+  onAccept: () => void;
+  onDecline: () => void;
+  onClose: () => void;
+}) => (
+  <div className="fixed inset-0 z-[200] flex items-center justify-center p-6">
+    {/* Backdrop */}
+    <div
+      className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+      onClick={onClose}
+    />
+    {/* Modal */}
+    <div className="relative w-full max-w-md rounded-xl border border-gold/30 bg-[#0A0A0A] p-6 space-y-5 animate-fade-in">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 text-text-dim hover:text-text-mid transition-colors"
+      >
+        <X className="w-5 h-5" />
+      </button>
+
+      <div>
+        <h3 className="font-bebas text-2xl tracking-[0.06em] text-gold mb-1">
+          ADD THE LIVE EXCEL MODEL
+        </h3>
+        <p className="text-text-mid text-sm">50% off when you bundle now</p>
+      </div>
+
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-lg text-text-dim line-through">
+          $99
+        </span>
+        <span className="font-mono text-3xl font-medium text-white">$49</span>
+      </div>
+
+      <p className="text-text-dim text-sm leading-relaxed">
+        Get the formula-driven Excel engine behind your finance plan. Change any
+        input — watch every investor's return recalculate instantly. Reuse on
+        every project.
+      </p>
+
+      <div className="space-y-3">
+        <button
+          onClick={onAccept}
+          className="w-full h-14 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96] bg-gold/[0.22] border-2 border-gold/60 text-gold text-base hover:border-gold/80 hover:bg-gold/[0.28]"
+        >
+          Yes, Add for $49
+        </button>
+        <button
+          onClick={onDecline}
+          className="w-full text-center text-text-dim text-sm hover:text-text-mid transition-colors py-2"
+        >
+          No thanks, continue
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+/* ═══════════════════════════════════════════════════════════════════
    PRODUCT CARD
    ═══════════════════════════════════════════════════════════════════ */
 const ProductCard = ({
@@ -216,14 +289,18 @@ const ProductCard = ({
   onDetails,
   visible,
   index,
+  workingModelSelected,
 }: {
   product: Product;
   onBuy: () => void;
   onDetails: () => void;
   visible: boolean;
   index: number;
+  workingModelSelected: boolean;
 }) => {
   const isFeatured = product.featured;
+  const addOnPrice = workingModelSelected ? 99 : 0;
+  const totalPrice = product.price + addOnPrice;
 
   return (
     <div
@@ -284,7 +361,7 @@ const ProductCard = ({
         ))}
       </ul>
 
-      {/* CTA Button — translucent gold system */}
+      {/* CTA Button */}
       <button
         onClick={onBuy}
         className={cn(
@@ -294,11 +371,11 @@ const ProductCard = ({
             : "bg-gold/[0.12] border-2 border-gold/40 text-gold text-sm hover:border-gold/60 hover:bg-gold/[0.18]"
         )}
       >
-        {isFeatured
-          ? `Get The Pitch Package — $${product.price}`
-          : product.slug === "the-export"
-            ? `Get My Export — $${product.price}`
-            : `Get The Working Model — $${product.price}`}
+        {workingModelSelected
+          ? `Get ${product.name} — $${totalPrice}`
+          : isFeatured
+            ? `Get The Pitch Package — $${product.price}`
+            : `Get The Blueprint — $${product.price}`}
       </button>
 
       {/* Details link */}
@@ -315,7 +392,7 @@ const ProductCard = ({
 /* ═══════════════════════════════════════════════════════════════════
    COMPARISON TABLE TIER KEYS
    ═══════════════════════════════════════════════════════════════════ */
-const tierKeys = ["theExport", "thePitchPackage", "theWorkingModel"] as const;
+const tierKeys = ["theBlueprint", "thePitchPackage"] as const;
 
 /* ═══════════════════════════════════════════════════════════════════
    MAIN STORE COMPONENT
@@ -325,6 +402,8 @@ const Store = () => {
   const [searchParams] = useSearchParams();
   const [showSuccess, setShowSuccess] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [workingModelSelected, setWorkingModelSelected] = useState(false);
+  const [showPopup, setShowPopup] = useState<Product | null>(null);
   const [purchasedEmail] = useState(() => {
     try {
       return localStorage.getItem("filmmaker_og_purchase_email") || "";
@@ -346,7 +425,7 @@ const Store = () => {
   const revealFaq = useReveal();
 
   // Mobile-sorted products: featured first
-  const mobileProducts = [...products].sort(
+  const mobileProducts = [...mainProducts].sort(
     (a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0)
   );
 
@@ -373,6 +452,30 @@ const Store = () => {
     }
     handleCopyLink();
   }, [handleCopyLink]);
+
+  const handleBuy = (product: Product) => {
+    if (workingModelSelected) {
+      // Working Model already selected at full price — go straight to checkout
+      navigate(`/store/${product.slug}?addon=the-working-model`);
+    } else {
+      // Show Working Model popup
+      setShowPopup(product);
+    }
+  };
+
+  const handlePopupAccept = () => {
+    if (!showPopup) return;
+    // Bundle: base + discounted Working Model
+    navigate(`/store/${showPopup.slug}?addon=the-working-model-discount`);
+    setShowPopup(null);
+  };
+
+  const handlePopupDecline = () => {
+    if (!showPopup) return;
+    // Base product only
+    navigate(`/store/${showPopup.slug}`);
+    setShowPopup(null);
+  };
 
   /* ─── SUCCESS / CONFIRMATION VIEW ─── */
   if (showSuccess) {
@@ -422,18 +525,28 @@ const Store = () => {
     <div className="min-h-screen bg-bg-void flex flex-col">
       <Header title="PACKAGES" />
 
+      {/* Working Model Popup */}
+      {showPopup && (
+        <WorkingModelPopup
+          baseProduct={showPopup}
+          onAccept={handlePopupAccept}
+          onDecline={handlePopupDecline}
+          onClose={() => setShowPopup(null)}
+        />
+      )}
+
       <main className="flex-1 animate-fade-in">
         {/* ═══════════════════════════════════════════════════════════
             HERO
             ═══════════════════════════════════════════════════════════ */}
         <section className="px-6 pt-10 pb-8 max-w-3xl mx-auto text-center">
           <h1 className="font-bebas text-[clamp(2rem,7vw,3.2rem)] leading-[1.05] mb-4">
-            <span className="text-gold">YOUR NUMBERS.</span>{" "}
-            <span className="text-white">PRESENTATION-READY.</span>
+            <span className="text-gold">YOUR FINANCE PLAN.</span>{" "}
+            <span className="text-white">BUILT FOR YOU.</span>
           </h1>
           <p className="text-text-mid text-sm leading-relaxed max-w-lg mx-auto mb-6">
-            You built the model. Now export it in the format that matches your
-            next move.
+            Tell us about your project. We build your complete finance plan —
+            delivered within 24 hours.
           </p>
           <button
             onClick={() =>
@@ -536,13 +649,13 @@ const Store = () => {
         <GoldDivider />
 
         {/* ═══════════════════════════════════════════════════════════
-            PRODUCT GRID
+            PRODUCT GRID — Two main products
             ═══════════════════════════════════════════════════════════ */}
         <SectionFrame id="products" alt>
           <div
             ref={revealProducts.ref}
             className={cn(
-              "max-w-5xl mx-auto transition-all duration-500 ease-out",
+              "max-w-4xl mx-auto transition-all duration-500 ease-out",
               revealProducts.visible
                 ? "opacity-100 translate-y-0"
                 : "opacity-0 translate-y-4"
@@ -559,16 +672,17 @@ const Store = () => {
               }
             />
 
-            {/* Desktop: original order (Export / Pitch / Working Model) */}
-            <div className="hidden md:grid md:grid-cols-3 gap-5">
-              {products.map((product, i) => (
+            {/* Desktop: side by side */}
+            <div className="hidden md:grid md:grid-cols-2 gap-5">
+              {mainProducts.map((product, i) => (
                 <ProductCard
                   key={product.id}
                   product={product}
-                  onBuy={() => navigate(`/store/${product.slug}`)}
+                  onBuy={() => handleBuy(product)}
                   onDetails={() => navigate(`/store/${product.slug}`)}
                   visible={revealProducts.visible}
                   index={i}
+                  workingModelSelected={workingModelSelected}
                 />
               ))}
             </div>
@@ -579,13 +693,60 @@ const Store = () => {
                 <ProductCard
                   key={product.id}
                   product={product}
-                  onBuy={() => navigate(`/store/${product.slug}`)}
+                  onBuy={() => handleBuy(product)}
                   onDetails={() => navigate(`/store/${product.slug}`)}
                   visible={revealProducts.visible}
                   index={i}
+                  workingModelSelected={workingModelSelected}
                 />
               ))}
             </div>
+
+            {/* ADD-ON: The Working Model */}
+            {addOnProduct && (
+              <div
+                className={cn(
+                  "mt-5 rounded-xl p-5 transition-all cursor-pointer",
+                  workingModelSelected
+                    ? "border-2 border-gold bg-gold/[0.06]"
+                    : "border border-[#2A2A2A] bg-[#141414] hover:border-gold/30"
+                )}
+                onClick={() => setWorkingModelSelected(!workingModelSelected)}
+              >
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="px-2 py-0.5 rounded text-[9px] tracking-[0.12em] uppercase font-bold text-text-dim border border-white/10">
+                        Add-on
+                      </span>
+                      <h3 className="font-bebas text-lg tracking-[0.06em] text-white">
+                        {addOnProduct.name.toUpperCase()}
+                      </h3>
+                    </div>
+                    <p className="text-text-dim text-sm leading-relaxed">
+                      {addOnProduct.shortDescription}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <span className="font-mono text-2xl font-medium text-white">
+                      ${addOnProduct.price}
+                    </span>
+                    <div
+                      className={cn(
+                        "w-6 h-6 rounded border-2 flex items-center justify-center transition-all",
+                        workingModelSelected
+                          ? "border-gold bg-gold"
+                          : "border-white/20 bg-transparent"
+                      )}
+                    >
+                      {workingModelSelected && (
+                        <Check className="w-4 h-4 text-black" />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </SectionFrame>
 
@@ -598,7 +759,7 @@ const Store = () => {
           <div
             ref={revealCompare.ref}
             className={cn(
-              "max-w-5xl mx-auto transition-all duration-500 ease-out",
+              "max-w-4xl mx-auto transition-all duration-500 ease-out",
               revealCompare.visible
                 ? "opacity-100 translate-y-0"
                 : "opacity-0 translate-y-4"
@@ -613,7 +774,7 @@ const Store = () => {
                 </>
               }
               plainSubtitle
-              subtitle="Every tier is built from the same institutional-grade financial model. The difference is depth, format, and flexibility."
+              subtitle="Both tiers are built from the same institutional-grade financial model. The difference is depth and deliverables."
             />
 
             <div className="overflow-x-auto rounded-xl border border-[#2A2A2A] bg-[#141414]">
@@ -623,7 +784,7 @@ const Store = () => {
                     <th className="text-left text-text-dim text-[10px] font-sans font-semibold tracking-wider p-3 border-b border-[#2A2A2A] min-w-[160px]">
                       Feature
                     </th>
-                    {products.map((p) => (
+                    {mainProducts.map((p) => (
                       <th
                         key={p.id}
                         className={cn(
@@ -648,7 +809,7 @@ const Store = () => {
                           </span>
                           {p.featured && (
                             <span className="block text-[8px] tracking-[0.15em] uppercase text-gold font-bold mt-1">
-                              Most Popular
+                              Recommended
                             </span>
                           )}
                         </button>
@@ -660,10 +821,9 @@ const Store = () => {
                 <tbody>
                   {comparisonSections.map((section) => (
                     <React.Fragment key={`section-${section.title}`}>
-                      {/* Section header row */}
                       <tr>
                         <td
-                          colSpan={4}
+                          colSpan={3}
                           className="px-3 pt-5 pb-2 border-b border-[#2A2A2A]"
                         >
                           <span className="font-bebas text-sm tracking-[0.1em] text-gold uppercase">
@@ -672,7 +832,6 @@ const Store = () => {
                         </td>
                       </tr>
 
-                      {/* Feature rows */}
                       {section.features.map((feature) => (
                         <tr
                           key={feature.label}
@@ -713,11 +872,11 @@ const Store = () => {
             </div>
 
             {/* CTA row below table */}
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
-              {products.map((p) => (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
+              {mainProducts.map((p) => (
                 <button
                   key={p.id}
-                  onClick={() => navigate(`/store/${p.slug}`)}
+                  onClick={() => handleBuy(p)}
                   className={cn(
                     "h-14 rounded-md font-bold tracking-[0.12em] uppercase transition-all active:scale-[0.96]",
                     p.featured
@@ -725,11 +884,9 @@ const Store = () => {
                       : "bg-gold/[0.08] border-2 border-gold/40 text-gold text-sm hover:border-gold/60 hover:bg-gold/[0.18]"
                   )}
                 >
-                  {p.slug === "the-export"
-                    ? `Get My Export — $${p.price}`
-                    : p.featured
-                      ? `Get The Pitch Package — $${p.price}`
-                      : `Get The Working Model — $${p.price}`}
+                  {p.featured
+                    ? `Get The Pitch Package — $${p.price}`
+                    : `Get The Blueprint — $${p.price}`}
                 </button>
               ))}
             </div>

--- a/src/pages/StoreCompare.tsx
+++ b/src/pages/StoreCompare.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft, Check, Minus } from "lucide-react";
 import Header from "@/components/Header";
 import { cn } from "@/lib/utils";
-import { products, comparisonSections } from "@/lib/store-products";
+import { mainProducts, comparisonSections } from "@/lib/store-products";
 
-const tierKeys = ["theExport", "thePitchPackage", "theWorkingModel"] as const;
+const tierKeys = ["theBlueprint", "thePitchPackage"] as const;
 
 const StoreCompare = () => {
   const navigate = useNavigate();
@@ -20,7 +20,7 @@ const StoreCompare = () => {
 
       <main className="flex-1 animate-fade-in">
         {/* BACK NAV */}
-        <div className="px-6 pt-6 max-w-5xl mx-auto">
+        <div className="px-6 pt-6 max-w-4xl mx-auto">
           <button
             onClick={() => navigate("/store")}
             className="flex items-center gap-2 text-sm text-text-dim hover:text-text-mid transition-colors"
@@ -31,18 +31,18 @@ const StoreCompare = () => {
         </div>
 
         {/* HEADER */}
-        <section className="px-6 pt-8 pb-6 max-w-5xl mx-auto text-center">
+        <section className="px-6 pt-8 pb-6 max-w-4xl mx-auto text-center">
           <h1 className="font-bebas text-3xl md:text-4xl tracking-[0.08em] text-white mb-3">
             COMPARE <span className="text-gold">PACKAGES</span>
           </h1>
           <p className="text-text-mid text-sm max-w-lg mx-auto">
-            Every tier is built from the same institutional-grade financial
-            model. The difference is depth, format, and flexibility.
+            Both tiers are built from the same institutional-grade financial
+            model. The difference is depth and deliverables.
           </p>
         </section>
 
         {/* COMPARISON TABLE */}
-        <section className="px-4 pb-10 max-w-5xl mx-auto">
+        <section className="px-4 pb-10 max-w-4xl mx-auto">
           <div className="overflow-x-auto rounded-xl border border-[#2A2A2A] bg-[#141414]">
             <table className="w-full border-collapse">
               {/* Table Header */}
@@ -51,7 +51,7 @@ const StoreCompare = () => {
                   <th className="text-left text-text-dim text-[10px] font-sans font-semibold tracking-wider p-3 border-b border-[#2A2A2A] min-w-[160px]">
                     Feature
                   </th>
-                  {products.map((p) => (
+                  {mainProducts.map((p) => (
                     <th
                       key={p.id}
                       className={cn(
@@ -76,7 +76,7 @@ const StoreCompare = () => {
                         </span>
                         {p.featured && (
                           <span className="block text-[8px] tracking-[0.15em] uppercase text-gold font-bold mt-1">
-                            Most Popular
+                            Recommended
                           </span>
                         )}
                       </button>
@@ -87,11 +87,11 @@ const StoreCompare = () => {
 
               <tbody>
                 {comparisonSections.map((section) => (
-                  <>
+                  <React.Fragment key={`section-${section.title}`}>
                     {/* Section header row */}
-                    <tr key={`section-${section.title}`}>
+                    <tr>
                       <td
-                        colSpan={4}
+                        colSpan={3}
                         className="px-3 pt-5 pb-2 border-b border-[#2A2A2A]"
                       >
                         <span className="font-bebas text-sm tracking-[0.1em] text-gold uppercase">
@@ -134,7 +134,7 @@ const StoreCompare = () => {
                         })}
                       </tr>
                     ))}
-                  </>
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>
@@ -142,9 +142,9 @@ const StoreCompare = () => {
         </section>
 
         {/* CTA ROW */}
-        <section className="px-4 sm:px-6 pb-10 max-w-5xl mx-auto">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {products.map((p) => (
+        <section className="px-4 sm:px-6 pb-10 max-w-4xl mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {mainProducts.map((p) => (
               <button
                 key={p.id}
                 onClick={() => navigate(`/store/${p.slug}`)}
@@ -155,11 +155,9 @@ const StoreCompare = () => {
                     : "bg-gold/[0.08] border-2 border-gold/40 text-gold text-sm hover:border-gold/60 hover:bg-gold/[0.18]"
                 )}
               >
-                {p.slug === "the-export"
-                  ? `Get My Export — $${p.price}`
-                  : p.featured
-                    ? `Get The Pitch Package — $${p.price}`
-                    : `Get The Working Model — $${p.price}`}
+                {p.featured
+                  ? `Get The Pitch Package — $${p.price}`
+                  : `Get The Blueprint — $${p.price}`}
               </button>
             ))}
           </div>

--- a/supabase/migrations/20260214120000_create_intake_submissions.sql
+++ b/supabase/migrations/20260214120000_create_intake_submissions.sql
@@ -1,0 +1,115 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- INTAKE SUBMISSIONS — Finance Plan Builder guided form data
+-- ═══════════════════════════════════════════════════════════════════
+
+CREATE TABLE public.intake_submissions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  purchase_id UUID REFERENCES public.purchases(id) ON DELETE SET NULL,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  email TEXT NOT NULL,
+  tier TEXT NOT NULL, -- 'the-blueprint' or 'the-pitch-package'
+  includes_working_model BOOLEAN DEFAULT false,
+  status TEXT DEFAULT 'draft', -- 'draft', 'submitted', 'processing', 'delivered'
+
+  -- Step 1: Project Identity
+  project_title TEXT,
+  production_company TEXT,
+  genre TEXT,
+  logline TEXT,
+
+  -- Step 2: Budget
+  total_budget NUMERIC,
+  budget_currency TEXT DEFAULT 'USD',
+
+  -- Step 3: Capital Stack (stored as JSONB arrays for flexibility)
+  equity_investors JSONB DEFAULT '[]',
+  -- Each investor: { label, amount, priority, preferred_return_pct, profit_participation_pct, is_default }
+  debt_tranches JSONB DEFAULT '[]',
+  -- Each tranche: { label, principal, interest_rate_pct, security_type, priority, is_default }
+  soft_money JSONB DEFAULT '[]',
+  -- Each source: { label, type, amount, is_default }
+  -- type: 'tax_credit', 'grant', 'rebate', 'presale'
+  deferments JSONB DEFAULT '[]',
+  -- Each deferment: { role, amount, triggers_at, is_default }
+
+  -- Step 4: Deal Structure
+  distribution_model TEXT, -- 'sales_agent' or 'direct_platform'
+  -- Sales Agent fields (conditional: only if distribution_model = 'sales_agent')
+  sa_domestic_commission_pct NUMERIC DEFAULT 12.5,
+  sa_international_commission_pct NUMERIC DEFAULT 22.5,
+  sa_expense_cap NUMERIC DEFAULT 75000,
+  sa_domestic_commission_is_default BOOLEAN DEFAULT true,
+  sa_international_commission_is_default BOOLEAN DEFAULT true,
+  sa_expense_cap_is_default BOOLEAN DEFAULT true,
+  -- Direct Platform fields (conditional: only if distribution_model = 'direct_platform')
+  dp_target_platform TEXT, -- 'netflix', 'amazon', 'hulu', 'tubi', 'other'
+  dp_deal_type TEXT, -- 'cost_plus', 'acquisition', 'negative_pickup'
+  -- Common fields
+  cam_fee_pct NUMERIC DEFAULT 0.75,
+  cam_fee_is_default BOOLEAN DEFAULT true,
+  distribution_fee_domestic_pct NUMERIC DEFAULT 25,
+  distribution_fee_international_pct NUMERIC DEFAULT 35,
+  distribution_fee_domestic_is_default BOOLEAN DEFAULT true,
+  distribution_fee_international_is_default BOOLEAN DEFAULT true,
+
+  -- Step 5: Scenarios
+  scenario_conservative NUMERIC,
+  scenario_target NUMERIC,
+  scenario_optimistic NUMERIC,
+
+  -- Meta
+  current_step INTEGER DEFAULT 1,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_intake_purchase_id ON public.intake_submissions(purchase_id);
+CREATE INDEX idx_intake_user_id ON public.intake_submissions(user_id);
+CREATE INDEX idx_intake_email ON public.intake_submissions(email);
+CREATE INDEX idx_intake_status ON public.intake_submissions(status);
+
+-- RLS
+ALTER TABLE public.intake_submissions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own submissions"
+  ON public.intake_submissions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can create submissions"
+  ON public.intake_submissions FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Users can update own submissions"
+  ON public.intake_submissions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Service role can do anything (for webhooks and admin)
+CREATE POLICY "Service role full access"
+  ON public.intake_submissions FOR ALL
+  USING (public.is_service_role());
+
+-- Updated_at trigger (reuse existing function)
+CREATE TRIGGER update_intake_submissions_updated_at
+  BEFORE UPDATE ON public.intake_submissions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Notification hook point: log when status changes to 'submitted'
+-- (v1: operator monitors Supabase dashboard; v2: trigger sends email)
+CREATE OR REPLACE FUNCTION public.notify_intake_submitted()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.status = 'submitted' AND (OLD.status IS NULL OR OLD.status != 'submitted') THEN
+    RAISE LOG 'Intake submission submitted: id=%, project=%, email=%',
+      NEW.id, NEW.project_title, NEW.email;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER intake_submission_notify
+  AFTER UPDATE ON public.intake_submissions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.notify_intake_submitted();


### PR DESCRIPTION
…e, and post-purchase flow

Complete implementation of the Finance Plan Builder per spec:

Product Architecture:
- Replace 3-tier products with 2 main products + add-on: The Blueprint ($197), The Pitch Package ($497), The Working Model ($99 add-on)
- Add isAddOn/requiresBase fields to Product interface
- Update comparison table for 2-column layout

Stripe Checkout:
- Update create-checkout with new product IDs and prices ($197/$497/$99/$49)
- Add multi-item checkout support for bundle transactions
- Add $49 discounted Working Model bundle price
- Route success URL to /build-your-plan

Post-Purchase Intake Form (/build-your-plan):
- Purchase gate: validates session_id or authenticated user's purchase
- 6-step guided form with progress bar:
  1. Project Identity (title, company, genre, logline)
  2. Budget (with contextual teaching copy by range)
  3. Capital Stack (dynamic equity/debt/soft money/deferment blocks)
  4. Deal Structure (sales agent vs direct platform with conditional fields)
  5. Scenarios (conservative/target/optimistic with validation)
  6. Review & Submit (full summary, defaults disclosure, confirmation)
- All industry defaults pre-populated with tooltips and ranges
- Auto-save (2s debounce) to Supabase draft
- Resume from last step on return visit

Store Updates:
- 2-card main grid + subordinate add-on card with toggle
- Working Model popup (50% off bundle offer before checkout)
- Updated FAQs, hero copy, and comparison table

Database:
- New intake_submissions table with full schema
- RLS policies, indexes, and notification trigger
- Updated Supabase types.ts

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7