### PR TITLE
Strip landing page chrome: remove decorative SectionFrame containers,…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, ReactNode } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -6,9 +6,8 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ErrorBoundary from "./components/ErrorBoundary";
 import BottomTabBar from "./components/BottomTabBar";
 import OgBotSheet from "./components/OgBotSheet";
-import OgBotFab from "./components/OgBotFab";
 import MobileMenu from "./components/MobileMenu";
-import AppHeader, { HeaderCtaContext } from "./components/AppHeader";
+import AppHeader from "./components/AppHeader";
 
 /* ═══════════════════════════════════════════════════════════════════
    Lazy-loaded pages — only the landing page is eagerly loaded.
@@ -48,12 +47,12 @@ const queryClient = new QueryClient();
 const AppShell = () => {
   const [isBotOpen, setIsBotOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [ctaSlot, setCtaSlot] = useState<ReactNode>(null);
 
   return (
-    <HeaderCtaContext.Provider value={{ ctaSlot, setCtaSlot }}>
+    <>
       <AppHeader
         onMoreOpen={() => setIsMenuOpen(true)}
+        onBotOpen={() => setIsBotOpen(true)}
       />
 
       <Suspense fallback={<PageLoader />}>
@@ -79,9 +78,8 @@ const AppShell = () => {
       {/* Global persistent UI — always mounted */}
       <OgBotSheet isOpen={isBotOpen} onOpenChange={setIsBotOpen} />
       <MobileMenu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen} />
-      <OgBotFab onClick={() => setIsBotOpen(true)} isActive={isBotOpen} />
       <BottomTabBar />
-    </HeaderCtaContext.Provider>
+    </>
   );
 };
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,40 +1,23 @@
-import { ReactNode, createContext, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
-   HeaderCtaContext — lets Index.tsx inject a sticky CTA into the
-   header's center slot without prop-drilling through the router.
-   ═══════════════════════════════════════════════════════════════════ */
-interface HeaderCtaContextType {
-  ctaSlot: ReactNode;
-  setCtaSlot: (node: ReactNode) => void;
-}
-
-export const HeaderCtaContext = createContext<HeaderCtaContextType>({
-  ctaSlot: null,
-  setCtaSlot: () => {},
-});
-
-export const useHeaderCta = () => useContext(HeaderCtaContext);
-
-/* ═══════════════════════════════════════════════════════════════════
    AppHeader — unified global header for all pages
    Left:   FILMMAKER.OG (→ home)
-   Center: conditional CTA slot (only on landing page, injected via context)
-   Right:  F-icon bot button + vertical ⋮ menu button
+   Center: OG bot pill
+   Right:  vertical ⋮ menu button
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
   onMoreOpen?: () => void;
+  onBotOpen?: () => void;
 }
 
 const GOLD_FULL = "rgba(212,175,55,1)";
 const GOLD_DIM  = "rgba(212,175,55,0.65)";
 
-const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
+const AppHeader = ({ onMoreOpen, onBotOpen }: AppHeaderProps) => {
   const navigate = useNavigate();
-  const { ctaSlot } = useHeaderCta();
   const haptics = useHaptics();
 
   return (
@@ -87,12 +70,35 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
             </span>
           </button>
 
-          {/* Center — optional sticky CTA (landing page only) */}
-          {ctaSlot && (
-            <div className="flex-1 flex justify-center px-3 overflow-hidden">
-              {ctaSlot}
-            </div>
-          )}
+          {/* Center — OG bot pill */}
+          <button
+            onClick={() => { haptics.light(); onBotOpen?.(); }}
+            className="flex items-center justify-center gap-1.5 transition-all duration-200 active:scale-95 hover:opacity-90"
+            aria-label="Ask OG"
+            style={{
+              height: "36px",
+              minWidth: "88px",
+              paddingLeft: "14px",
+              paddingRight: "14px",
+              borderRadius: "999px",
+              background: "rgba(20,20,20,0.90)",
+              border: "1px solid rgba(212,175,55,0.35)",
+              boxShadow: "0 2px 8px rgba(0,0,0,0.40), inset 0 1px 0 rgba(255,255,255,0.03)",
+            }}
+          >
+            <span
+              className="font-bebas text-[15px] tracking-[0.14em]"
+              style={{ color: GOLD_FULL }}
+            >
+              OG
+            </span>
+            <span
+              className="text-[12px] tracking-[0.06em]"
+              style={{ color: "rgba(255,255,255,0.35)" }}
+            >
+              Ask
+            </span>
+          </button>
 
           {/* Right — vertical ⋮ menu */}
           <div className="flex items-center flex-shrink-0">

--- a/src/components/SectionFrame.tsx
+++ b/src/components/SectionFrame.tsx
@@ -12,15 +12,8 @@ const SectionFrame = ({
   alt?: boolean;
 }) => (
   <section id={id} className="snap-section px-4 py-4">
-    <div className="flex overflow-hidden border border-white/[0.06] rounded-2xl">
-      <div
-        className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20"
-        style={{ boxShadow: "0 0 16px rgba(212,175,55,0.30)" }}
-      />
-      <div className={cn("flex-1 min-w-0 bg-black", className)}>
-        <div className="h-[2px] bg-gradient-to-r from-transparent via-gold/25 to-transparent" />
-        <div className="px-7 py-5 md:px-10 md:py-7">{children}</div>
-      </div>
+    <div className={cn("px-7 py-5 md:px-10 md:py-7", className)}>
+      {children}
     </div>
   </section>
 );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,7 +9,6 @@ import {
   ChevronDown,
 } from "lucide-react";
 import filmmakerLogo from "@/assets/filmmaker-f-icon.png";
-import { useHeaderCta } from "@/components/AppHeader";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import {
   Accordion,
@@ -117,17 +116,6 @@ const useReveal = (threshold = 0.15) => {
 };
 
 /* ═══════════════════════════════════════════════════════════════════
-   DIVIDER
-   ═══════════════════════════════════════════════════════════════════ */
-const Divider = () => (
-  <div className="py-4 px-6">
-    <div className="max-w-md mx-auto">
-      <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/25 to-transparent" />
-    </div>
-  </div>
-);
-
-/* ═══════════════════════════════════════════════════════════════════
    MAIN COMPONENT
    ═══════════════════════════════════════════════════════════════════ */
 const Index = () => {
@@ -159,10 +147,6 @@ const Index = () => {
       navigate(destination);
     }
   }, [hasSession, navigate]);
-
-  // Hero scroll tracking (for sticky CTA)
-  const heroRef = useRef<HTMLElement>(null);
-  const [heroPast, setHeroPast] = useState(false);
 
   // Intro skip
   const introTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -283,47 +267,6 @@ const Index = () => {
   const isPulsed = ['pulse','tagline','complete'].includes(phase) || shouldSkip;
   const showTagline = ['tagline','complete'].includes(phase) || shouldSkip;
 
-  // Hero scroll observer — triggers sticky CTA
-  useEffect(() => {
-    if (!isComplete) return;
-    const el = heroRef.current;
-    if (!el) return;
-    const obs = new IntersectionObserver(
-      ([entry]) => setHeroPast(!entry.isIntersecting),
-      { threshold: 0, rootMargin: '-56px 0px 0px 0px' }
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, [isComplete]);
-
-  // Inject sticky CTA into the global AppHeader via context
-  const { setCtaSlot } = useHeaderCta();
-
-  useEffect(() => {
-    if (!isComplete) return;
-    const ctaButton = (
-      <button
-        onClick={handleStartClick}
-        className={cn(
-          "font-bebas text-[13px] tracking-[0.14em] uppercase whitespace-nowrap",
-          "h-9 px-3.5",
-          "bg-gold-cta-subtle border border-gold-cta-muted text-gold-cta",
-          "transition-all duration-300 ease-out",
-          "hover:border-gold-cta",
-          "active:scale-[0.97]",
-          heroPast
-            ? "opacity-100 translate-y-0 pointer-events-auto"
-            : "opacity-0 -translate-y-1 pointer-events-none"
-        )}
-        style={{ borderRadius: 10 }}
-      >
-        BUILD NOW
-      </button>
-    );
-    setCtaSlot(ctaButton);
-    return () => setCtaSlot(null);
-  }, [isComplete, heroPast, handleStartClick, setCtaSlot]);
-
   return (
     <>
 
@@ -392,7 +335,7 @@ const Index = () => {
           {/* ──────────────────────────────────────────────────────────
                § 1  HERO
              ────────────────────────────────────────────────────────── */}
-          <section id="hero" ref={heroRef} className="snap-section min-h-0 pt-20 pb-12 flex flex-col justify-center relative overflow-hidden">
+          <section id="hero" className="snap-section min-h-0 pt-20 pb-12 flex flex-col justify-center relative overflow-hidden">
             <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none animate-spotlight-pulse"
               style={{ width: '100vw', height: '120%', background: `radial-gradient(ellipse 50% 50% at 50% 15%, rgba(212,175,55,0.10) 0%, rgba(212,175,55,0.04) 45%, transparent 75%)` }} />
             {/* Static spotlight cone — settled version of cinematic intro beam */}
@@ -433,9 +376,8 @@ const Index = () => {
 
               <div className="w-full max-w-[320px] mx-auto space-y-3">
                 <button onClick={handleStartClick} className="w-full h-14 text-base btn-cta-primary">
-                  BUILD YOUR WATERFALL &mdash; FREE
+                  BUILD YOUR WATERFALL
                 </button>
-                <p className="text-white/50 text-sm tracking-wider">No credit card. Takes 2{"\u00A0"}minutes.</p>
               </div>
 
               <div className="mt-8 flex justify-center animate-bounce-subtle cursor-pointer active:scale-[0.97]"
@@ -445,7 +387,6 @@ const Index = () => {
             </div>
           </section>
 
-          <Divider />
 
           {/* ──────────────────────────────────────────────────────────
                § 2  THE PROBLEM — narrative setup for waterfall reveal
@@ -529,7 +470,6 @@ const Index = () => {
             </div>
           </SectionFrame>
 
-          <Divider />
 
           {/* ──────────────────────────────────────────────────────────
                § 3  THE WATERFALL — the reveal
@@ -642,7 +582,7 @@ const Index = () => {
                 <div className="mt-6 text-center">
                   <button onClick={handleStartClick}
                     className="w-full max-w-[320px] h-14 text-base btn-cta-primary mx-auto">
-                    BUILD YOUR WATERFALL &mdash; FREE
+                    BUILD YOUR WATERFALL
                   </button>
                   <p className="text-white/55 text-[15px] tracking-wider mt-3">See how to keep more of it.</p>
                 </div>
@@ -650,7 +590,6 @@ const Index = () => {
             </div>
           </SectionFrame>
 
-          <Divider />
 
           {/* ──────────────────────────────────────────────────────────
                § 4  THE THESIS — why film has no tools
@@ -964,7 +903,7 @@ const Index = () => {
               <div className="text-center mt-10">
                 <button onClick={handleStartClick}
                   className="w-full max-w-[320px] h-14 text-base btn-cta-primary mx-auto">
-                  BUILD YOUR WATERFALL &mdash; FREE
+                  BUILD YOUR WATERFALL
                 </button>
                 <div className="mt-5 flex items-center justify-center gap-4">
                   <button onClick={() => navigate("/store")} className="text-white/50 text-[15px] hover:text-gold transition-colors">
@@ -975,7 +914,6 @@ const Index = () => {
             </div>
           </SectionFrame>
 
-          <Divider />
 
           {/* ──────────────────────────────────────────────────────────
                § 8  FAQ
@@ -1001,7 +939,6 @@ const Index = () => {
             </div>
           </SectionFrame>
 
-          <Divider />
 
           {/* ──────────────────────────────────────────────────────────
                § 9  FINAL CTA


### PR DESCRIPTION
… dividers, sticky CTA, floating bot FAB; add header bot pill

- Remove "— FREE" from all CTA buttons and "No credit card" hero subtitle
- Strip SectionFrame to minimal invisible wrapper (no gold bar, border, top line)
- Remove all <Divider /> components between content sections
- Remove HeaderCtaContext system (sticky CTA injection into header)
- Remove heroRef/heroPast scroll tracking and IntersectionObserver
- Remove OgBotFab floating button from App shell
- Add compact "OG Ask" pill button to AppHeader between wordmark and kebab menu
- Wire onBotOpen prop through AppHeader → AppShell → OgBotSheet

https://claude.ai/code/session_01SQw8HmmpDc74kr2mzAss2L