### PR TITLE
Direct-to-Stripe checkout: eliminate StorePackage as checkout interme…

### DIFF
--- a/src/components/WorkingModelPopup.tsx
+++ b/src/components/WorkingModelPopup.tsx
@@ -1,0 +1,70 @@
+import { X } from "lucide-react";
+import type { Product } from "@/lib/store-products";
+
+interface WorkingModelPopupProps {
+  baseProduct: Product;
+  onAccept: () => void;
+  onDecline: () => void;
+  onClose: () => void;
+}
+
+const WorkingModelPopup = ({
+  baseProduct,
+  onAccept,
+  onDecline,
+  onClose,
+}: WorkingModelPopupProps) => (
+  <div className="fixed inset-0 z-[200] flex items-center justify-center p-6">
+    {/* Backdrop */}
+    <div
+      className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+      onClick={onClose}
+    />
+    {/* Modal */}
+    <div className="relative w-full max-w-md rounded-xl border border-gold/30 bg-bg-header p-6 space-y-5 animate-fade-in">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 text-text-dim hover:text-text-mid transition-colors"
+      >
+        <X className="w-5 h-5" />
+      </button>
+
+      <div>
+        <h3 className="font-bebas text-2xl tracking-[0.06em] text-gold mb-1">
+          ADD THE LIVE EXCEL MODEL
+        </h3>
+        <p className="text-text-mid text-sm">50% off when you bundle now</p>
+      </div>
+
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-lg text-text-dim line-through">
+          $99
+        </span>
+        <span className="font-mono text-3xl font-medium text-white">$49</span>
+      </div>
+
+      <p className="text-text-dim text-sm leading-relaxed">
+        Get the formula-driven Excel engine behind your finance plan. Change any
+        input — watch every investor's return recalculate instantly. Reuse on
+        every project.
+      </p>
+
+      <div className="space-y-3">
+        <button
+          onClick={onAccept}
+          className="w-full h-14 text-base btn-cta-primary"
+        >
+          Yes, Add for $49
+        </button>
+        <button
+          onClick={onDecline}
+          className="w-full text-center text-text-dim text-sm hover:text-text-mid transition-colors py-2"
+        >
+          No thanks, continue
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default WorkingModelPopup;

--- a/src/lib/checkout.ts
+++ b/src/lib/checkout.ts
@@ -1,0 +1,22 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Invoke create-checkout edge function and return the Stripe URL.
+ * Email is NOT required — Stripe Checkout will collect it if not provided.
+ */
+export async function startCheckout(
+  productId: string,
+  addonId?: string
+): Promise<string> {
+  const body: Record<string, unknown> = addonId
+    ? { items: [productId, addonId] }
+    : { productId };
+
+  const { data, error } = await supabase.functions.invoke("create-checkout", {
+    body,
+  });
+
+  if (error) throw error;
+  if (!data?.url) throw new Error("No checkout URL returned");
+  return data.url;
+}

--- a/src/pages/StorePackage.tsx
+++ b/src/pages/StorePackage.tsx
@@ -72,11 +72,6 @@ const StorePackage = () => {
     if (!agreedTerms || !isEmailValid()) return;
     setLoading(true);
     try {
-      // Save email for confirmation page
-      try {
-        localStorage.setItem("filmmaker_og_purchase_email", getEmail()!);
-      } catch { /* ignore */ }
-
       // Build the checkout request
       let body: Record<string, unknown>;
       if (addonId) {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -54,10 +54,18 @@ serve(async (req) => {
         Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
       );
 
+      // Pull email from Stripe's customer_details (collected on checkout page),
+      // then fall back to customer_email or metadata.
+      const purchaseEmail =
+        session.customer_details?.email ||
+        session.customer_email ||
+        metadata.userEmail ||
+        "";
+
       // Insert purchase record
       const { error: insertError } = await supabaseAdmin.from("purchases").insert({
         user_id: metadata.userId || null,
-        email: session.customer_email || metadata.userEmail || "",
+        email: purchaseEmail,
         stripe_session_id: session.id,
         stripe_payment_intent: typeof session.payment_intent === "string" ? session.payment_intent : null,
         product_id: metadata.productId || "",


### PR DESCRIPTION
…diary

Buy buttons on Store.tsx and StoreCompare.tsx now invoke create-checkout directly after the Working Model popup decision — no navigation to StorePackage for email/terms collection. Stripe Checkout collects email.

- create-checkout: email is now optional; Stripe collects it if not provided
- stripe-webhook: pull email from session.customer_details (Stripe-collected)
- Store.tsx: handleBuy → popup → doCheckout() → Stripe redirect
- StoreCompare.tsx: same direct-to-Stripe pattern with popup
- Extract shared WorkingModelPopup component and startCheckout utility
- Delete dead success view from Store.tsx (Stripe redirects to /build-your-plan)
- Delete localStorage email persistence chain (no longer needed)

https://claude.ai/code/session_011tUAWx7RptDuM7ja9EsHA7