### PR TITLE
Round 3: OG bot FAB, Resources page, tab bar polish, bot sheet cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import { lazy, Suspense, useState, ReactNode } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ErrorBoundary from "./components/ErrorBoundary";
 import BottomTabBar from "./components/BottomTabBar";
 import OgBotSheet from "./components/OgBotSheet";
+import OgBotFab from "./components/OgBotFab";
 import MobileMenu from "./components/MobileMenu";
 import AppHeader, { HeaderCtaContext } from "./components/AppHeader";
 
@@ -20,6 +21,7 @@ const CapitalInfo = lazy(() => import("./pages/CapitalInfo"));
 const FeesInfo = lazy(() => import("./pages/FeesInfo"));
 const WaterfallInfo = lazy(() => import("./pages/WaterfallInfo"));
 const Glossary = lazy(() => import("./pages/Glossary"));
+const Resources = lazy(() => import("./pages/Resources"));
 const Auth = lazy(() => import("./pages/Auth"));
 const Calculator = lazy(() => import("./pages/Calculator"));
 const Store = lazy(() => import("./pages/Store"));
@@ -51,8 +53,6 @@ const AppShell = () => {
   return (
     <HeaderCtaContext.Provider value={{ ctaSlot, setCtaSlot }}>
       <AppHeader
-        onBotOpen={() => setIsBotOpen(true)}
-        isBotOpen={isBotOpen}
         onMoreOpen={() => setIsMenuOpen(true)}
       />
 
@@ -62,8 +62,9 @@ const AppShell = () => {
           <Route path="/budget-info" element={<BudgetInfo />} />
           <Route path="/capital-info" element={<CapitalInfo />} />
           <Route path="/fees-info" element={<FeesInfo />} />
-          <Route path="/waterfall-info" element={<WaterfallInfo />} />
-          <Route path="/glossary" element={<Glossary />} />
+          <Route path="/resources" element={<Resources />} />
+          <Route path="/waterfall-info" element={<Navigate to="/resources?tab=waterfall" replace />} />
+          <Route path="/glossary" element={<Navigate to="/resources?tab=terms" replace />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/calculator" element={<Calculator />} />
           <Route path="/store" element={<Store />} />
@@ -78,6 +79,7 @@ const AppShell = () => {
       {/* Global persistent UI — always mounted */}
       <OgBotSheet isOpen={isBotOpen} onOpenChange={setIsBotOpen} />
       <MobileMenu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen} />
+      <OgBotFab onClick={() => setIsBotOpen(true)} isActive={isBotOpen} />
       <BottomTabBar />
     </HeaderCtaContext.Provider>
   );

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -25,15 +25,13 @@ export const useHeaderCta = () => useContext(HeaderCtaContext);
    Right:  F-icon bot button + vertical ⋮ menu button
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
-  onBotOpen?: () => void;
-  isBotOpen?: boolean;
   onMoreOpen?: () => void;
 }
 
 const GOLD_FULL = "rgba(212,175,55,1)";
 const GOLD_DIM  = "rgba(212,175,55,0.65)";
 
-const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
+const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
   const navigate = useNavigate();
   const { ctaSlot } = useHeaderCta();
 
@@ -70,42 +68,8 @@ const AppHeader = ({ onBotOpen, isBotOpen, onMoreOpen }: AppHeaderProps) => {
             </div>
           )}
 
-          {/* Right — Bot icon + vertical ⋮ */}
-          <div className="flex items-center gap-1 flex-shrink-0">
-            {/* OG Bot button */}
-            <button
-              onClick={onBotOpen}
-              className="relative w-10 h-10 flex flex-col items-center justify-center transition-all duration-200 active:scale-90"
-              aria-label="Ask the OG Bot"
-              style={{
-                background: isBotOpen ? "rgba(212,175,55,0.08)" : "rgba(255,255,255,0.06)",
-                border: isBotOpen ? "1px solid rgba(212,175,55,0.25)" : "1px solid rgba(255,255,255,0.10)",
-                borderRadius: "6px",
-              }}
-            >
-              <span
-                className="font-bebas leading-none transition-all duration-200"
-                style={{
-                  fontSize: "17px",
-                  letterSpacing: "0.14em",
-                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.85)",
-                }}
-              >
-                OG
-              </span>
-              <span
-                className="font-mono uppercase leading-none transition-all duration-200"
-                style={{
-                  fontSize: "9px",
-                  letterSpacing: "0.10em",
-                  color: isBotOpen ? GOLD_FULL : "rgba(212,175,55,0.55)",
-                }}
-              >
-                bot
-              </span>
-            </button>
-
-            {/* Vertical ⋮ menu button */}
+          {/* Right — vertical ⋮ menu */}
+          <div className="flex items-center flex-shrink-0">
             <button
               onClick={onMoreOpen}
               className="w-10 h-10 flex items-center justify-center transition-all duration-200 active:scale-90 hover:opacity-80"

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Home, Calculator, ShoppingBag } from "lucide-react";
+import { Home, Calculator, ShoppingBag, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const tabs = [
   { id: "home",       path: "/",           label: "HOME", icon: Home },
   { id: "calculator", path: "/calculator", label: "CALC", icon: Calculator },
   { id: "store",      path: "/store",      label: "PKGS", icon: ShoppingBag },
+  { id: "resources",  path: "/resources",  label: "INFO", icon: BookOpen },
 ];
 
 const BottomTabBar = () => {
@@ -26,7 +27,7 @@ const BottomTabBar = () => {
   }, [navigate]);
 
   const GOLD_FULL = "rgba(212,175,55,1)";
-  const GOLD_DIM  = "rgba(212,175,55,0.65)";
+  const GOLD_DIM  = "rgba(212,175,55,0.75)";
 
   return (
     /* Full-width transparent wrapper — handles safe-area, centers the pill */
@@ -48,9 +49,9 @@ const BottomTabBar = () => {
           height: "54px",
           borderRadius: "16px",
           background: "#0A0A0A",
-          border: "1.5px solid rgba(212,175,55,0.35)",
+          border: "1.5px solid rgba(212,175,55,0.45)",
           boxShadow:
-            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.10)",
+            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.10), 0 0 15px rgba(212,175,55,0.08)",
           paddingLeft: "6px",
           paddingRight: "6px",
         }}
@@ -64,7 +65,11 @@ const BottomTabBar = () => {
               onClick={() => handleTap(tab)}
               className={cn(
                 "relative flex-1 flex flex-col items-center justify-center gap-[3px] transition-all duration-200 active:scale-95 overflow-hidden",
+                isActive && "rounded-lg",
               )}
+              style={{
+                background: isActive ? "rgba(255,255,255,0.06)" : "transparent",
+              }}
               aria-label={tab.label}
             >
               {/* Gold tap-ripple */}
@@ -84,7 +89,7 @@ const BottomTabBar = () => {
                   fontSize: "10px",
                   letterSpacing: isActive ? "0.16em" : "0.10em",
                   fontWeight: isActive ? 500 : 400,
-                  color: isActive ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.55)",
+                  color: isActive ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.65)",
                 }}
               >
                 {tab.label}
@@ -94,8 +99,8 @@ const BottomTabBar = () => {
                 <span
                   className="absolute bottom-[5px] left-1/2 -translate-x-1/2"
                   style={{
-                    width: "18px",
-                    height: "2px",
+                    width: "24px",
+                    height: "2.5px",
                     borderRadius: "2px",
                     background: GOLD_FULL,
                     display: "block",

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -156,21 +156,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
               </button>
 
               <button
-                onClick={() => handleNavigate('/waterfall-info')}
+                onClick={() => handleNavigate('/resources')}
                 className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
                 style={{ borderRadius: 0 }}
               >
                 <BookOpen className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
-                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Waterfall</span>
-              </button>
-
-              <button
-                onClick={() => handleNavigate('/glossary')}
-                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
-                style={{ borderRadius: 0 }}
-              >
-                <Book className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
-                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Glossary</span>
+                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Resources</span>
               </button>
             </div>
           </div>

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -1,0 +1,41 @@
+interface OgBotFabProps {
+  onClick: () => void;
+  isActive?: boolean;
+}
+
+const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
+  return (
+    <button
+      onClick={onClick}
+      aria-label="Ask the OG Bot"
+      className="fixed z-[145] flex items-center justify-center transition-all duration-200 active:scale-90"
+      style={{
+        bottom: "calc(78px + env(safe-area-inset-bottom))",
+        right: "16px",
+        width: "48px",
+        height: "48px",
+        borderRadius: 0,
+        background: isActive ? "rgba(212,175,55,1)" : "#0A0A0A",
+        border: isActive
+          ? "1.5px solid rgba(212,175,55,0.70)"
+          : "1.5px solid rgba(212,175,55,0.45)",
+        boxShadow: isActive
+          ? "0 0 24px rgba(212,175,55,0.30), 0 4px 16px rgba(0,0,0,0.60)"
+          : "0 0 20px rgba(212,175,55,0.15), 0 4px 16px rgba(0,0,0,0.60)",
+      }}
+    >
+      <span
+        className="font-bebas leading-none"
+        style={{
+          fontSize: "18px",
+          letterSpacing: "0.14em",
+          color: isActive ? "#000000" : "rgba(212,175,55,1)",
+        }}
+      >
+        OG
+      </span>
+    </button>
+  );
+};
+
+export default OgBotFab;

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -243,29 +243,11 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           <div className="w-10 h-[3px] rounded-full" style={{ background: "rgba(255,255,255,0.15)" }} />
         </div>
 
-        {/* ── Sheet header — eyebrow pattern ── */}
+        {/* ── Sheet header ── */}
         <div
           className="px-5 pt-3 pb-4 flex-shrink-0 border-b"
           style={{ borderColor: "rgba(212,175,55,0.18)" }}
         >
-          {/* Eyebrow flanking line row */}
-          <div className="flex items-center gap-3 mb-3">
-            <div className="h-[1px] flex-1" style={{ background: "linear-gradient(to right, transparent, rgba(212,175,55,0.40))" }} />
-            <div className="flex items-center gap-2">
-              <img
-                src={filmmakerFIcon}
-                alt="OG"
-                className="w-4 h-4 object-contain"
-                style={{ filter: "drop-shadow(0 0 4px rgba(212,175,55,0.7))", opacity: 0.9 }}
-              />
-              <span className="font-mono text-[10px] tracking-[0.28em] uppercase" style={{ color: "rgba(212,175,55,0.60)" }}>
-                Film Industry Q&amp;A
-              </span>
-            </div>
-            <div className="h-[1px] flex-1" style={{ background: "linear-gradient(to left, transparent, rgba(212,175,55,0.40))" }} />
-          </div>
-
-          {/* Big title row */}
           <div className="flex items-end justify-between">
             <h2 className="font-bebas text-[28px] tracking-[0.15em] leading-none" style={{ color: "rgba(212,175,55,1)" }}>
               ASK THE OG
@@ -301,14 +283,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           {/* Empty state — example chips with eyebrow */}
           {ogMessages.length === 0 && (
             <div className="flex flex-col items-center gap-5 pt-3">
-              {/* Eyebrow */}
-              <div className="flex items-center gap-3 w-full">
-                <div className="h-[1px] flex-1" style={{ background: "rgba(255,255,255,0.08)" }} />
-                <span className="font-mono text-[10px] tracking-[0.22em] uppercase whitespace-nowrap" style={{ color: "rgba(255,255,255,0.22)" }}>
-                  What do you want to know
-                </span>
-                <div className="h-[1px] flex-1" style={{ background: "rgba(255,255,255,0.08)" }} />
-              </div>
+              <span className="font-bebas text-[14px] tracking-[0.12em]" style={{ color: "rgba(255,255,255,0.70)" }}>
+                What do you want to know
+              </span>
 
               {/* Chips */}
               <div className="flex flex-wrap gap-2.5 justify-center">
@@ -317,7 +294,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     key={chip}
                     onClick={() => handleAsk(chip)}
                     disabled={ogLoading}
-                    className="font-mono text-[12px] uppercase tracking-[0.18em] px-4 py-2.5 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
+                    className="font-mono text-[13px] uppercase tracking-[0.18em] px-5 py-3 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
                     onMouseEnter={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.14)";
@@ -326,7 +303,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     onMouseLeave={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.08)";
-                      e.currentTarget.style.color = "rgba(212,175,55,0.75)";
+                      e.currentTarget.style.color = "rgba(212,175,55,0.85)";
                     }}
                     onTouchStart={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
@@ -340,7 +317,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       borderRadius: 0,
                       borderColor: "rgba(212,175,55,0.30)",
                       background: "rgba(212,175,55,0.08)",
-                      color: "rgba(212,175,55,0.75)",
+                      color: "rgba(212,175,55,0.85)",
                     }}
                   >
                     {chip}
@@ -381,8 +358,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   style={{
                     borderRadius: 0,
                     background: "#000000",
-                    borderColor: "rgba(212,175,55,0.25)",
-                    boxShadow: "0 0 30px rgba(212,175,55,0.10)",
+                    borderColor: "rgba(212,175,55,0.15)",
+                    boxShadow: "0 0 30px rgba(212,175,55,0.08)",
                   }}
                 >
                   {/* Gold header band */}

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1,0 +1,449 @@
+import { useEffect, useState, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { X, ExternalLink } from "lucide-react";
+import SectionFrame from "@/components/SectionFrame";
+import SectionHeader from "@/components/SectionHeader";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+// ------------------------------------------------------------------
+// SCROLL REVEAL HOOK
+// ------------------------------------------------------------------
+const useReveal = (threshold = 0.05) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      ([e]) => { if (e.isIntersecting) { setVisible(true); obs.disconnect(); } },
+      { threshold }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [threshold]);
+  return { ref, visible };
+};
+
+// ------------------------------------------------------------------
+// TOP 10 MUST-KNOW TERMS
+// ------------------------------------------------------------------
+type Top10Term = {
+  num: string;
+  term: string;
+  category: string;
+  def: string;
+};
+
+const TOP_10: Top10Term[] = [
+  {
+    num: "01",
+    term: "Waterfall",
+    category: "The Math",
+    def: "The strict priority order in which revenue flows from the box office to every stakeholder. Money trickles down: Theaters → Distributor → Sales Agent → Lenders → Investors → Producers. Understanding this is understanding independent film finance.",
+  },
+  {
+    num: "02",
+    term: "Recoupment",
+    category: "The Math",
+    def: "Earning back the initial investment before profits are shared. The recoupment schedule defines who gets paid back first — and at what premium — before anyone sees net profit. This is the core negotiation in any investor deal.",
+  },
+  {
+    num: "03",
+    term: "Capital Stack",
+    category: "Finance",
+    def: "The layered combination of funding sources used to finance a budget: tax credits (lowest risk), senior debt, gap/mezzanine loans, and equity (highest risk). Each tier has its own cost, priority, and return profile.",
+  },
+  {
+    num: "04",
+    term: "Negative Cost",
+    category: "Finance",
+    def: "The actual all-in cost to produce the finished film — development, production, and post — excluding marketing and distribution. This is the number you're financing. Not 'the budget estimate.' The final, locked number.",
+  },
+  {
+    num: "05",
+    term: "Senior Debt",
+    category: "Finance",
+    def: "First-position loans secured by reliable collateral — tax credits or pre-sale contracts. Lowest risk, lowest cost (typically SOFR + 5–10%), and paid back first in the waterfall. Banks write these. They don't lose.",
+  },
+  {
+    num: "06",
+    term: "Equity",
+    category: "Finance",
+    def: "Cash investment in exchange for ownership and backend profits. Highest risk, paid last, but holds a percentage of profits forever. Standard structure: principal back + 20% premium, then 50% of net profits going forward.",
+  },
+  {
+    num: "07",
+    term: "Cross-Collateral.",
+    category: "Legal",
+    def: "A trap. When a distributor uses profits from one film to cover losses on another in their portfolio. Your Film A profit funds their Film B write-off. Always require 'Single Picture Accounting' in any distribution contract.",
+  },
+  {
+    num: "08",
+    term: "Sales Agent",
+    category: "Roles",
+    def: "The broker who sells your international distribution rights — territory by territory — at film markets (Cannes, AFM, Berlin). Takes 10–20% commission off gross receipts. Their estimates can also be used to secure pre-sale bank loans.",
+  },
+  {
+    num: "09",
+    term: "Producer's Corridor",
+    category: "The Math",
+    def: "A percentage of first-dollar gross receipts reserved for the producer — paid before expenses are deducted. Rare, powerful, and a sign of real leverage. If you can negotiate it, do. It fundamentally changes your position in the waterfall.",
+  },
+  {
+    num: "10",
+    term: "CAM",
+    category: "Roles",
+    def: "Collection Account Manager. A neutral third party that receives all revenue and distributes it according to the agreed waterfall. Takes approximately 1% off the top. Essential for transparency and investor confidence. Without a CAM, you're trusting a distributor to pay everyone correctly.",
+  },
+];
+
+// ------------------------------------------------------------------
+// INDUSTRY LINKS
+// ------------------------------------------------------------------
+const INDUSTRY_LINKS = [
+  { name: "Producers Guild (PGA)", url: "https://producersguild.org", desc: "The guild for film & TV producers" },
+  { name: "Writers Guild (WGA)", url: "https://www.wga.org", desc: "Union for screenwriters" },
+  { name: "Directors Guild (DGA)", url: "https://www.dga.org", desc: "Union for directors & teams" },
+  { name: "SAG-AFTRA", url: "https://www.sagaftra.org", desc: "Actors & performers union" },
+  { name: "IATSE", url: "https://iatse.net", desc: "Below-the-line crew union" },
+  { name: "Box Office Mojo", url: "https://www.boxofficemojo.com", desc: "Box office tracking & data" },
+  { name: "The Numbers", url: "https://www.the-numbers.com", desc: "Film financial analysis" },
+  { name: "Film Independent", url: "https://www.filmindependent.org", desc: "Indie filmmaker resources" },
+  { name: "@filmmaker.og", url: "https://www.instagram.com/filmmaker.og", desc: "Follow us on Instagram" },
+];
+
+// ------------------------------------------------------------------
+// TAB IDS
+// ------------------------------------------------------------------
+type TabId = "terms" | "waterfall";
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "terms", label: "TERMS" },
+  { id: "waterfall", label: "WATERFALL" },
+];
+
+// ------------------------------------------------------------------
+// WATERFALL CONTENT (extracted from WaterfallInfo)
+// ------------------------------------------------------------------
+const WaterfallContent = () => (
+  <div className="space-y-8">
+    {/* The Bucket Metaphor */}
+    <div className="relative bg-white/[0.04] border border-white/[0.10] p-6 pl-7 space-y-4 overflow-hidden">
+      <div className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ background: 'linear-gradient(to bottom, rgba(212,175,55,0.55), rgba(212,175,55,0.25), transparent)' }} />
+      <h2 className="font-bebas text-[22px] tracking-[0.06em] text-gold">
+        The &ldquo;Bucket&rdquo; Metaphor
+      </h2>
+      <p className="text-[15px] text-white/75 leading-[1.7]">
+        Imagine a series of buckets arranged vertically. Water (revenue) is poured into the top bucket.
+        Only when the first bucket is full does it spill over into the next one.
+      </p>
+      <p className="text-[15px] text-white/75 leading-[1.7]">
+        If the flow of water stops, the buckets at the bottom stay dry.
+        <span className="text-gold font-semibold"> You (the Producer) are at the very bottom.</span>
+      </p>
+    </div>
+
+    {/* Recoupment Schedule */}
+    <div className="space-y-4">
+      <h2 className="font-bebas text-[22px] tracking-[0.06em] text-gold">
+        The Recoupment Schedule
+      </h2>
+      <div className="bg-white/[0.03] border border-white/[0.10] overflow-hidden">
+        <div className="grid grid-cols-[auto_1fr] gap-0 divide-y divide-white/[0.06]">
+          {[
+            { num: '01', title: 'CAM', desc: 'Takes ~1% off the top to manage the money. Protects you from the distributor holding your cash.' },
+            { num: '02', title: 'Sales Fees & Expenses', desc: 'Sales Agent takes 10–25% commission + capped expenses.', trap: 'TRAP: Ensure expenses are "Capped" in your contract.' },
+            { num: '03', title: 'Guild Residuals', desc: 'SAG-AFTRA, DGA, WGA deposits. Don\'t pay = they shut you down.' },
+            { num: '04', title: 'Senior Debt', desc: 'Banks get paid first — least risk, lowest cost (SOFR + 5–10%).' },
+            { num: '05', title: 'Gap / Mezzanine Debt', desc: 'Higher risk lenders charging higher interest behind the bank.' },
+            { num: '06', title: 'Equity Investors', desc: '100% principal back + 20% premium. Only then does "Net Profit" split begin.' },
+          ].map((row) => (
+            <div key={row.num} className="contents">
+              <div className="p-3 bg-white/[0.03] text-gold font-mono font-medium border-r border-white/[0.06] flex items-center justify-center min-w-[48px] text-[14px]">
+                {row.num}
+              </div>
+              <div className="p-4">
+                <h3 className="text-white font-semibold text-[15px] mb-1">{row.title}</h3>
+                <p className="text-[14px] text-white/70 leading-[1.7]">
+                  {row.desc}
+                  {row.trap && (
+                    <span className="block mt-1.5 text-gold text-[13px] font-semibold tracking-wide">{row.trap}</span>
+                  )}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    {/* Backend Split */}
+    <div className="space-y-4">
+      <h2 className="font-bebas text-[22px] tracking-[0.06em] text-gold">
+        The Backend Split
+      </h2>
+      <p className="text-[14px] text-white/70 leading-[1.7]">
+        Once everyone above is paid, the remaining revenue enters the "Net Profit" pool — typically split 50/50.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="relative border border-gold/25 bg-gold/[0.06] p-4 overflow-hidden">
+          <div className="absolute top-0 left-0 right-0 h-[2px] bg-gold/50" />
+          <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/70 mb-2">Producer Corridor</p>
+          <div className="font-mono text-[32px] font-bold text-gold leading-none mb-2">50%</div>
+          <p className="text-[13px] text-gold/70 leading-[1.6]">You, the director, and talent points.</p>
+        </div>
+        <div className="relative border border-white/[0.15] bg-white/[0.05] p-4 overflow-hidden">
+          <div className="absolute top-0 left-0 right-0 h-[2px] bg-white/[0.15]" />
+          <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-white/60 mb-2">Investor Corridor</p>
+          <div className="font-mono text-[32px] font-bold text-white/80 leading-none mb-2">50%</div>
+          <p className="text-[13px] text-white/60 leading-[1.6]">Pro-rata share to equity financiers.</p>
+        </div>
+      </div>
+    </div>
+
+    {/* Common Traps */}
+    <div className="relative bg-gold/[0.04] border border-gold/20 p-6 pl-7 space-y-4 overflow-hidden">
+      <div className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ background: 'linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.35), transparent)' }} />
+      <h2 className="font-bebas text-[18px] tracking-[0.08em] uppercase text-gold">
+        Common Traps
+      </h2>
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-white font-semibold text-[14px] mb-1">Cross-Collateralization</h3>
+          <p className="text-[13px] text-white/70 leading-[1.65]">
+            When a distributor uses your film's profits to cover losses on another film.
+            <span className="block mt-1.5 text-gold text-[12px] font-semibold tracking-wide">
+              Never allow this. Require "Single Picture Accounting".
+            </span>
+          </p>
+        </div>
+        <div>
+          <h3 className="text-white font-semibold text-[14px] mb-1">Overhead Fees</h3>
+          <p className="text-[13px] text-white/70 leading-[1.65]">
+            Distributors charge 10-15% "overhead" on top of commission. Pure profit for them. Fight to cap or remove it.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+// ------------------------------------------------------------------
+// MAIN COMPONENT
+// ------------------------------------------------------------------
+const Resources = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab = (searchParams.get("tab") as TabId) || "terms";
+  const [activeTab, setActiveTab] = useState<TabId>(initialTab);
+  const [selectedTerm, setSelectedTerm] = useState<Top10Term | null>(null);
+  const revTop10 = useReveal();
+
+  useEffect(() => { window.scrollTo(0, 0); }, []);
+
+  const handleTabChange = (tab: TabId) => {
+    setActiveTab(tab);
+    setSearchParams({ tab });
+  };
+
+  return (
+    <>
+      <div className="min-h-screen bg-black text-white page-safe pb-8 font-sans">
+
+        {/* PAGE TITLE */}
+        <div className="px-6 md:px-10 pt-2 pb-1">
+          <div className="max-w-4xl mx-auto">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.25em] text-gold/80 mb-3">
+              Film Finance
+            </p>
+            <h1 className="font-bebas text-5xl md:text-7xl tracking-wide text-white leading-none">
+              The <span className="text-gold">Resource</span>
+            </h1>
+            <p className="text-[15px] text-white/55 leading-relaxed mt-3 max-w-xl">
+              The film industry uses jargon to keep outsiders out. This is your definitive resource.
+            </p>
+          </div>
+        </div>
+
+        {/* TAB SWITCHER */}
+        <div className="px-6 md:px-10 pt-4 pb-2">
+          <div className="max-w-4xl mx-auto flex gap-2">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => handleTabChange(tab.id)}
+                className="font-bebas text-[15px] tracking-[0.14em] px-5 py-2.5 border transition-all"
+                style={{
+                  borderRadius: 0,
+                  background: activeTab === tab.id ? "rgba(212,175,55,0.12)" : "rgba(255,255,255,0.04)",
+                  borderColor: activeTab === tab.id ? "rgba(212,175,55,0.50)" : "rgba(255,255,255,0.10)",
+                  color: activeTab === tab.id ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.55)",
+                }}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* TAB CONTENT */}
+        {activeTab === "terms" && (
+          <div
+            ref={revTop10.ref}
+            style={{
+              opacity: revTop10.visible ? 1 : 0,
+              transform: revTop10.visible ? "translateY(0)" : "translateY(24px)",
+              transition: "opacity 0.6s ease, transform 0.6s ease",
+            }}
+          >
+            <SectionFrame id="top10">
+              <SectionHeader
+                eyebrow="The Essential 10"
+                title="KNOW THESE FIRST"
+                plainSubtitle
+              />
+
+              <div className="grid grid-cols-2 gap-2 mt-4">
+                {TOP_10.map((item, i) => (
+                  <button
+                    key={item.num}
+                    onClick={() => setSelectedTerm(item)}
+                    style={{
+                      borderRadius: 0,
+                      opacity: revTop10.visible ? 1 : 0,
+                      transform: revTop10.visible ? "translateY(0)" : "translateY(12px)",
+                      transition: `opacity 0.45s ease ${i * 0.04}s, transform 0.45s ease ${i * 0.04}s`,
+                    }}
+                    className="group flex items-center gap-3 px-3 py-3 border border-white/[0.08] bg-white/[0.02] hover:border-gold/40 hover:bg-gold/[0.06] transition-all text-left"
+                  >
+                    <span className="font-mono text-[11px] font-bold text-gold/65 group-hover:text-gold/80 transition-colors flex-shrink-0 tabular-nums leading-none">
+                      {item.num}
+                    </span>
+                    <span className="font-bebas text-[17px] tracking-wide text-white/80 group-hover:text-white transition-colors leading-none truncate">
+                      {item.term}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <p className="text-center text-[11px] text-white/35 font-mono uppercase tracking-widest mt-4">
+                Tap any term to read the definition
+              </p>
+            </SectionFrame>
+          </div>
+        )}
+
+        {activeTab === "waterfall" && (
+          <div className="px-4 py-4">
+            <div className="max-w-4xl mx-auto">
+              <WaterfallContent />
+            </div>
+          </div>
+        )}
+
+        {/* INDUSTRY LINKS — always visible */}
+        <div className="px-6 md:px-10 pt-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="h-[1px] flex-1" style={{ background: "linear-gradient(90deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
+              <span className="font-bebas text-[12px] text-gold/60 uppercase tracking-[0.25em] flex-shrink-0">Industry Links</span>
+              <div className="h-[1px] flex-1" style={{ background: "linear-gradient(270deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {INDUSTRY_LINKS.map((link) => (
+                <a
+                  key={link.name}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group relative flex items-center gap-3 px-4 py-3 border border-white/[0.08] bg-white/[0.02] hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
+                  style={{ borderRadius: 0 }}
+                >
+                  <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
+                  <div className="flex-1 min-w-0">
+                    <span className="font-bebas text-[15px] tracking-wide text-white/80 group-hover:text-white transition-colors leading-none block">
+                      {link.name}
+                    </span>
+                    <span className="text-[11px] text-white/35 group-hover:text-white/50 transition-colors leading-none mt-1 block">
+                      {link.desc}
+                    </span>
+                  </div>
+                  <ExternalLink className="w-3.5 h-3.5 text-gold/40 group-hover:text-gold/70 flex-shrink-0 transition-colors" />
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* TERM DEFINITION MODAL */}
+      <Dialog open={!!selectedTerm} onOpenChange={(open) => !open && setSelectedTerm(null)}>
+        <DialogContent
+          className="p-0 overflow-hidden border-gold/30 max-w-[calc(100vw-2rem)] w-full sm:max-w-lg [&>button:last-child]:hidden"
+          style={{ borderRadius: 0, background: "#0D0900", boxShadow: "0 0 60px rgba(212,175,55,0.10)" }}
+        >
+          {selectedTerm && (
+            <>
+              <div className="flex items-center justify-between px-5 py-3 bg-gold">
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-[12px] font-bold text-black/60 tabular-nums">
+                    {selectedTerm.num}
+                  </span>
+                  <span className="font-bebas text-xl tracking-[0.15em] text-black leading-none">
+                    {selectedTerm.term}
+                  </span>
+                  <span className="text-[9px] uppercase tracking-[0.15em] font-mono text-black/50 hidden sm:block">
+                    {selectedTerm.category}
+                  </span>
+                </div>
+                <button
+                  onClick={() => setSelectedTerm(null)}
+                  className="text-black/50 hover:text-black transition-colors p-1"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+
+              <div className="px-5 py-5">
+                <p className="text-[16px] text-white/85 leading-[1.8]">
+                  {selectedTerm.def}
+                </p>
+              </div>
+
+              <div className="flex border-t border-white/[0.06]">
+                {(() => {
+                  const idx = TOP_10.findIndex(t => t.num === selectedTerm.num);
+                  const prev = idx > 0 ? TOP_10[idx - 1] : null;
+                  const next = idx < TOP_10.length - 1 ? TOP_10[idx + 1] : null;
+                  return (
+                    <>
+                      <button
+                        onClick={() => prev && setSelectedTerm(prev)}
+                        disabled={!prev}
+                        className="flex-1 py-3 text-[11px] font-mono uppercase tracking-wider text-white/20 hover:text-gold/60 hover:bg-gold/[0.04] disabled:opacity-0 transition-all text-left pl-5"
+                      >
+                        ← {prev?.term}
+                      </button>
+                      <div className="w-[1px] bg-white/[0.06]" />
+                      <button
+                        onClick={() => next && setSelectedTerm(next)}
+                        disabled={!next}
+                        className="flex-1 py-3 text-[11px] font-mono uppercase tracking-wider text-white/20 hover:text-gold/60 hover:bg-gold/[0.04] disabled:opacity-0 transition-all text-right pr-5"
+                      >
+                        {next?.term} →
+                      </button>
+                    </>
+                  );
+                })()}
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default Resources;


### PR DESCRIPTION
- Move OG bot from header to floating action button (bottom-right, above tab bar)
- Add 4th INFO tab to bottom nav linking to /resources
- Active tab now shows background pad + wider gold underline (24px)
- Brighter inactive tab labels (white/65) and icons (gold/75)
- Create combined Resources page with Terms/Waterfall tabs + industry links footer
- Bot sheet: remove eyebrow, make instruction text white/readable, bigger chips
- Reduce answer card gold density (border gold/15, softer glow)
- Menu: replace Waterfall+Glossary with single Resources item
- Old /glossary and /waterfall-info routes redirect to /resources

https://claude.ai/code/session_01Jpn593v6fScWfUqiLCzoj4