### PR TITLE
Round 4: Frosted glass tab bar, OG bot FAB redesign, menu readability…

### DIFF
--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -41,21 +41,30 @@ const BottomTabBar = () => {
     >
       {/* Floating box-rounded nav pill */}
       <nav
-        className="flex items-stretch"
+        className="relative flex items-stretch overflow-hidden"
         style={{
           pointerEvents: "auto",
           width: "100%",
           maxWidth: "340px",
           height: "54px",
           borderRadius: "16px",
-          background: "#0A0A0A",
-          border: "1.5px solid rgba(212,175,55,0.45)",
+          background: "rgba(0,0,0,0.85)",
+          backdropFilter: "blur(16px)",
+          WebkitBackdropFilter: "blur(16px)",
+          border: "1.5px solid rgba(212,175,55,0.60)",
           boxShadow:
-            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.10), 0 0 15px rgba(212,175,55,0.08)",
+            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.15), 0 0 20px rgba(212,175,55,0.12), inset 0 0.5px 0 rgba(212,175,55,0.10)",
           paddingLeft: "6px",
           paddingRight: "6px",
         }}
       >
+        {/* Gold top edge line */}
+        <div
+          className="absolute top-0 left-0 right-0 h-[1px] pointer-events-none"
+          style={{
+            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.30) 30%, rgba(212,175,55,0.40) 50%, rgba(212,175,55,0.30) 70%, transparent 100%)",
+          }}
+        />
         {tabs.map((tab) => {
           const isActive = getActive(tab.path);
           const Icon = tab.icon;
@@ -68,7 +77,7 @@ const BottomTabBar = () => {
                 isActive && "rounded-lg",
               )}
               style={{
-                background: isActive ? "rgba(212,175,55,0.12)" : "transparent",
+                background: isActive ? "rgba(212,175,55,0.15)" : "transparent",
               }}
               aria-label={tab.label}
             >
@@ -104,6 +113,7 @@ const BottomTabBar = () => {
                     borderRadius: "2px",
                     background: GOLD_FULL,
                     display: "block",
+                    boxShadow: "0 0 8px rgba(212,175,55,0.50), 0 0 16px rgba(212,175,55,0.20)",
                   }}
                 />
               )}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -59,7 +59,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
   const SectionLabel = ({ children }: { children: React.ReactNode }) => (
     <div className="flex items-center gap-3 pl-1 mb-2">
       <div className="h-[1px] flex-1" style={{ background: "linear-gradient(90deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
-      <span className="font-bebas text-[11px] text-gold/50 uppercase tracking-[0.25em] flex-shrink-0">{children}</span>
+      <span className="font-bebas text-[13px] text-gold/60 uppercase tracking-[0.25em] flex-shrink-0">{children}</span>
       <div className="h-[1px] flex-1" style={{ background: "linear-gradient(270deg, rgba(212,175,55,0.35) 0%, transparent 100%)" }} />
     </div>
   );
@@ -92,7 +92,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
         <div
           className="h-[1px] w-full"
           style={{
-            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.50) 30%, rgba(212,175,55,0.50) 70%, transparent 100%)",
+            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.65) 30%, rgba(212,175,55,0.65) 70%, transparent 100%)",
           }}
         />
 
@@ -101,10 +101,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           <div className="w-8 h-1 bg-gold/30 rounded-full" />
           <button
             onClick={() => setIsOpen(false)}
-            className="absolute top-2 right-4 w-8 h-8 flex items-center justify-center text-gold/40 hover:text-gold transition-colors"
+            className="absolute top-2 right-4 w-9 h-9 flex items-center justify-center text-gold/60 hover:text-gold transition-colors"
             aria-label="Close menu"
           >
-            <CloseIcon className="w-4 h-4" />
+            <CloseIcon className="w-5 h-5" />
           </button>
         </div>
 
@@ -129,6 +129,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                       borderRadius: 0,
                       borderColor: item.featured ? "rgba(212,175,55,0.50)" : "rgba(255,255,255,0.12)",
                       background: item.featured ? "rgba(212,175,55,0.10)" : "rgba(255,255,255,0.04)",
+                      boxShadow: item.featured ? "0 0 20px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)" : "none",
                     }}
                   >
                     {/* Gold left accent on featured */}
@@ -143,7 +144,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                       style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.70)" }}
                     />
                     <span
-                      className="font-bebas text-[16px] tracking-[0.12em] leading-none transition-colors"
+                      className="font-bebas text-[18px] tracking-[0.12em] leading-none transition-colors"
                       style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.85)" }}
                     >
                       {item.label}
@@ -160,34 +161,34 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
             <div className="grid grid-cols-3 gap-2">
               <a
                 href="mailto:thefilmmaker.og@gmail.com"
-                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
+                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
-                <Mail className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Email</span>
+                <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
+                <Mail className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[14px] tracking-[0.08em] text-white/70 group-hover:text-white leading-none transition-colors">Email</span>
               </a>
 
               <a
                 href="https://www.instagram.com/filmmaker.og"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
+                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
-                <Instagram className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Instagram</span>
+                <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
+                <Instagram className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[14px] tracking-[0.08em] text-white/70 group-hover:text-white leading-none transition-colors">Instagram</span>
               </a>
 
               <button
                 onClick={handleShare}
-                className="relative flex flex-col items-center gap-1.5 p-3.5 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
+                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
                 style={{ borderRadius: 0 }}
               >
-                <div className="absolute left-0 top-0 bottom-0 w-[1px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)" }} />
-                <Share2 className="w-4 h-4 text-gold/60 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-xs tracking-wide text-white/60 group-hover:text-white leading-none transition-colors">Share</span>
+                <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
+                <Share2 className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[14px] tracking-[0.08em] text-white/70 group-hover:text-white leading-none transition-colors">Share</span>
               </button>
             </div>
           </div>

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -14,40 +14,69 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
         right: "16px",
         width: "52px",
         height: "52px",
-        borderRadius: 0,
-        background: isActive ? "rgba(212,175,55,1)" : "#0A0A0A",
+        borderRadius: "14px",
+        background: isActive
+          ? "linear-gradient(135deg, #D4AF37 0%, #F9E076 100%)"
+          : "linear-gradient(135deg, #0A0A0A 0%, #111111 100%)",
         border: isActive
-          ? "1.5px solid rgba(212,175,55,0.70)"
+          ? "1.5px solid rgba(249,224,118,0.70)"
           : "1.5px solid rgba(212,175,55,0.50)",
         boxShadow: isActive
-          ? "0 0 28px rgba(212,175,55,0.35), 0 4px 16px rgba(0,0,0,0.60)"
-          : "0 0 22px rgba(212,175,55,0.18), 0 4px 16px rgba(0,0,0,0.60), inset 0 1px 0 rgba(212,175,55,0.08)",
+          ? "0 0 28px rgba(212,175,55,0.40), 0 4px 16px rgba(0,0,0,0.60)"
+          : "0 0 20px rgba(212,175,55,0.15), 0 4px 16px rgba(0,0,0,0.60)",
       }}
     >
-      {/* Corner accents — decorative notch marks */}
-      <div className="absolute top-0 left-0 w-[6px] h-[1px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute top-0 left-0 w-[1px] h-[6px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute top-0 right-0 w-[6px] h-[1px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute top-0 right-0 w-[1px] h-[6px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute bottom-0 left-0 w-[6px] h-[1px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute bottom-0 left-0 w-[1px] h-[6px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute bottom-0 right-0 w-[6px] h-[1px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
-      <div className="absolute bottom-0 right-0 w-[1px] h-[6px] pointer-events-none"
-        style={{ background: isActive ? "rgba(0,0,0,0.30)" : "rgba(212,175,55,0.50)" }} />
+      {/* Inner atmosphere — subtle gold light source */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          borderRadius: "13px",
+          background: isActive
+            ? "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.15) 0%, transparent 60%)"
+            : "radial-gradient(circle at 30% 30%, rgba(212,175,55,0.12) 0%, transparent 60%)",
+        }}
+      />
+
+      {/* Inner border ring — lens/bezel depth */}
+      <div
+        className="absolute pointer-events-none"
+        style={{
+          inset: "3px",
+          borderRadius: "11px",
+          border: isActive
+            ? "1px solid rgba(0,0,0,0.12)"
+            : "1px solid rgba(212,175,55,0.15)",
+        }}
+      />
+
+      {/* Orbital accent dot — rotates slowly when inactive */}
+      {!isActive && (
+        <div
+          className="absolute inset-0 pointer-events-none animate-orbit"
+          style={{ borderRadius: "14px" }}
+        >
+          <div
+            className="absolute"
+            style={{
+              width: "4px",
+              height: "4px",
+              borderRadius: "50%",
+              background: "rgba(212,175,55,0.60)",
+              boxShadow: "0 0 6px rgba(212,175,55,0.40)",
+              top: "-2px",
+              left: "50%",
+              marginLeft: "-2px",
+            }}
+          />
+        </div>
+      )}
 
       {/* OG text */}
       <span
-        className="font-bebas leading-none"
+        className="relative font-bebas leading-none"
         style={{
-          fontSize: "19px",
-          letterSpacing: "0.14em",
+          fontSize: "20px",
+          letterSpacing: "0.16em",
           color: isActive ? "#000000" : "rgba(212,175,55,1)",
         }}
       >
@@ -55,11 +84,11 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
       </span>
       {/* bot label */}
       <span
-        className="font-mono uppercase leading-none"
+        className="relative font-bebas uppercase leading-none"
         style={{
-          fontSize: "8px",
-          letterSpacing: "0.12em",
-          color: isActive ? "rgba(0,0,0,0.60)" : "rgba(212,175,55,0.60)",
+          fontSize: "9px",
+          letterSpacing: "0.20em",
+          color: isActive ? "rgba(0,0,0,0.55)" : "rgba(212,175,55,0.55)",
           marginTop: "1px",
         }}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -804,7 +804,7 @@
     pointer-events: none;
     z-index: 50;
     background: radial-gradient(
-      ellipse 70% 60% at 50% 50%,
+      ellipse 500px 60% at 50% 50%,
       transparent 50%,
       rgba(0,0,0,0.4) 100%
     );
@@ -902,5 +902,27 @@
   }
   .animate-tap-ripple {
     animation: tap-ripple 400ms ease-out forwards;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════
+     OG BOT FAB — orbital accent dot rotation
+     ═══════════════════════════════════════════════════════════════════ */
+  @keyframes orbit {
+    0%   { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+  .animate-orbit {
+    animation: orbit 8s linear infinite;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════
+     PULSE GOLD — subtle active glow breathing
+     ═══════════════════════════════════════════════════════════════════ */
+  @keyframes pulse-gold {
+    0%, 100% { box-shadow: 0 0 20px rgba(212,175,55,0.15); }
+    50%      { box-shadow: 0 0 30px rgba(212,175,55,0.30); }
+  }
+  .animate-pulse-gold {
+    animation: pulse-gold 3s ease-in-out infinite;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -414,7 +414,7 @@ const Index = () => {
             {/* Floor bounce glow */}
             <div className="absolute bottom-0 left-0 right-0 h-1/3 pointer-events-none"
               style={{
-                background: `radial-gradient(ellipse 60% 80% at 50% 100%, rgba(212,175,55,0.06) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
+                background: `radial-gradient(ellipse 400px 80% at 50% 100%, rgba(212,175,55,0.06) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
               }} />
             <div className="relative px-6 py-4 max-w-xl mx-auto text-center">
               <div className="mb-5 relative inline-block">
@@ -706,7 +706,7 @@ const Index = () => {
           {/* ── PIVOT — "Until now." ── */}
           <section className="py-10 md:py-14 px-6 relative">
             <div className="absolute inset-0 pointer-events-none"
-              style={{ background: 'radial-gradient(ellipse 60% 55% at 50% 50%, rgba(212,175,55,0.06) 0%, transparent 70%)' }} />
+              style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.06) 0%, transparent 70%)' }} />
             <div
               ref={revUntilNow.ref}
               className={cn(
@@ -773,7 +773,7 @@ const Index = () => {
              ────────────────────────────────────────────────────────── */}
           <section className="py-10 md:py-16 px-6 relative">
             <div className="absolute inset-0 pointer-events-none"
-              style={{ background: 'radial-gradient(ellipse 60% 55% at 50% 50%, rgba(212,175,55,0.07) 0%, transparent 70%)' }} />
+              style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.07) 0%, transparent 70%)' }} />
             <div ref={revDecl.ref} className={cn("max-w-md mx-auto relative transition-all duration-700 ease-out", revDecl.visible ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]")}>
               <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
               <div className="py-12 px-4 text-center">
@@ -837,7 +837,7 @@ const Index = () => {
           {/* ── TRANSITION — gatekeepers to arsenal hinge ── */}
           <section className="py-10 md:py-14 px-6 relative">
             <div className="absolute inset-0 pointer-events-none"
-              style={{ background: 'radial-gradient(ellipse 60% 55% at 50% 50%, rgba(212,175,55,0.06) 0%, transparent 70%)' }} />
+              style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.06) 0%, transparent 70%)' }} />
             <div
               ref={revTransition.ref}
               className={cn(
@@ -1015,7 +1015,7 @@ const Index = () => {
 
               {/* Ambient glow */}
               <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none"
-                style={{ width: '100%', height: '100%', background: `radial-gradient(ellipse 60% 50% at 50% 20%, rgba(212,175,55,0.08) 0%, transparent 70%)` }} />
+                style={{ width: '100%', height: '100%', background: `radial-gradient(ellipse 320px 50% at 50% 20%, rgba(212,175,55,0.08) 0%, transparent 70%)` }} />
 
               <div className="relative p-10 md:p-16 max-w-md mx-auto text-center">
                 <p className="text-white/50 text-[13px] tracking-[0.3em] uppercase font-semibold mb-5">The Moment of Truth</p>


### PR DESCRIPTION
…, desktop glow fix

- BottomTabBar: semi-transparent black (0.85) with backdrop-blur-16px frosted glass, stronger gold border (0.60), gold top edge line, active indicator glow
- OgBotFab: complete redesign with 14px rounded squircle, gradient bg, inner atmosphere radial glow, inner border ring, animated orbital dot (8s cycle), rebalanced typography
- MobileMenu: bumped all text sizes (section labels 11→13px, grid items 16→18px, contact labels xs→14px, icons 4→5, X button gold/40→gold/60), thicker accent bars
- Index.tsx: capped radial gradient radii from percentage to fixed pixel values (320-400px) to prevent hazy glow blowout on desktop viewports
- index.css: added orbit and pulse-gold keyframes, capped vignette ellipse

https://claude.ai/code/session_01Jpn593v6fScWfUqiLCzoj4