### PR TITLE
Visual/UX fixes: CTA gold enforcement, dead CSS cleanup, header + cal…

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import MobileMenu from "./MobileMenu";
 
-interface HeaderProps {
-  title?: string;
-}
-
-const Header = ({ title }: HeaderProps) => {
+const Header = () => {
   const navigate = useNavigate();
 
   const handleLogoClick = () => {
@@ -31,13 +27,6 @@ const Header = ({ title }: HeaderProps) => {
               BETA
             </span>
           </button>
-
-          {/* Center: Title (optional) */}
-          {title && (
-            <span className="font-bebas text-sm tracking-[0.15em] text-gold absolute left-1/2 -translate-x-1/2">
-              {title}
-            </span>
-          )}
 
           {/* Right: Hamburger Menu */}
           <MobileMenu />

--- a/src/components/calculator/ChapterCard.tsx
+++ b/src/components/calculator/ChapterCard.tsx
@@ -41,8 +41,8 @@ const ChapterCard = ({
         </div>
       </header>
 
-      {/* Body - Applied bg-elevated to match Wiki style cards */}
-      <div className="chapter-card-body bg-bg-elevated/50">
+      {/* Body */}
+      <div className="chapter-card-body">
         {children}
       </div>
     </section>

--- a/src/components/calculator/StandardStepLayout.tsx
+++ b/src/components/calculator/StandardStepLayout.tsx
@@ -44,7 +44,7 @@ const StandardStepLayout = ({
         chapter={chapter}
         title={title}
         isActive={true}
-        className="overflow-visible min-h-[500px]" 
+        className="overflow-visible" 
       >
         <div className="flex flex-col h-full justify-between space-y-6">
           {/* Top Content */}

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -212,7 +212,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, onExport }
                 </p>
                 <button
                   onClick={onExport}
-                  className="btn-vault w-full"
+                  className="btn-cta-primary w-full h-14"
                 >
                   <FileSpreadsheet className="w-4 h-4 mr-2" />
                   EXPORT YOUR FINANCIAL SNAPSHOT

--- a/src/index.css
+++ b/src/index.css
@@ -187,37 +187,33 @@
      Matches Wiki Style: bg-elevated, border-gold-muted, shadow-gold-glow
      ═══════════════════════════════════════════════════════════════════ */
   .chapter-card {
-    background: var(--bg-card); /* Fallback */
-    /* Radiant Gold Border */
-    border: 1px solid rgba(212, 175, 55, 0.3); 
+    background: var(--bg-card);
+    border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: var(--radius-lg);
     overflow: hidden;
-    min-height: 400px;
-    /* Subtle Inner Glow */
-    box-shadow: inset 0 0 20px rgba(212, 175, 55, 0.05); 
+    min-height: auto;
     position: relative;
   }
 
-  /* The "Active" state is now the default visual language for the calculator steps */
   .chapter-card.is-active {
-    border-color: var(--gold-muted);
-    box-shadow: 0 0 25px rgba(212, 175, 55, 0.1), inset 0 0 20px rgba(212, 175, 55, 0.05);
+    border-color: rgba(255, 255, 255, 0.06);
   }
 
   .chapter-card-header {
     display: grid;
-    grid-template-columns: 4px 60px 1fr auto;
+    grid-template-columns: 3px 52px 1fr auto;
     align-items: center;
-    height: 66px;
-    background: linear-gradient(90deg, rgba(212, 175, 55, 0.15) 0%, var(--bg-elevated) 20%, var(--bg-elevated) 100%);
+    height: 52px;
+    background: var(--bg-elevated);
     border-bottom: 1px solid var(--border-subtle);
   }
 
+  /* Gold accent bar — matches SectionFrame's left bar */
   .chapter-card-gold-bar {
-    width: 4px;
+    width: 3px;
     height: 100%;
-    background: linear-gradient(180deg, var(--gold) 0%, var(--gold-muted) 100%);
-    box-shadow: 0 0 12px var(--gold-glow);
+    background: linear-gradient(180deg, var(--gold) 0%, rgba(212, 175, 55, 0.60) 60%, rgba(212, 175, 55, 0.20) 100%);
+    box-shadow: 0 0 16px rgba(212, 175, 55, 0.30);
   }
 
   .chapter-card-number {
@@ -227,18 +223,16 @@
     height: 100%;
     border-right: 1px solid var(--border-subtle);
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 24px;
+    font-size: 22px;
     letter-spacing: 1px;
     color: var(--gold);
-    background: var(--gold-subtle);
-    text-shadow: 0 0 10px var(--gold-glow);
     transition: all var(--timing-medium) ease;
   }
 
   .chapter-card-title {
     padding: 0 var(--space-md);
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 22px;
+    font-size: 20px;
     letter-spacing: 1.5px;
     text-transform: uppercase;
     color: var(--text-primary);
@@ -246,8 +240,7 @@
 
   .chapter-card-body {
     padding: var(--space-lg);
-    /* Ensure the body matches the "elevated" grey look */
-    background: var(--bg-elevated); 
+    background: var(--bg-elevated);
   }
 
   /* ═══════════════════════════════════════════════════════════════════
@@ -268,77 +261,9 @@
   }
 
   /* ═══════════════════════════════════════════════════════════════════
-     STORE BUTTONS
+     STORE BUTTONS — Legacy classes removed. All CTAs now use
+     .btn-cta-primary / .btn-cta-secondary (see STANDARDISED CTA section)
      ═══════════════════════════════════════════════════════════════════ */
-  .btn-vault {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    min-height: 52px;
-    padding: var(--space-md) var(--space-lg);
-    background: linear-gradient(135deg, rgba(249, 224, 118, 0.18) 0%, rgba(212, 175, 55, 0.12) 100%);
-    border: 1px solid var(--gold-cta-muted);
-    border-radius: var(--radius-md);
-    font-family: 'DM Sans', sans-serif;
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--gold-cta);
-    cursor: pointer;
-    transition: all var(--timing-fast) ease;
-    box-shadow: 0 8px 32px rgba(249, 224, 118, 0.2), inset 0 1px 0 rgba(249, 224, 118, 0.1);
-  }
-
-  .btn-vault:hover {
-    background: linear-gradient(135deg, rgba(249, 224, 118, 0.25) 0%, rgba(212, 175, 55, 0.18) 100%);
-    box-shadow: 0 12px 40px rgba(249, 224, 118, 0.3), inset 0 1px 0 rgba(249, 224, 118, 0.15);
-  }
-
-  .btn-vault:active {
-    transform: scale(0.97);
-  }
-
-  .btn-vault:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
-    box-shadow: none;
-  }
-
-  .btn-ghost-gold {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    min-height: 52px;
-    padding: var(--space-md) var(--space-lg);
-    background: rgba(212, 175, 55, 0.04);
-    border: 1px solid rgba(212, 175, 55, 0.25);
-    border-radius: var(--radius-md);
-    font-family: 'DM Sans', sans-serif;
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--gold);
-    cursor: pointer;
-    transition: all var(--timing-fast) ease;
-  }
-
-  .btn-ghost-gold:hover {
-    background: rgba(212, 175, 55, 0.08);
-    border-color: rgba(212, 175, 55, 0.4);
-  }
-
-  .btn-ghost-gold:active {
-    transform: scale(0.97);
-  }
-
-  .btn-ghost-gold:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
-  }
 
   /* ═══════════════════════════════════════════════════════════════════
      STORE-SPECIFIC STYLES
@@ -566,64 +491,9 @@
   }
 
   /* ═══════════════════════════════════════════════════════════════════
-     PRIMARY BUTTON (CTA) — Uses CTA Gold exclusively
+     LEGACY BUTTON CLASSES — Removed (.btn-primary, .btn-secondary)
+     All CTAs now consolidated under .btn-cta-primary / .btn-cta-secondary
      ═══════════════════════════════════════════════════════════════════ */
-  .btn-primary {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    min-height: 52px;
-    padding: var(--space-md) var(--space-lg);
-    background: var(--gold-cta-subtle);
-    border: 1px solid var(--gold-cta-muted);
-    border-radius: var(--radius-md);
-    font-family: 'DM Sans', sans-serif;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--gold-cta);
-    cursor: pointer;
-    transition: all var(--timing-fast) ease;
-    box-shadow: var(--shadow-button);
-  }
-
-  .btn-primary:active {
-    transform: scale(0.92);
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════
-     SECONDARY BUTTON
-     ═══════════════════════════════════════════════════════════════════ */
-  .btn-secondary {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    min-height: 52px;
-    padding: var(--space-md) var(--space-lg);
-    background: transparent;
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    font-family: 'DM Sans', sans-serif;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-primary);
-    cursor: pointer;
-    transition: all var(--timing-fast) ease;
-  }
-
-  .btn-secondary:active {
-    transform: scale(0.92);
-  }
 
   /* ═══════════════════════════════════════════════════════════════════
      TOUCH FEEDBACK
@@ -756,16 +626,16 @@
      CTA GLOW SOFT — inviting, not aggressive
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes cta-glow-soft {
-    0%, 100% { box-shadow: 0 0 12px rgba(212,175,55,0.10); }
-    50% { box-shadow: 0 0 20px rgba(212,175,55,0.20); }
+    0%, 100% { box-shadow: 0 0 12px rgba(249,224,118,0.08); }
+    50% { box-shadow: 0 0 20px rgba(249,224,118,0.18); }
   }
   .animate-cta-glow-soft {
     animation: cta-glow-soft 3s ease-in-out infinite;
   }
 
   @keyframes cta-glow-pulse {
-    0%, 100% { box-shadow: 0 0 14px rgba(212,175,55,0.12); }
-    50% { box-shadow: 0 0 24px rgba(212,175,55,0.25); }
+    0%, 100% { box-shadow: 0 0 14px rgba(249,224,118,0.10); }
+    50% { box-shadow: 0 0 24px rgba(249,224,118,0.22); }
   }
   .animate-cta-glow-pulse {
     animation: cta-glow-pulse 3s ease-in-out infinite;
@@ -777,9 +647,9 @@
      Secondary: non-featured product / comparison CTAs
      ═══════════════════════════════════════════════════════════════════ */
   .btn-cta-primary {
-    background: rgba(212, 175, 55, 0.18);
-    border: 2px solid rgba(212, 175, 55, 0.50);
-    color: var(--gold);
+    background: var(--gold-cta-subtle);
+    border: 2px solid var(--gold-cta-muted);
+    color: var(--gold-cta);
     font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
@@ -788,16 +658,16 @@
     animation: cta-glow-soft 3s ease-in-out infinite;
   }
   .btn-cta-primary:hover {
-    border-color: rgba(212, 175, 55, 0.70);
-    background: rgba(212, 175, 55, 0.22);
+    border-color: rgba(249, 224, 118, 0.65);
+    background: rgba(249, 224, 118, 0.18);
   }
   .btn-cta-primary:active {
     transform: scale(0.96);
   }
 
   .btn-cta-secondary {
-    background: rgba(212, 175, 55, 0.12);
-    border: 2px solid rgba(212, 175, 55, 0.40);
+    background: transparent;
+    border: 1px solid var(--gold-muted);
     color: var(--gold);
     font-weight: 700;
     letter-spacing: 0.12em;
@@ -807,7 +677,7 @@
   }
   .btn-cta-secondary:hover {
     border-color: rgba(212, 175, 55, 0.60);
-    background: rgba(212, 175, 55, 0.18);
+    background: rgba(212, 175, 55, 0.08);
   }
   .btn-cta-secondary:active {
     transform: scale(0.96);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -98,7 +98,7 @@ const Auth = () => {
     <div className="min-h-screen min-h-[100dvh] bg-bg-void flex flex-col">
       
       {/* Header with hamburger menu */}
-      <Header title="SIGN IN" />
+      <Header />
 
       {/* Main Content - Centered */}
       <main className="flex-1 flex items-center justify-center px-6 py-12">

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -402,7 +402,7 @@ const Store = () => {
   if (showSuccess) {
     return (
       <div className="min-h-screen bg-bg-void flex flex-col">
-        <Header title="CONFIRMED" />
+        <Header />
         <main className="flex-1 px-6 py-16 flex items-center justify-center animate-fade-in">
           <div className="text-center max-w-md">
             <div className="w-20 h-20 border-2 border-gold mx-auto mb-6 rounded-lg flex items-center justify-center">
@@ -444,7 +444,7 @@ const Store = () => {
   /* ─── MAIN STORE VIEW ─── */
   return (
     <div className="min-h-screen bg-bg-void flex flex-col">
-      <Header title="PACKAGES" />
+      <Header />
 
       {/* Working Model Popup */}
       {showPopup && (

--- a/src/pages/StoreCompare.tsx
+++ b/src/pages/StoreCompare.tsx
@@ -16,7 +16,7 @@ const StoreCompare = () => {
 
   return (
     <div className="min-h-screen bg-bg-void flex flex-col">
-      <Header title="PACKAGES" />
+      <Header />
 
       <main className="flex-1 animate-fade-in">
         {/* BACK NAV */}

--- a/src/pages/StorePackage.tsx
+++ b/src/pages/StorePackage.tsx
@@ -46,7 +46,7 @@ const StorePackage = () => {
   if (!product) {
     return (
       <div className="min-h-screen bg-bg-void flex flex-col">
-        <Header title="NOT FOUND" />
+        <Header />
         <main className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <p className="text-text-mid mb-4">Package not found.</p>
@@ -118,7 +118,7 @@ const StorePackage = () => {
 
   return (
     <div className="min-h-screen bg-bg-void flex flex-col">
-      <Header title="PACKAGES" />
+      <Header />
 
       <main className="flex-1 animate-fade-in">
         {/* BACK NAV */}

--- a/src/pages/WaterfallInfo.tsx
+++ b/src/pages/WaterfallInfo.tsx
@@ -54,7 +54,7 @@ const WaterfallInfo = () => {
               </Button>
               <button
                 onClick={handleReturnToCalculator}
-                className="btn-vault h-9 w-auto px-4 text-xs"
+                className="btn-cta-secondary h-9 w-auto px-4 text-xs"
               >
                 <Calculator className="w-3 h-3 mr-2" />
                 Open Calculator
@@ -230,7 +230,7 @@ const WaterfallInfo = () => {
             </p>
             <button
               onClick={handleReturnToCalculator}
-              className="btn-vault w-full max-w-xs h-12 px-8 text-sm"
+              className="btn-cta-primary w-full max-w-xs h-12 px-8 text-sm"
             >
               Open Calculator
               <ArrowRight className="ml-2 w-4 h-4" />


### PR DESCRIPTION
…culator alignment

1. Button system: .btn-cta-primary now uses CTA gold (#F9E076) per two-gold rule; .btn-cta-secondary uses metallic gold, 1px border, transparent bg. CTA glow keyframes updated to pulse CTA gold.

2. Dead CSS deleted (~120 lines): .btn-vault, .btn-ghost-gold, .btn-primary, .btn-secondary — all replaced by .btn-cta-* classes.

3. Header title prop removed: centered title competed with logo on mobile's 56px header; stripped from Header.tsx + all callers (Store, Auth, StoreCompare, StorePackage).

4. Calculator cards aligned to SectionFrame: border changed to white/[0.06], gold bar matches SectionFrame's gradient + shadow, header flattened to 52px bg-elevated, removed inner glow + gold number cell bg + min-height constraints + double bg-elevated stacking.

5. btn-vault refs updated: WaterfallTab export CTA → btn-cta-primary, WaterfallInfo nav button → btn-cta-secondary.

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7