### PR TITLE
Visual polish: footer indicators, header sizing, menu premium redesign

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, createContext, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
-import filmmakerFIcon from "@/assets/filmmaker-f-icon.png";
 
 /* ═══════════════════════════════════════════════════════════════════
    HeaderCtaContext — lets Index.tsx inject a sticky CTA into the
@@ -54,7 +53,7 @@ const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
             className="flex items-center gap-2.5 hover:opacity-80 transition-opacity group flex-shrink-0"
             aria-label="Go home"
           >
-            <span className="font-bebas text-lg tracking-[0.2em] group-hover:opacity-80 transition-opacity duration-200"
+            <span className="font-bebas text-[22px] tracking-[0.2em] group-hover:opacity-80 transition-opacity duration-200"
               style={{ color: GOLD_FULL }}
             >
               FILMMAKER
@@ -73,24 +72,32 @@ const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
 
           {/* Right — Bot icon + vertical ⋮ */}
           <div className="flex items-center gap-1 flex-shrink-0">
-            {/* F-icon bot button */}
+            {/* OG Bot button */}
             <button
               onClick={onBotOpen}
-              className="relative w-10 h-10 flex items-center justify-center transition-all duration-200 active:scale-90"
-              aria-label="Ask the OG"
-              style={{ color: isBotOpen ? GOLD_FULL : GOLD_DIM }}
+              className="relative w-10 h-10 flex flex-col items-center justify-center transition-all duration-200 active:scale-90"
+              aria-label="Ask the OG Bot"
             >
-              <img
-                src={filmmakerFIcon}
-                alt="OG Bot"
-                className="w-6 h-6 object-contain transition-all duration-200"
+              <span
+                className="font-bebas leading-none transition-opacity duration-200"
                 style={{
-                  opacity: isBotOpen ? 1 : 0.65,
-                  filter: isBotOpen
-                    ? "drop-shadow(0 0 8px rgba(212,175,55,0.95)) brightness(1.1)"
-                    : "sepia(0.3) saturate(0.8)",
+                  fontSize: "15px",
+                  letterSpacing: "0.14em",
+                  color: isBotOpen ? GOLD_FULL : GOLD_DIM,
                 }}
-              />
+              >
+                OG
+              </span>
+              <span
+                className="font-mono uppercase leading-none transition-opacity duration-200"
+                style={{
+                  fontSize: "8px",
+                  letterSpacing: "0.10em",
+                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.45)",
+                }}
+              >
+                bot
+              </span>
               {/* Active glow ring */}
               {isBotOpen && (
                 <span
@@ -115,14 +122,8 @@ const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
           </div>
         </div>
 
-        {/* Gold gradient separator line — identical to Header.tsx */}
-        <div
-          className="h-[1px] w-full"
-          style={{
-            background:
-              "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.45) 20%, rgba(212,175,55,0.45) 80%, transparent 100%)",
-          }}
-        />
+        {/* Gold gradient separator line */}
+        <div className="h-[1px] w-full bg-gradient-to-r from-transparent via-gold/45 to-transparent" />
       </header>
 
       {/* Spacer for fixed header */}

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Home, Calculator, ShoppingBag } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -11,11 +12,18 @@ const tabs = [
 const BottomTabBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [rippleId, setRippleId] = useState<string | null>(null);
 
   const getActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
     return location.pathname.startsWith(path);
   };
+
+  const handleTap = useCallback((tab: typeof tabs[0]) => {
+    setRippleId(tab.id);
+    navigate(tab.path);
+    setTimeout(() => setRippleId(null), 420);
+  }, [navigate]);
 
   const GOLD_FULL = "rgba(212,175,55,1)";
   const GOLD_DIM  = "rgba(212,175,55,0.65)";
@@ -53,16 +61,23 @@ const BottomTabBar = () => {
           return (
             <button
               key={tab.id}
-              onClick={() => navigate(tab.path)}
+              onClick={() => handleTap(tab)}
               className={cn(
-                "relative flex-1 flex flex-col items-center justify-center gap-[3px] transition-all duration-200 active:scale-95",
+                "relative flex-1 flex flex-col items-center justify-center gap-[3px] transition-all duration-200 active:scale-95 overflow-hidden",
               )}
               style={{ color: isActive ? GOLD_FULL : GOLD_DIM }}
               aria-label={tab.label}
             >
+              {/* Gold tap-ripple */}
+              {rippleId === tab.id && (
+                <span
+                  className="absolute top-1/2 left-1/2 w-10 h-10 rounded-full pointer-events-none animate-tap-ripple"
+                  style={{ background: "rgba(212,175,55,0.3)" }}
+                />
+              )}
               <Icon className="w-5 h-5" />
               <span
-                className="font-mono leading-none transition-all"
+                className="font-bebas leading-none transition-all"
                 style={{
                   fontSize: "10px",
                   letterSpacing: isActive ? "0.16em" : "0.10em",

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -59,7 +59,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
   const SectionLabel = ({ children }: { children: React.ReactNode }) => (
     <div className="flex items-center gap-3 pl-1 mb-2">
       <div className="h-[1px] flex-1" style={{ background: "linear-gradient(90deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
-      <span className="font-bebas text-[10px] text-gold/50 uppercase tracking-[0.25em] flex-shrink-0">{children}</span>
+      <span className="font-bebas text-[11px] text-gold/50 uppercase tracking-[0.25em] flex-shrink-0">{children}</span>
       <div className="h-[1px] flex-1" style={{ background: "linear-gradient(270deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
     </div>
   );
@@ -73,15 +73,16 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
         />
       )}
 
-      {/* Bottom Sheet */}
+      {/* Bottom Sheet — premium black */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 bg-bg-card z-[201] rounded-t-2xl max-h-[85vh] overflow-y-auto",
+          "fixed bottom-0 left-0 right-0 z-[201] rounded-t-2xl max-h-[85vh] overflow-y-auto",
           "transition-transform duration-300 ease-out",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}
         style={{
           paddingBottom: "env(safe-area-inset-bottom)",
+          background: "#0A0A0A",
           boxShadow: "0 -4px 60px rgba(212,175,55,0.12), 0 -2px 20px rgba(0,0,0,0.80)",
         }}
         onTouchStart={handleTouchStart}
@@ -97,10 +98,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
         {/* Drag handle + X close button */}
         <div className="relative flex justify-center pt-3 pb-5">
-          <div className="w-8 h-1 bg-white/15 rounded-full" />
+          <div className="w-8 h-1 bg-gold/30 rounded-full" />
           <button
             onClick={() => setIsOpen(false)}
-            className="absolute top-2 right-4 w-8 h-8 flex items-center justify-center text-white/40 hover:text-gold transition-colors"
+            className="absolute top-2 right-4 w-8 h-8 flex items-center justify-center text-gold/40 hover:text-gold transition-colors"
             aria-label="Close menu"
           >
             <CloseIcon className="w-4 h-4" />
@@ -112,9 +113,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           <div className="space-y-2">
             <SectionLabel>Menu</SectionLabel>
             <div className="grid grid-cols-2 gap-2">
+              {/* Packages — featured card with gold left accent */}
               <button
                 onClick={() => handleNavigate('/store')}
-                className="flex items-center gap-2.5 p-3.5 border col-span-2 text-left group transition-all"
+                className="relative flex items-center gap-2.5 p-3.5 border col-span-2 text-left group transition-all overflow-hidden"
                 style={{
                   borderRadius: 0,
                   borderColor: "rgba(212,175,55,0.50)",
@@ -122,18 +124,22 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                 }}
               >
                 <div
+                  className="absolute left-0 top-0 bottom-0 w-[3px]"
+                  style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.30), transparent)" }}
+                />
+                <div
                   className="w-7 h-7 flex items-center justify-center flex-shrink-0"
                   style={{ background: "var(--gold)", borderRadius: 0 }}
                 >
                   <Book className="w-4 h-4 text-black" />
                 </div>
                 <span className="font-bebas text-base tracking-wide text-gold leading-none">Packages</span>
-                <span className="ml-auto font-bebas text-[10px] tracking-[0.2em] text-gold/40 leading-none">VIEW ALL →</span>
+                <span className="ml-auto font-bebas text-[11px] tracking-[0.2em] text-gold/40 leading-none">VIEW ALL →</span>
               </button>
 
               <button
                 onClick={() => handleNavigate('/')}
-                className="flex items-center gap-2.5 p-3.5 border border-border-subtle bg-white/[0.02] text-left group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Home className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
@@ -142,7 +148,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
               <button
                 onClick={() => handleNavigate('/calculator')}
-                className="flex items-center gap-2.5 p-3.5 border border-border-subtle bg-white/[0.02] text-left group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Calculator className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
@@ -151,7 +157,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
               <button
                 onClick={() => handleNavigate('/waterfall-info')}
-                className="flex items-center gap-2.5 p-3.5 border border-border-subtle bg-white/[0.02] text-left group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <BookOpen className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
@@ -160,7 +166,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
               <button
                 onClick={() => handleNavigate('/glossary')}
-                className="flex items-center gap-2.5 p-3.5 border border-border-subtle bg-white/[0.02] text-left group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Book className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
@@ -170,12 +176,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           </div>
 
           {/* Contact + Share */}
-          <div className="pt-2 border-t border-border-subtle space-y-2">
+          <div className="pt-2 border-t border-white/[0.08] space-y-2">
             <SectionLabel>Contact & Share</SectionLabel>
             <div className="grid grid-cols-3 gap-2">
               <a
                 href="mailto:thefilmmaker.og@gmail.com"
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-border-subtle bg-white/[0.02] text-center group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Mail className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
@@ -186,7 +192,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                 href="https://www.instagram.com/filmmaker.og"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-border-subtle bg-white/[0.02] text-center group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Instagram className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
@@ -195,7 +201,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
               <button
                 onClick={handleShare}
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-border-subtle bg-white/[0.02] text-center group hover:border-gold/30 hover:bg-gold/[0.04] transition-all"
+                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <Share2 className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
@@ -215,7 +221,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
               onClick={() => handleNavigate('/')}
               className="flex items-center gap-2 hover:opacity-80 transition-opacity group"
             >
-              <span className="font-bebas text-lg tracking-[0.2em] text-gold group-hover:text-white transition-colors duration-200">
+              <span className="font-bebas text-[22px] tracking-[0.2em] text-gold group-hover:text-white transition-colors duration-200">
                 FILMMAKER<span className="text-white group-hover:text-gold transition-colors duration-200">.OG</span>
               </span>
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -891,4 +891,15 @@
   .animate-typing-dot-3 {
     animation: typingDot 1.4s ease-in-out 0.4s infinite;
   }
+
+  /* ═══════════════════════════════════════════════════════════════════
+     TAP RIPPLE — gold radial pulse for BottomTabBar
+     ═══════════════════════════════════════════════════════════════════ */
+  @keyframes tap-ripple {
+    0%   { transform: translate(-50%, -50%) scale(0); opacity: 0.4; }
+    100% { transform: translate(-50%, -50%) scale(1); opacity: 0; }
+  }
+  .animate-tap-ripple {
+    animation: tap-ripple 400ms ease-out forwards;
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -57,7 +57,7 @@ const productTiers = [
   {
     tier: "Courtesy", product: "Waterfall Simulator", price: "Free",
     desc: "Model your deal. See where every dollar goes.",
-    pct: 30, barClass: "bg-[#D4AF37]/30", tierColor: "text-gold/50",
+    pct: 30, barClass: "bg-[#D4AF37]/30", tierColor: "text-gold/65",
     nameColor: "text-white/90", descColor: "text-white/50", barH: "h-2",
     featured: false, elevated: false,
   },
@@ -326,7 +326,7 @@ const Index = () => {
         )}
         style={{ borderRadius: 0 }}
       >
-        BUILD FREE
+        BUILD NOW
       </button>
     );
     setCtaSlot(ctaButton);
@@ -952,11 +952,11 @@ const Index = () => {
                       className={cn(
                         "w-full mt-2 font-bebas tracking-[0.10em] uppercase transition-all",
                         t.featured
-                          ? "h-12 text-sm btn-cta-primary"
+                          ? "h-12 text-base btn-cta-primary"
                           : "h-10 text-sm btn-cta-secondary"
                       )}
                     >
-                      {i === 0 ? "BUILD FREE" : "VIEW PACKAGE"}
+                      {i === 0 ? "START BUILDING" : "VIEW PACKAGE"}
                     </button>
                   </div>
                 ))}
@@ -966,7 +966,7 @@ const Index = () => {
               <div className="text-center mt-10">
                 <button onClick={handleStartClick}
                   className="w-full max-w-[320px] h-14 text-base btn-cta-primary mx-auto">
-                  BUILD YOUR WATERFALL &mdash; FREE
+                  BUILD YOUR WATERFALL
                 </button>
                 <div className="mt-5 flex items-center justify-center gap-4">
                   <button onClick={() => navigate("/store")} className="text-white/50 text-[15px] hover:text-gold transition-colors">
@@ -1043,23 +1043,26 @@ const Index = () => {
             <div className="max-w-sm mx-auto">
               <div className="grid grid-cols-3 gap-3 mb-8 max-w-[340px] mx-auto">
                 <a href="mailto:thefilmmaker.og@gmail.com"
-                  className="flex items-center justify-center gap-2.5 text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
+                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
                   <Mail className="w-4 h-4" /><span>Email</span>
                 </a>
                 <a href="https://www.instagram.com/filmmaker.og" target="_blank" rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2.5 text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
+                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
                   <Instagram className="w-4 h-4" /><span>Instagram</span>
                 </a>
                 <button onClick={() => { haptics.light(); handleShare(); }}
-                  className="flex items-center justify-center gap-2.5 text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
+                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
                   <Share2 className="w-4 h-4" /><span>Share</span>
                 </button>
               </div>
 
-              <div className="flex items-center justify-center mb-4">
+              {/* Flanking gold lines around wordmark */}
+              <div className="flex items-center gap-4 mb-4">
+                <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent to-gold/30" />
                 <span className="font-bebas text-3xl tracking-[0.2em] text-gold">
                   FILMMAKER<span className="text-white">.OG</span>
                 </span>
+                <div className="h-[1px] flex-1 bg-gradient-to-l from-transparent to-gold/30" />
               </div>
               <p className="text-white/40 text-xs tracking-wide leading-relaxed text-center">
                 For educational and informational purposes only. Not legal, tax, or investment advice.


### PR DESCRIPTION
- Add gold tap-ripple animation to BottomTabBar icons on press
- Bump FILMMAKER.OG header wordmark from 18px to 22px
- Replace F-icon PNG bot button with text-based "OG / bot" element
- Remove "FREE" from all CTAs except the hero (first) CTA
- MobileMenu: darken bg to #0A0A0A, gold drag handle, gold accents, stronger borders, gold left-accent bar on Packages button
- Footer: add font-bebas to icon buttons, flanking gold lines on wordmark
- BottomTabBar labels from font-mono to font-bebas
- Bump Courtesy tier label opacity from gold/50 to gold/65
- Unify header separator to Tailwind gradient pattern
- Featured product CTA bumped to text-base

https://claude.ai/code/session_01Jpn593v6fScWfUqiLCzoj4