### PR TITLE
Design polish: global curvature pass, haptics everywhere, header refi…

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, createContext, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
+import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
    HeaderCtaContext — lets Index.tsx inject a sticky CTA into the
@@ -34,20 +35,33 @@ const GOLD_DIM  = "rgba(212,175,55,0.65)";
 const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
   const navigate = useNavigate();
   const { ctaSlot } = useHeaderCta();
+  const haptics = useHaptics();
 
   return (
     <>
       <header
         className="fixed top-0 left-0 right-0 z-[150]"
-        style={{ background: "var(--bg-header)" }}
+        style={{
+          background: "rgba(10,10,10,0.88)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+        }}
       >
+        {/* Subtle top gold edge — bookends with footer */}
+        <div
+          className="h-[1px] w-full"
+          style={{
+            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.20) 30%, rgba(212,175,55,0.20) 70%, transparent 100%)",
+          }}
+        />
+
         <div
           className="flex items-center justify-between px-4"
           style={{ height: "var(--appbar-h)" }}
         >
           {/* Left — FILMMAKER.OG wordmark */}
           <button
-            onClick={() => navigate("/")}
+            onClick={() => { haptics.light(); navigate("/"); }}
             className="flex items-center gap-2.5 hover:opacity-80 transition-opacity group flex-shrink-0"
             aria-label="Go home"
           >
@@ -71,7 +85,7 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
           {/* Right — vertical ⋮ menu */}
           <div className="flex items-center flex-shrink-0">
             <button
-              onClick={onMoreOpen}
+              onClick={() => { haptics.light(); onMoreOpen?.(); }}
               className="w-10 h-10 flex items-center justify-center transition-all duration-200 active:scale-90 hover:opacity-80"
               aria-label="More options"
               style={{ color: GOLD_DIM }}
@@ -81,8 +95,14 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
           </div>
         </div>
 
-        {/* Gold gradient separator line */}
-        <div className="h-[1px] w-full bg-gradient-to-r from-transparent via-gold/45 to-transparent" />
+        {/* Gold gradient separator line — enhanced to match footer presence */}
+        <div
+          className="h-[1px] w-full"
+          style={{
+            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.55) 30%, rgba(212,175,55,0.55) 70%, transparent 100%)",
+            boxShadow: "0 1px 12px rgba(212,175,55,0.08)",
+          }}
+        />
       </header>
 
       {/* Spacer for fixed header */}

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -2,17 +2,19 @@ import { useState, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Home, Calculator, ShoppingBag, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useHaptics } from "@/hooks/use-haptics";
 
 const tabs = [
   { id: "home",       path: "/",           label: "HOME", icon: Home },
   { id: "calculator", path: "/calculator", label: "CALC", icon: Calculator },
-  { id: "store",      path: "/store",      label: "PKGS", icon: ShoppingBag },
+  { id: "store",      path: "/store",      label: "SHOP", icon: ShoppingBag },
   { id: "resources",  path: "/resources",  label: "INFO", icon: BookOpen },
 ];
 
 const BottomTabBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const haptics = useHaptics();
   const [rippleId, setRippleId] = useState<string | null>(null);
 
   const getActive = (path: string) => {
@@ -21,10 +23,11 @@ const BottomTabBar = () => {
   };
 
   const handleTap = useCallback((tab: typeof tabs[0]) => {
+    haptics.light();
     setRippleId(tab.id);
     navigate(tab.path);
     setTimeout(() => setRippleId(null), 420);
-  }, [navigate]);
+  }, [navigate, haptics]);
 
   const GOLD_FULL = "rgba(212,175,55,1)";
   const GOLD_DIM  = "rgba(212,175,55,0.75)";

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Home, Calculator, BookOpen, Book, Mail, Instagram, Share2, X as CloseIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
+import { useHaptics } from "@/hooks/use-haptics";
 
 interface MobileMenuProps {
   isOpen?: boolean;
@@ -17,6 +18,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
     else setInternalOpen(v);
   };
   const navigate = useNavigate();
+  const haptics = useHaptics();
 
   // Swipe-to-dismiss
   const touchStartY = useRef<number | null>(null);
@@ -33,11 +35,13 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
   };
 
   const handleNavigate = (path: string) => {
+    haptics.light();
     setIsOpen(false);
     navigate(path);
   };
 
   const handleShare = async () => {
+    haptics.light();
     if (navigator.share) {
       try {
         await navigator.share({
@@ -100,7 +104,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
         <div className="relative flex justify-center pt-3 pb-5">
           <div className="w-8 h-1 bg-gold/30 rounded-full" />
           <button
-            onClick={() => setIsOpen(false)}
+            onClick={() => { haptics.light(); setIsOpen(false); }}
             className="absolute top-2 right-4 w-9 h-9 flex items-center justify-center text-gold/60 hover:text-gold transition-colors"
             aria-label="Close menu"
           >
@@ -126,7 +130,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                     onClick={() => handleNavigate(item.path)}
                     className="relative flex flex-col items-center justify-center gap-2 py-5 border text-center group transition-all overflow-hidden"
                     style={{
-                      borderRadius: 0,
+                      borderRadius: 8,
                       borderColor: item.featured ? "rgba(212,175,55,0.50)" : "rgba(255,255,255,0.12)",
                       background: item.featured ? "rgba(212,175,55,0.10)" : "rgba(255,255,255,0.04)",
                       boxShadow: item.featured ? "0 0 20px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)" : "none",
@@ -161,8 +165,9 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
             <div className="grid grid-cols-3 gap-2">
               <a
                 href="mailto:thefilmmaker.og@gmail.com"
+                onClick={() => haptics.light()}
                 className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 0 }}
+                style={{ borderRadius: 8 }}
               >
                 <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
                 <Mail className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
@@ -173,8 +178,9 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                 href="https://www.instagram.com/filmmaker.og"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => haptics.light()}
                 className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 0 }}
+                style={{ borderRadius: 8 }}
               >
                 <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
                 <Instagram className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
@@ -184,7 +190,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
               <button
                 onClick={handleShare}
                 className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.04] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 0 }}
+                style={{ borderRadius: 8 }}
               >
                 <div className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.40), transparent)", boxShadow: "0 0 8px rgba(212,175,55,0.15)" }} />
                 <Share2 className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />

--- a/src/components/SectionFrame.tsx
+++ b/src/components/SectionFrame.tsx
@@ -12,7 +12,7 @@ const SectionFrame = ({
   alt?: boolean;
 }) => (
   <section id={id} className="snap-section px-4 py-4">
-    <div className="flex overflow-hidden border border-white/[0.06]">
+    <div className="flex overflow-hidden border border-white/[0.06] rounded-lg">
       <div
         className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20"
         style={{ boxShadow: "0 0 16px rgba(212,175,55,0.30)" }}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -51,7 +51,7 @@ const SectionHeader = ({
           "text-center max-w-lg mx-auto mt-4 leading-relaxed",
           plainSubtitle
             ? "text-text-mid text-base"
-            : "text-text-mid text-base px-4 py-2.5 bg-gold/[0.06] border border-gold/20"
+            : "text-text-mid text-base px-4 py-2.5 bg-gold/[0.06] border border-gold/20 rounded-md"
         )}
       >
         {subtitle}

--- a/src/index.css
+++ b/src/index.css
@@ -671,7 +671,7 @@
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    border-radius: 0;
+    border-radius: 6px;
     transition: all 0.25s cubic-bezier(0.22, 1, 0.36, 1);
     box-shadow:
       0 4px 20px rgba(212, 175, 55, 0.35),
@@ -727,7 +727,7 @@
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    border-radius: 0;
+    border-radius: 6px;
     transition: all 0.25s cubic-bezier(0.22, 1, 0.36, 1);
     box-shadow:
       0 4px 24px rgba(124, 58, 237, 0.35),
@@ -780,7 +780,7 @@
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    border-radius: 0;
+    border-radius: 6px;
     transition: all var(--timing-fast) ease;
   }
   .btn-cta-secondary:hover {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -100,8 +100,10 @@ const faqs = [
    ═══════════════════════════════════════════════════════════════════ */
 const useReveal = (threshold = 0.15) => {
   const ref = useRef<HTMLDivElement>(null);
-  const [visible, setVisible] = useState(false);
+  const prefersReduced = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const [visible, setVisible] = useState(prefersReduced);
   useEffect(() => {
+    if (prefersReduced) return;
     const el = ref.current;
     if (!el) return;
     const obs = new IntersectionObserver(
@@ -110,7 +112,7 @@ const useReveal = (threshold = 0.15) => {
     );
     obs.observe(el);
     return () => obs.disconnect();
-  }, [threshold]);
+  }, [threshold, prefersReduced]);
   return { ref, visible };
 };
 
@@ -313,7 +315,7 @@ const Index = () => {
             ? "opacity-100 translate-y-0 pointer-events-auto"
             : "opacity-0 -translate-y-1 pointer-events-none"
         )}
-        style={{ borderRadius: 0 }}
+        style={{ borderRadius: 6 }}
       >
         BUILD NOW
       </button>
@@ -453,7 +455,7 @@ const Index = () => {
               <SectionHeader eyebrow="The Problem" title={<>MOST FILMS LOSE <span className="text-white">MONEY.</span></>} flankingLines compact />
 
               <div className="max-w-md mx-auto">
-                <div className="relative bg-white/[0.04] border border-white/[0.10] overflow-hidden"
+                <div className="relative bg-white/[0.04] border border-white/[0.10] overflow-hidden rounded-lg"
                   style={{ boxShadow: '0 0 20px rgba(212,175,55,0.06)' }}>
                   {/* Gold left accent */}
                   <div className="absolute left-0 top-0 bottom-0 w-[3px]"
@@ -554,7 +556,7 @@ const Index = () => {
 
               <div ref={waterBarRef} className="max-w-md mx-auto">
                 {/* Waterfall rows — all identical structure */}
-                <div className="border border-white/[0.06] bg-black overflow-hidden">
+                <div className="border border-white/[0.06] bg-black overflow-hidden rounded-lg">
                   {waterfallTiers.filter(t => !t.isFinal).map((tier, i) => (
                     <div
                       key={tier.name}
@@ -599,7 +601,7 @@ const Index = () => {
                 </div>
 
                 {/* Net Profits — then corridor split */}
-                <div className="mt-4 border border-gold/25 bg-gold/[0.04] px-5 py-4 text-center">
+                <div className="mt-4 border border-gold/25 bg-gold/[0.04] px-5 py-4 text-center rounded-md">
                   <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/60 mb-1">Net Profits</p>
                   <span className="font-mono text-[22px] font-bold text-gold">
                     ${countVal.toLocaleString()}
@@ -621,14 +623,14 @@ const Index = () => {
 
                 {/* Two corridor boxes */}
                 <div className="grid grid-cols-2 gap-4">
-                  <div className="relative border border-gold/25 bg-gold/[0.06] px-4 py-5 text-center overflow-hidden">
+                  <div className="relative border border-gold/25 bg-gold/[0.06] px-4 py-5 text-center overflow-hidden rounded-md">
                     <div className="absolute top-0 left-0 right-0 h-[2px] bg-gold/50" />
                     <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/70 mb-1">Producer Corridor</p>
                     <span className="font-mono text-[18px] font-bold text-gold">
                       ${producerVal.toLocaleString()}
                     </span>
                   </div>
-                  <div className="border border-white/[0.10] bg-white/[0.05] px-4 py-5 text-center">
+                  <div className="border border-white/[0.10] bg-white/[0.05] px-4 py-5 text-center rounded-md">
                     <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-white/45 mb-1">Investor Corridor</p>
                     <span className="font-mono text-[18px] font-bold text-white/70">
                       ${investorVal.toLocaleString()}
@@ -659,7 +661,7 @@ const Index = () => {
 
               {/* Stacked manifesto */}
               <div className="max-w-md mx-auto">
-                <div className="relative bg-white/[0.04] border border-white/[0.10] overflow-hidden">
+                <div className="relative bg-white/[0.04] border border-white/[0.10] overflow-hidden rounded-lg">
                   {/* Gold left accent */}
                   <div className="absolute left-0 top-0 bottom-0 w-[3px]"
                     style={{ background: 'linear-gradient(to bottom, rgba(212,175,55,0.55), rgba(212,175,55,0.25), transparent)' }} />
@@ -739,9 +741,16 @@ const Index = () => {
               )}
             >
               <div
-                className="relative bg-gold/[0.08] border-2 border-gold/45 overflow-hidden"
+                className="relative bg-gold/[0.08] border-2 border-gold/45 overflow-hidden rounded-lg"
                 style={{ boxShadow: '0 0 40px rgba(212,175,55,0.12), 0 8px 32px rgba(212,175,55,0.06), inset 0 1px 0 rgba(212,175,55,0.15)' }}
               >
+                {/* Inner atmospheric haze */}
+                <div
+                  className="absolute inset-0 pointer-events-none rounded-lg"
+                  style={{
+                    background: 'radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.06) 0%, transparent 70%)',
+                  }}
+                />
                 {/* Gold left accent — strong */}
                 <div className="absolute left-0 top-0 bottom-0 w-[3px]"
                   style={{ background: 'linear-gradient(to bottom, rgba(212,175,55,0.80), rgba(212,175,55,0.40), transparent)' }} />
@@ -754,7 +763,7 @@ const Index = () => {
                       Filmmakers have a perception in the business world of being kind of flaky dudes{"\u2026"} you need to be buttoned down{"\u2026"} speak the language that they speak.
                     </p>
                   </blockquote>
-                  <div className="mt-4 -mx-1 p-3 bg-gold/[0.12] border border-gold/30">
+                  <div className="mt-4 -mx-1 p-3 bg-gold/[0.12] border border-gold/30 rounded-md">
                     <div className="flex items-center gap-3">
                       <div className="w-10 h-[1.5px] bg-gold/50" />
                       <cite className="not-italic">
@@ -801,7 +810,7 @@ const Index = () => {
                   <div
                     key={door.name}
                     className={cn(
-                      "relative border p-5 flex flex-col justify-between transition-all duration-700 ease-out overflow-hidden",
+                      "relative border p-5 flex flex-col justify-between transition-all duration-700 ease-out overflow-hidden rounded-lg",
                       "bg-white/[0.06] border-white/[0.12] aspect-square",
                       revCost.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
                     )}
@@ -888,7 +897,7 @@ const Index = () => {
                   <div
                     key={t.tier}
                     className={cn(
-                      "relative border overflow-hidden p-5 md:p-7 transition-all duration-600 ease-out",
+                      "relative border overflow-hidden p-5 md:p-7 transition-all duration-600 ease-out rounded-lg",
                       t.featured
                         ? "border-gold/50 bg-gold/[0.04]"
                         : t.elevated
@@ -917,7 +926,7 @@ const Index = () => {
                     />
                     {t.featured && (
                       <div className="mb-3">
-                        <span className="text-[12px] tracking-[0.20em] uppercase font-bold text-gold bg-gold/[0.12] px-3 py-1.5 border border-gold/30">
+                        <span className="text-[12px] tracking-[0.20em] uppercase font-bold text-gold bg-gold/[0.12] px-3 py-1.5 border border-gold/30 rounded-sm">
                           Recommended
                         </span>
                       </div>
@@ -979,7 +988,7 @@ const Index = () => {
             <div ref={revFaq.ref} className={cn("max-w-lg mx-auto transition-all duration-700 ease-out", revFaq.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
               <SectionHeader eyebrow="Common Questions" title={<>WHAT FILMMAKERS <span className="text-white">ASK</span></>} flankingLines compact />
 
-              <div className="bg-black px-5 border border-white/[0.06]">
+              <div className="bg-black px-5 border border-white/[0.06] rounded-lg">
                 <Accordion type="single" collapsible className="w-full">
                   {faqs.map((faq, i) => (
                     <AccordionItem key={faq.q} value={`faq-${i}`} className="border-b border-white/[0.08]">


### PR DESCRIPTION
…nement

- CTA buttons: border-radius 0 → 6px (primary, final, secondary)
- SectionFrame: added rounded-lg to outer container
- Index.tsx: rounded-lg/md on all content boxes, cards, FAQ, waterfall, corridor splits, Blum quote card, product tier cards, featured badges
- AppHeader: backdrop blur + translucency, enhanced gold separator line with glow, added subtle top gold edge to bookend with footer, haptics on wordmark and ellipsis menu button
- BottomTabBar: haptics on tab tap, PKGS → SHOP label
- MobileMenu: haptics on all interactive elements (nav items, contact links, share button, close button, brand footer), border-radius 0 → 8 on all menu grid items
- SectionHeader: rounded-md on non-plain subtitle variant
- Blum card: inner atmospheric radial-gradient haze overlay
- useReveal: prefers-reduced-motion support (shows all content immediately)
- Header sticky CTA: border-radius 0 → 6 to match new button style

https://claude.ai/code/session_01EhyUuMKiC4aP2ikFYkuC9g