### PR TITLE
Fix landing page chrome: restore kebab/FAB, revert to 4 tabs, refine …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ErrorBoundary from "./components/ErrorBoundary";
 import BottomTabBar from "./components/BottomTabBar";
 import OgBotSheet from "./components/OgBotSheet";
+import OgBotFab from "./components/OgBotFab";
 import MobileMenu from "./components/MobileMenu";
 import AppHeader from "./components/AppHeader";
 
@@ -51,7 +52,7 @@ const AppShell = () => {
   return (
     <>
       <AppHeader
-        onBotOpen={() => setIsBotOpen(true)}
+        onMoreOpen={() => setIsMenuOpen(true)}
       />
 
       <Suspense fallback={<PageLoader />}>
@@ -77,7 +78,8 @@ const AppShell = () => {
       {/* Global persistent UI — always mounted */}
       <OgBotSheet isOpen={isBotOpen} onOpenChange={setIsBotOpen} />
       <MobileMenu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen} />
-      <BottomTabBar onMoreOpen={() => setIsMenuOpen(true)} />
+      <OgBotFab onClick={() => setIsBotOpen(true)} isActive={isBotOpen} />
+      <BottomTabBar />
     </>
   );
 };

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,18 +1,19 @@
 import { useNavigate } from "react-router-dom";
+import { MoreVertical } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
    AppHeader — unified global header for all pages
    Left:   FILMMAKER.OG (→ home)
-   Right:  OG bot search pill (→ OgBotSheet)
+   Right:  kebab menu (→ MobileMenu)
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
-  onBotOpen?: () => void;
+  onMoreOpen?: () => void;
 }
 
 const GOLD_FULL = "rgba(212,175,55,1)";
 
-const AppHeader = ({ onBotOpen }: AppHeaderProps) => {
+const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
   const navigate = useNavigate();
   const haptics = useHaptics();
 
@@ -66,33 +67,20 @@ const AppHeader = ({ onBotOpen }: AppHeaderProps) => {
             </span>
           </button>
 
-          {/* Right — OG bot search pill */}
+          {/* Right — kebab menu */}
           <button
-            onClick={() => { haptics.light(); onBotOpen?.(); }}
-            className="flex items-center gap-2 transition-all duration-200 active:scale-95 hover:opacity-90 flex-shrink-0"
-            aria-label="Ask OG"
+            onClick={() => { haptics.light(); onMoreOpen?.(); }}
+            className="flex items-center justify-center transition-all duration-200 active:scale-95 flex-shrink-0"
+            aria-label="More options"
             style={{
-              height: "34px",
-              width: "130px",
-              paddingLeft: "14px",
-              paddingRight: "14px",
-              borderRadius: "999px",
-              background: "#000000",
-              border: "1px solid rgba(212,175,55,0.35)",
+              width: "40px",
+              height: "40px",
             }}
           >
-            <span
-              className="font-bebas text-[14px] tracking-[0.14em]"
+            <MoreVertical
+              className="w-5 h-5"
               style={{ color: GOLD_FULL }}
-            >
-              OG
-            </span>
-            <span
-              className="text-[13px] tracking-[0.15em]"
-              style={{ color: "rgba(255,255,255,0.30)" }}
-            >
-              ...
-            </span>
+            />
           </button>
         </nav>
       </header>

--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Home, Calculator, ShoppingBag, BookOpen, MoreHorizontal } from "lucide-react";
+import { Home, Calculator, ShoppingBag, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useHaptics } from "@/hooks/use-haptics";
 
@@ -9,21 +9,15 @@ const tabs = [
   { id: "calculator", path: "/calculator", label: "CALC", icon: Calculator },
   { id: "store",      path: "/store",      label: "SHOP", icon: ShoppingBag },
   { id: "resources",  path: "/resources",  label: "INFO", icon: BookOpen },
-  { id: "more",       path: null,          label: "MORE", icon: MoreHorizontal },
 ];
 
-interface BottomTabBarProps {
-  onMoreOpen?: () => void;
-}
-
-const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
+const BottomTabBar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const haptics = useHaptics();
   const [rippleId, setRippleId] = useState<string | null>(null);
 
-  const getActive = (path: string | null) => {
-    if (!path) return false;
+  const getActive = (path: string) => {
     if (path === "/") return location.pathname === "/";
     return location.pathname.startsWith(path);
   };
@@ -31,13 +25,9 @@ const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
   const handleTap = useCallback((tab: typeof tabs[0]) => {
     haptics.light();
     setRippleId(tab.id);
-    if (tab.id === "more") {
-      onMoreOpen?.();
-    } else if (tab.path) {
-      navigate(tab.path);
-    }
+    navigate(tab.path);
     setTimeout(() => setRippleId(null), 420);
-  }, [navigate, haptics, onMoreOpen]);
+  }, [navigate, haptics]);
 
   const GOLD_FULL = "rgba(212,175,55,1)";
   const GOLD_DIM  = "rgba(212,175,55,0.75)";
@@ -66,7 +56,7 @@ const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
           WebkitBackdropFilter: "blur(16px)",
           border: "1.5px solid rgba(212,175,55,0.60)",
           boxShadow:
-            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.15), 0 0 20px rgba(212,175,55,0.12), inset 0 0.5px 0 rgba(212,175,55,0.10)",
+            "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.15), 0 0 12px rgba(212,175,55,0.06), inset 0 0.5px 0 rgba(212,175,55,0.10)",
           paddingLeft: "6px",
           paddingRight: "6px",
         }}
@@ -90,7 +80,7 @@ const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
                 isActive && "rounded-lg",
               )}
               style={{
-                background: isActive ? "rgba(212,175,55,0.15)" : "transparent",
+                background: isActive ? "rgba(212,175,55,0.06)" : "transparent",
               }}
               aria-label={tab.label}
             >
@@ -111,7 +101,7 @@ const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
                   fontSize: "11px",
                   letterSpacing: isActive ? "0.16em" : "0.10em",
                   fontWeight: 500,
-                  color: isActive ? GOLD_FULL : GOLD_DIM,
+                  color: isActive ? GOLD_FULL : "rgba(255,255,255,0.55)",
                 }}
               >
                 {tab.label}
@@ -126,7 +116,6 @@ const BottomTabBar = ({ onMoreOpen }: BottomTabBarProps) => {
                     borderRadius: "2px",
                     background: GOLD_FULL,
                     display: "block",
-                    boxShadow: "0 0 8px rgba(212,175,55,0.50), 0 0 16px rgba(212,175,55,0.20)",
                   }}
                 />
               )}

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -1,3 +1,5 @@
+import { Sparkles } from "lucide-react";
+
 interface OgBotFabProps {
   onClick: () => void;
   isActive?: boolean;
@@ -49,27 +51,18 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
         }}
       />
 
-      {/* Orbital accent dot — rotates slowly when inactive */}
-      {!isActive && (
-        <div
-          className="absolute inset-0 pointer-events-none animate-orbit"
-          style={{ borderRadius: "14px" }}
-        >
-          <div
-            className="absolute"
-            style={{
-              width: "4px",
-              height: "4px",
-              borderRadius: "50%",
-              background: "rgba(212,175,55,0.60)",
-              boxShadow: "0 0 6px rgba(212,175,55,0.40)",
-              top: "-2px",
-              left: "50%",
-              marginLeft: "-2px",
-            }}
-          />
-        </div>
-      )}
+      {/* Sparkle accent — top-right corner */}
+      <Sparkles
+        className="absolute pointer-events-none"
+        style={{
+          top: "-2px",
+          right: "-2px",
+          width: "13px",
+          height: "13px",
+          color: "rgba(212,175,55,0.70)",
+        }}
+        strokeWidth={2}
+      />
 
       {/* OG text */}
       <span

--- a/src/index.css
+++ b/src/index.css
@@ -796,21 +796,6 @@
   }
 
   /* ═══════════════════════════════════════════════════════════════════
-     CINEMATIC VIGNETTE
-     ═══════════════════════════════════════════════════════════════════ */
-  .vignette {
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 50;
-    background: radial-gradient(
-      ellipse 500px 60% at 50% 50%,
-      transparent 50%,
-      rgba(0,0,0,0.4) 100%
-    );
-  }
-
-  /* ═══════════════════════════════════════════════════════════════════
      SPOTLIGHT INTRO ANIMATIONS
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes spotlight-beam-expand {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -276,29 +276,12 @@ const Index = () => {
              ────────────────────────────────────────────────────────── */}
           <section id="hero" className="snap-section min-h-0 pt-20 pb-12 flex flex-col justify-center relative overflow-hidden">
             <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none animate-spotlight-pulse"
-              style={{ width: '100vw', height: '120%', background: `radial-gradient(ellipse 50% 50% at 50% 15%, rgba(212,175,55,0.10) 0%, rgba(212,175,55,0.04) 45%, transparent 75%)` }} />
+              style={{ width: '100vw', height: '120%', background: `radial-gradient(ellipse 35% 35% at 50% 15%, rgba(212,175,55,0.06) 0%, rgba(212,175,55,0.04) 45%, transparent 75%)` }} />
             {/* Static spotlight cone — settled version of cinematic intro beam */}
             <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none"
               style={{
-                background: `radial-gradient(ellipse 25% 40% at 50% 0%, rgba(255,255,255,0.12) 0%, rgba(255,255,255,0.06) 30%, rgba(212,175,55,0.02) 50%, transparent 70%)`,
+                background: `radial-gradient(ellipse 25% 40% at 50% 0%, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.03) 30%, rgba(212,175,55,0.02) 50%, transparent 70%)`,
                 clipPath: 'polygon(42% 0%, 58% 0%, 72% 100%, 28% 100%)',
-              }} />
-            {/* Left spotlight cone */}
-            <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none"
-              style={{
-                background: `radial-gradient(ellipse 20% 35% at 30% 0%, rgba(255,255,255,0.07) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
-                clipPath: 'polygon(22% 0%, 38% 0%, 55% 100%, 15% 100%)',
-              }} />
-            {/* Right spotlight cone */}
-            <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none"
-              style={{
-                background: `radial-gradient(ellipse 20% 35% at 70% 0%, rgba(255,255,255,0.07) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
-                clipPath: 'polygon(62% 0%, 78% 0%, 85% 100%, 45% 100%)',
-              }} />
-            {/* Floor bounce glow */}
-            <div className="absolute bottom-0 left-0 right-0 h-1/3 pointer-events-none"
-              style={{
-                background: `radial-gradient(ellipse 400px 80% at 50% 100%, rgba(212,175,55,0.06) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
               }} />
             <div className="relative px-6 py-4 max-w-xl mx-auto text-center">
               <div className="mb-5 relative inline-block">
@@ -333,7 +316,9 @@ const Index = () => {
           <SectionFrame id="waterfall">
             <div ref={revWater.ref} className={cn("transition-all duration-700 ease-out", revWater.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
 
-              <p className="text-white/50 text-[15px] text-center mb-6">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
+              <h2 className="font-bebas text-[36px] md:text-[44px] text-gold tracking-[0.08em] text-center">THE WATERFALL</h2>
+              <p className="text-[14px] text-white/40 tracking-[0.12em] uppercase text-center">Your recoupment structure</p>
+              <p className="text-white/50 text-[15px] text-center mb-6 mt-4">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
 
               <div ref={waterBarRef} className="max-w-md mx-auto">
                 {/* Waterfall rows — unified financial table */}
@@ -411,8 +396,8 @@ const Index = () => {
                     </span>
                   </div>
                   <div className="border border-gold/25 bg-black px-4 py-5 text-center rounded-lg">
-                    <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-white/45 mb-1">Investor Corridor</p>
-                    <span className="font-mono text-[18px] font-bold text-white/70">
+                    <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/60 mb-1">Investor Corridor</p>
+                    <span className="font-mono text-[18px] font-bold text-gold">
                       ${investorVal.toLocaleString()}
                     </span>
                   </div>
@@ -605,7 +590,7 @@ const Index = () => {
                       Filmmakers have a perception in the business world of being kind of flaky dudes{"\u2026"} you need to be buttoned down{"\u2026"} speak the language that they speak.
                     </p>
                   </blockquote>
-                  <div className="mt-4 -mx-1 p-3 bg-gold/[0.06] border border-gold/25 rounded-lg">
+                  <div className="mt-4 pt-3">
                     <div className="flex items-center gap-3">
                       <div className="w-10 h-[1.5px] bg-gold/50" />
                       <cite className="not-italic">
@@ -615,27 +600,6 @@ const Index = () => {
                     <p className="text-white/50 text-[13px] tracking-[0.08em] mt-1.5 ml-9">Blumhouse "Paranormal Activity"</p>
                   </div>
                 </div>
-              </div>
-            </div>
-          </section>
-
-          {/* ──────────────────────────────────────────────────────────
-               DECLARATION — the hinge before gatekeepers
-             ────────────────────────────────────────────────────────── */}
-          <section className="py-10 md:py-16 px-6 relative">
-            <div className="absolute inset-0 pointer-events-none"
-              style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.07) 0%, transparent 70%)' }} />
-            <div ref={revDecl.ref} className={cn("max-w-md mx-auto relative transition-all duration-700 ease-out", revDecl.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5")}>
-              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
-              <div className="py-12 px-4 text-center">
-                <h3 className="font-bebas text-[32px] md:text-[40px] tracking-[0.08em] uppercase text-gold leading-tight">
-                  We Built The Toolkit They Didn{"\u2019"}t Teach You In Film{"\u00A0"}<span className="text-white">School</span>.
-                </h3>
-              </div>
-              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
-              <div className="flex justify-center mt-6 cursor-pointer active:scale-[0.97]"
-                onClick={() => { haptics.light(); document.getElementById('cost')?.scrollIntoView({ behavior: 'smooth' }); }}>
-                <ChevronDown className="w-5 h-5 text-gold/50 animate-bounce-subtle" />
               </div>
             </div>
           </section>
@@ -683,6 +647,27 @@ const Index = () => {
               </div>
             </div>
           </SectionFrame>
+
+          {/* ──────────────────────────────────────────────────────────
+               DECLARATION — the hinge before final CTA
+             ────────────────────────────────────────────────────────── */}
+          <section className="py-10 md:py-16 px-6 relative">
+            <div className="absolute inset-0 pointer-events-none"
+              style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.07) 0%, transparent 70%)' }} />
+            <div ref={revDecl.ref} className={cn("max-w-md mx-auto relative transition-all duration-700 ease-out", revDecl.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5")}>
+              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
+              <div className="py-12 px-4 text-center">
+                <h3 className="font-bebas text-[32px] md:text-[40px] tracking-[0.08em] uppercase text-gold leading-tight">
+                  We Built The Toolkit They Didn{"\u2019"}t Teach You In Film{"\u00A0"}<span className="text-white">School</span>.
+                </h3>
+              </div>
+              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
+              <div className="flex justify-center mt-6 cursor-pointer active:scale-[0.97]"
+                onClick={() => { haptics.light(); document.getElementById('final-cta')?.scrollIntoView({ behavior: 'smooth' }); }}>
+                <ChevronDown className="w-5 h-5 text-gold/50 animate-bounce-subtle" />
+              </div>
+            </div>
+          </section>
 
 
           {/* ──────────────────────────────────────────────────────────


### PR DESCRIPTION
…visuals

- Header: replace bot search pill with kebab menu button (MoreVertical)
- Re-mount OgBotFab in App.tsx, replace orbit animation with Sparkles icon
- Bottom tab bar: revert to 4 tabs (remove MORE), fix inactive text color to white/55, reduce active bg opacity, remove indicator shadow, soften nav pill glow
- Hero: remove left/right spotlight cones and floor bounce, tighten center spotlight ellipse and reduce opacity
- Waterfall: add "THE WATERFALL" title and subtitle above budget context
- Unify corridor boxes: Investor Corridor now uses gold labels/numbers
- Clean Blum attribution: remove container box (bg, border, rounded-lg)
- Swap section order: Closed Doors grid before "We Built The Toolkit"
- Update Declaration ChevronDown target from #cost to #final-cta
- Delete unused .vignette CSS class

https://claude.ai/code/session_01WVhNWbriE8NCU5UULFj2o6