### PR TITLE
Round 2: OG bot visibility, white tab labels, menu gold pop, footer c…

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -77,37 +77,32 @@ const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
               onClick={onBotOpen}
               className="relative w-10 h-10 flex flex-col items-center justify-center transition-all duration-200 active:scale-90"
               aria-label="Ask the OG Bot"
+              style={{
+                background: isBotOpen ? "rgba(212,175,55,0.08)" : "rgba(255,255,255,0.06)",
+                border: isBotOpen ? "1px solid rgba(212,175,55,0.25)" : "1px solid rgba(255,255,255,0.10)",
+                borderRadius: "6px",
+              }}
             >
               <span
-                className="font-bebas leading-none transition-opacity duration-200"
+                className="font-bebas leading-none transition-all duration-200"
                 style={{
-                  fontSize: "15px",
+                  fontSize: "17px",
                   letterSpacing: "0.14em",
-                  color: isBotOpen ? GOLD_FULL : GOLD_DIM,
+                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.85)",
                 }}
               >
                 OG
               </span>
               <span
-                className="font-mono uppercase leading-none transition-opacity duration-200"
+                className="font-mono uppercase leading-none transition-all duration-200"
                 style={{
-                  fontSize: "8px",
+                  fontSize: "9px",
                   letterSpacing: "0.10em",
-                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.45)",
+                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.55)",
                 }}
               >
                 bot
               </span>
-              {/* Active glow ring */}
-              {isBotOpen && (
-                <span
-                  className="absolute inset-0 rounded-md pointer-events-none"
-                  style={{
-                    background: "rgba(212,175,55,0.08)",
-                    border: "1px solid rgba(212,175,55,0.25)",
-                  }}
-                />
-              )}
             </button>
 
             {/* Vertical ⋮ menu button */}

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -65,7 +65,6 @@ const BottomTabBar = () => {
               className={cn(
                 "relative flex-1 flex flex-col items-center justify-center gap-[3px] transition-all duration-200 active:scale-95 overflow-hidden",
               )}
-              style={{ color: isActive ? GOLD_FULL : GOLD_DIM }}
               aria-label={tab.label}
             >
               {/* Gold tap-ripple */}
@@ -75,13 +74,17 @@ const BottomTabBar = () => {
                   style={{ background: "rgba(212,175,55,0.3)" }}
                 />
               )}
-              <Icon className="w-5 h-5" />
+              <Icon
+                className="w-5 h-5"
+                style={{ color: isActive ? GOLD_FULL : GOLD_DIM }}
+              />
               <span
                 className="font-bebas leading-none transition-all"
                 style={{
                   fontSize: "10px",
                   letterSpacing: isActive ? "0.16em" : "0.10em",
                   fontWeight: isActive ? 500 : 400,
+                  color: isActive ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.55)",
                 }}
               >
                 {tab.label}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -181,10 +181,11 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
             <div className="grid grid-cols-3 gap-2">
               <a
                 href="mailto:thefilmmaker.og@gmail.com"
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
+                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <Mail className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
+                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
+                <Mail className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
                 <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Email</span>
               </a>
 
@@ -192,19 +193,21 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                 href="https://www.instagram.com/filmmaker.og"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
+                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <Instagram className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
+                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
+                <Instagram className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
                 <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Instagram</span>
               </a>
 
               <button
                 onClick={handleShare}
-                className="flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
+                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <Share2 className="w-4 h-4 text-white/50 group-hover:text-gold transition-colors" />
+                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
+                <Share2 className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
                 <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Share</span>
               </button>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -776,6 +776,7 @@
     background: rgba(212, 175, 55, 0.06);
     border: 1px solid rgba(212, 175, 55, 0.30);
     color: var(--gold);
+    font-family: 'Bebas Neue', sans-serif;
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,9 +6,6 @@ import {
   Check,
   X,
   LockKeyhole,
-  Mail,
-  Instagram,
-  Share2,
   ChevronDown,
 } from "lucide-react";
 import filmmakerLogo from "@/assets/filmmaker-f-icon.png";
@@ -21,7 +18,6 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { cn } from "@/lib/utils";
-import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
 import SectionFrame from "@/components/SectionFrame";
 import SectionHeader from "@/components/SectionHeader";
 
@@ -278,13 +274,6 @@ const Index = () => {
   }, [phase, hasSeenCinematic]);
 
   const handleStartClick    = () => { haptics.medium(); gatedNavigate("/calculator?tab=budget"); };
-
-  const handleShare = useCallback(async () => {
-    if (navigator.share) {
-      try { await navigator.share({ title: SHARE_TITLE, text: SHARE_TEXT, url: getShareUrl() }); return; } catch {}
-    }
-    navigator.clipboard.writeText(`${SHARE_TEXT}\n\n${getShareUrl()}`).catch(() => {});
-  }, []);
 
   const isComplete = phase === 'complete';
   const showBeam = phase !== 'dark' && !shouldSkip;
@@ -901,7 +890,7 @@ const Index = () => {
                     className={cn(
                       "relative border overflow-hidden p-5 md:p-7 transition-all duration-600 ease-out",
                       t.featured
-                        ? "border-gold/50 bg-white/[0.04]"
+                        ? "border-gold/50 bg-gold/[0.04]"
                         : t.elevated
                           ? "border-white/[0.12] bg-white/[0.04]"
                           : "border-white/[0.10] bg-white/[0.04]",
@@ -909,12 +898,16 @@ const Index = () => {
                     )}
                     style={{
                       transitionDelay: revPath.visible ? `${i * 150}ms` : '0ms',
-                      ...(t.featured ? { boxShadow: '0 0 30px rgba(212,175,55,0.10), 0 0 60px rgba(212,175,55,0.05)' } : {}),
+                      ...(t.featured ? { boxShadow: '0 0 40px rgba(212,175,55,0.15), 0 0 80px rgba(212,175,55,0.06)' } : {}),
                     }}
                   >
-                    {/* Gold top accent — featured gets a full-width gold bar */}
+                    {/* Gold top accent — featured gets a full-width gold bar + glow */}
                     {t.featured && (
-                      <div className="absolute top-0 left-0 right-0 h-[2px] bg-gold/70" />
+                      <>
+                        <div className="absolute top-0 left-0 right-0 h-[2px] bg-gold/70" />
+                        <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
+                          style={{ width: '80%', height: '60px', background: 'radial-gradient(ellipse 80% 100% at 50% 0%, rgba(212,175,55,0.08) 0%, transparent 70%)' }} />
+                      </>
                     )}
                     {/* Gold left accent — all cards get one, same weight */}
                     <div className="absolute left-0 top-0 bottom-0 w-[3px]"
@@ -924,7 +917,7 @@ const Index = () => {
                     />
                     {t.featured && (
                       <div className="mb-3">
-                        <span className="text-[11px] tracking-[0.16em] uppercase font-bold text-gold bg-gold/[0.12] px-3 py-1.5 border border-gold/30">
+                        <span className="text-[12px] tracking-[0.20em] uppercase font-bold text-gold bg-gold/[0.12] px-3 py-1.5 border border-gold/30">
                           Recommended
                         </span>
                       </div>
@@ -938,7 +931,7 @@ const Index = () => {
                         t.featured ? "text-gold" : "text-white/50"
                       )}>
                         {'originalPrice' in t && t.originalPrice && (
-                          <span className="text-white/40 line-through mr-1.5 text-[13px]">{t.originalPrice}</span>
+                          <span className="text-white/50 line-through mr-1.5 text-[13px]">{t.originalPrice}</span>
                         )}
                         {t.price}
                       </span>
@@ -1041,21 +1034,6 @@ const Index = () => {
           <footer className="py-10 px-6">
             <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/40 to-transparent mb-8" />
             <div className="max-w-sm mx-auto">
-              <div className="grid grid-cols-3 gap-3 mb-8 max-w-[340px] mx-auto">
-                <a href="mailto:thefilmmaker.og@gmail.com"
-                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
-                  <Mail className="w-4 h-4" /><span>Email</span>
-                </a>
-                <a href="https://www.instagram.com/filmmaker.og" target="_blank" rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
-                  <Instagram className="w-4 h-4" /><span>Instagram</span>
-                </a>
-                <button onClick={() => { haptics.light(); handleShare(); }}
-                  className="flex items-center justify-center gap-2.5 font-bebas text-sm tracking-wider text-gold/80 hover:text-gold bg-white/[0.04] hover:bg-white/[0.07] transition-all active:scale-[0.97] py-5 border border-white/[0.12] hover:border-gold/40">
-                  <Share2 className="w-4 h-4" /><span>Share</span>
-                </button>
-              </div>
-
               {/* Flanking gold lines around wordmark */}
               <div className="flex items-center gap-4 mb-4">
                 <div className="h-[1px] flex-1 bg-gradient-to-r from-transparent to-gold/30" />


### PR DESCRIPTION
…leanup

- OG bot button: add visible container (bg + border), bump text sizes (OG→17px, bot→9px), brighten inactive colors for clear visibility
- Bottom tab labels: gold → white (icons stay gold, labels white/55 inactive, white/95 active) for better readability
- MobileMenu contact icons: default gold/60 with 1px gold left-accent bars for visual structure and brand reinforcement
- .btn-cta-secondary: add missing font-family 'Bebas Neue' to match primary and final CTA button typography
- Arsenal featured card: stronger glow shadow, gold-tinted bg, larger Recommended badge, brighter strikethrough price, top gold radial glow
- Footer: remove redundant Email/Instagram/Share buttons (already in menu), clean minimal footer with just wordmark + disclaimer
- Clean up unused imports (Mail, Instagram, Share2, handleShare)

https://claude.ai/code/session_01Jpn593v6fScWfUqiLCzoj4