### PR TITLE
Menu 2x2 grid, tab bar glow gold active state, OG FAB with bot label

### DIFF
--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -68,7 +68,7 @@ const BottomTabBar = () => {
                 isActive && "rounded-lg",
               )}
               style={{
-                background: isActive ? "rgba(255,255,255,0.06)" : "transparent",
+                background: isActive ? "rgba(212,175,55,0.12)" : "transparent",
               }}
               aria-label={tab.label}
             >
@@ -86,10 +86,10 @@ const BottomTabBar = () => {
               <span
                 className="font-bebas leading-none transition-all"
                 style={{
-                  fontSize: "10px",
+                  fontSize: "11px",
                   letterSpacing: isActive ? "0.16em" : "0.10em",
-                  fontWeight: isActive ? 500 : 400,
-                  color: isActive ? "rgba(255,255,255,0.95)" : "rgba(255,255,255,0.65)",
+                  fontWeight: 500,
+                  color: isActive ? "rgba(255,255,255,1)" : "rgba(255,255,255,0.75)",
                 }}
               >
                 {tab.label}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -109,60 +109,48 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
         </div>
 
         <div className="px-4 pb-6 space-y-6">
-          {/* Primary Nav — 2-col grid */}
+          {/* Primary Nav — 2×2 grid */}
           <div className="space-y-2">
             <SectionLabel>Menu</SectionLabel>
-            <div className="grid grid-cols-2 gap-2">
-              {/* Packages — featured card with gold left accent */}
-              <button
-                onClick={() => handleNavigate('/store')}
-                className="relative flex items-center gap-2.5 p-3.5 border col-span-2 text-left group transition-all overflow-hidden"
-                style={{
-                  borderRadius: 0,
-                  borderColor: "rgba(212,175,55,0.50)",
-                  background: "rgba(212,175,55,0.12)",
-                }}
-              >
-                <div
-                  className="absolute left-0 top-0 bottom-0 w-[3px]"
-                  style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.30), transparent)" }}
-                />
-                <div
-                  className="w-7 h-7 flex items-center justify-center flex-shrink-0"
-                  style={{ background: "var(--gold)", borderRadius: 0 }}
-                >
-                  <Book className="w-4 h-4 text-black" />
-                </div>
-                <span className="font-bebas text-base tracking-wide text-gold leading-none">Packages</span>
-                <span className="ml-auto font-bebas text-[11px] tracking-[0.2em] text-gold/40 leading-none">VIEW ALL →</span>
-              </button>
-
-              <button
-                onClick={() => handleNavigate('/')}
-                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
-                style={{ borderRadius: 0 }}
-              >
-                <Home className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
-                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Home</span>
-              </button>
-
-              <button
-                onClick={() => handleNavigate('/calculator')}
-                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
-                style={{ borderRadius: 0 }}
-              >
-                <Calculator className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
-                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Calculator</span>
-              </button>
-
-              <button
-                onClick={() => handleNavigate('/resources')}
-                className="flex items-center gap-2.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-left group hover:border-gold/40 hover:bg-gold/[0.06] transition-all"
-                style={{ borderRadius: 0 }}
-              >
-                <BookOpen className="w-4 h-4 text-white/50 group-hover:text-gold flex-shrink-0 transition-colors" />
-                <span className="font-bebas text-base tracking-wide text-white/70 group-hover:text-white leading-none transition-colors">Resources</span>
-              </button>
+            <div className="grid grid-cols-2 gap-2.5">
+              {([
+                { path: "/store",      icon: Book,       label: "Packages",   featured: true },
+                { path: "/",           icon: Home,       label: "Home",       featured: false },
+                { path: "/calculator", icon: Calculator, label: "Calculator", featured: false },
+                { path: "/resources",  icon: BookOpen,   label: "Resources",  featured: false },
+              ] as const).map((item) => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.path}
+                    onClick={() => handleNavigate(item.path)}
+                    className="relative flex flex-col items-center justify-center gap-2 py-5 border text-center group transition-all overflow-hidden"
+                    style={{
+                      borderRadius: 0,
+                      borderColor: item.featured ? "rgba(212,175,55,0.50)" : "rgba(255,255,255,0.12)",
+                      background: item.featured ? "rgba(212,175,55,0.10)" : "rgba(255,255,255,0.04)",
+                    }}
+                  >
+                    {/* Gold left accent on featured */}
+                    {item.featured && (
+                      <div
+                        className="absolute left-0 top-0 bottom-0 w-[2px]"
+                        style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.25))" }}
+                      />
+                    )}
+                    <Icon
+                      className="w-5 h-5 transition-colors"
+                      style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.70)" }}
+                    />
+                    <span
+                      className="font-bebas text-[16px] tracking-[0.12em] leading-none transition-colors"
+                      style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.85)" }}
+                    >
+                      {item.label}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
           </div>
 

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -8,31 +8,62 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
     <button
       onClick={onClick}
       aria-label="Ask the OG Bot"
-      className="fixed z-[145] flex items-center justify-center transition-all duration-200 active:scale-90"
+      className="fixed z-[145] flex flex-col items-center justify-center transition-all duration-200 active:scale-90"
       style={{
         bottom: "calc(78px + env(safe-area-inset-bottom))",
         right: "16px",
-        width: "48px",
-        height: "48px",
+        width: "52px",
+        height: "52px",
         borderRadius: 0,
         background: isActive ? "rgba(212,175,55,1)" : "#0A0A0A",
         border: isActive
           ? "1.5px solid rgba(212,175,55,0.70)"
-          : "1.5px solid rgba(212,175,55,0.45)",
+          : "1.5px solid rgba(212,175,55,0.50)",
         boxShadow: isActive
-          ? "0 0 24px rgba(212,175,55,0.30), 0 4px 16px rgba(0,0,0,0.60)"
-          : "0 0 20px rgba(212,175,55,0.15), 0 4px 16px rgba(0,0,0,0.60)",
+          ? "0 0 28px rgba(212,175,55,0.35), 0 4px 16px rgba(0,0,0,0.60)"
+          : "0 0 22px rgba(212,175,55,0.18), 0 4px 16px rgba(0,0,0,0.60), inset 0 1px 0 rgba(212,175,55,0.08)",
       }}
     >
+      {/* Corner accents — decorative notch marks */}
+      <div className="absolute top-0 left-0 w-[6px] h-[1px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute top-0 left-0 w-[1px] h-[6px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute top-0 right-0 w-[6px] h-[1px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute top-0 right-0 w-[1px] h-[6px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute bottom-0 left-0 w-[6px] h-[1px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute bottom-0 left-0 w-[1px] h-[6px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute bottom-0 right-0 w-[6px] h-[1px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      <div className="absolute bottom-0 right-0 w-[1px] h-[6px] pointer-events-none"
+        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+
+      {/* OG text */}
       <span
         className="font-bebas leading-none"
         style={{
-          fontSize: "18px",
+          fontSize: "19px",
           letterSpacing: "0.14em",
           color: isActive ? "#000000" : "rgba(212,175,55,1)",
         }}
       >
         OG
+      </span>
+      {/* bot label */}
+      <span
+        className="font-mono uppercase leading-none"
+        style={{
+          fontSize: "8px",
+          letterSpacing: "0.12em",
+          color: isActive ? "rgba(0,0,0,0.60)" : "rgba(212,175,55,0.60)",
+          marginTop: "1px",
+        }}
+      >
+        bot
       </span>
     </button>
   );


### PR DESCRIPTION
- Menu: 4 nav items now a proper 2x2 grid with centered icons + labels, brighter text (white/85), bigger font (16px), Packages gold-accented
- Bottom tab bar: active state background changed from white/6 to gold/12 (glowing gold), labels bumped to 11px and brighter (white/75 inactive, white/100 active)
- OG FAB: added "bot" label below "OG", decorative corner accent notches on all 4 corners, bumped to 52px, stronger glow and inset highlight

https://claude.ai/code/session_01Jpn593v6fScWfUqiLCzoj4