### PR TITLE
Fix crash: remove leftover isReturningUser refs in sticky CTA

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -312,7 +312,7 @@ const Index = () => {
   // Sticky CTA button for the header
   const stickyCtaButton = isComplete ? (
     <button
-      onClick={isReturningUser ? handleContinueClick : handleStartClick}
+      onClick={handleStartClick}
       className={cn(
         "font-bebas text-[13px] tracking-[0.14em] uppercase whitespace-nowrap",
         "h-8 px-3.5",
@@ -326,7 +326,7 @@ const Index = () => {
       )}
       style={{ borderRadius: 0 }}
     >
-      {isReturningUser ? "CONTINUE" : "BUILD FREE"}
+      BUILD FREE
     </button>
   ) : undefined;
 


### PR DESCRIPTION
The sticky header CTA still referenced isReturningUser and handleContinueClick which were deleted in the previous commit, causing a ReferenceError on page load. Always use handleStartClick and "BUILD FREE" label.

https://claude.ai/code/session_01N73V8uvqitXPJwAyGdSDKV