### PR TITLE
Polish UI chrome: redesign bot sheet, unify menu, refine landing details

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { Home, Calculator, BookOpen, Book, Mail, Instagram, Share2, X as CloseIcon } from "lucide-react";
+import { Home, Calculator, BookOpen, ShoppingBag, Mail, Instagram, Share2, X as CloseIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
 import { useHaptics } from "@/hooks/use-haptics";
@@ -118,10 +118,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
             <SectionLabel>Menu</SectionLabel>
             <div className="grid grid-cols-2 gap-2.5">
               {([
-                { path: "/store",      icon: Book,       label: "Packages",   featured: true },
-                { path: "/",           icon: Home,       label: "Home",       featured: false },
-                { path: "/calculator", icon: Calculator, label: "Calculator", featured: false },
-                { path: "/resources",  icon: BookOpen,   label: "Resources",  featured: false },
+                { path: "/",           icon: Home,        label: "Home" },
+                { path: "/calculator", icon: Calculator,  label: "Calculator" },
+                { path: "/store",      icon: ShoppingBag, label: "Shop" },
+                { path: "/resources",  icon: BookOpen,    label: "Resources" },
               ] as const).map((item) => {
                 const Icon = item.icon;
                 return (
@@ -131,25 +131,17 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                     className="relative flex flex-col items-center justify-center gap-2 py-5 border text-center group transition-all overflow-hidden"
                     style={{
                       borderRadius: 12,
-                      borderColor: item.featured ? "rgba(212,175,55,0.50)" : "rgba(255,255,255,0.10)",
-                      background: item.featured ? "rgba(212,175,55,0.08)" : "rgba(255,255,255,0.03)",
-                      boxShadow: item.featured ? "0 0 20px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)" : "none",
+                      borderColor: "rgba(255,255,255,0.10)",
+                      background: "rgba(255,255,255,0.03)",
                     }}
                   >
-                    {/* Gold left accent on featured */}
-                    {item.featured && (
-                      <div
-                        className="absolute left-0 top-0 bottom-0 w-[2px]"
-                        style={{ background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.25))" }}
-                      />
-                    )}
                     <Icon
                       className="w-5 h-5 transition-colors"
-                      style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.70)" }}
+                      style={{ color: "rgba(212,175,55,1)" }}
                     />
                     <span
                       className="font-bebas text-[18px] tracking-[0.12em] leading-none transition-colors"
-                      style={{ color: item.featured ? "rgba(212,175,55,1)" : "rgba(255,255,255,0.85)" }}
+                      style={{ color: "rgba(255,255,255,0.85)" }}
                     >
                       {item.label}
                     </span>

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -51,15 +51,15 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
         }}
       />
 
-      {/* Sparkle accent — top-right corner */}
+      {/* Sparkle accent — inside top-right */}
       <Sparkles
         className="absolute pointer-events-none"
         style={{
-          top: "-2px",
-          right: "-2px",
-          width: "13px",
-          height: "13px",
-          color: "rgba(212,175,55,0.70)",
+          top: "6px",
+          right: "6px",
+          width: "11px",
+          height: "11px",
+          color: "rgba(212,175,55,0.60)",
         }}
         strokeWidth={2}
       />
@@ -68,24 +68,12 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
       <span
         className="relative font-bebas leading-none"
         style={{
-          fontSize: "20px",
+          fontSize: "22px",
           letterSpacing: "0.16em",
           color: isActive ? "#000000" : "rgba(212,175,55,1)",
         }}
       >
         OG
-      </span>
-      {/* bot label */}
-      <span
-        className="relative font-bebas uppercase leading-none"
-        style={{
-          fontSize: "9px",
-          letterSpacing: "0.20em",
-          color: isActive ? "rgba(0,0,0,0.55)" : "rgba(212,175,55,0.55)",
-          marginTop: "1px",
-        }}
-      >
-        bot
       </span>
     </button>
   );

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -208,7 +208,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       {/* ── Bottom Sheet ── */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-[180] transition-transform duration-300 ease-out",
+          "fixed bottom-0 left-0 right-0 z-[180] transition-transform duration-300 ease-out rounded-t-2xl",
           "flex flex-col",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}
@@ -216,25 +216,17 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           height: "min(72vh, 580px)",
           paddingBottom: "calc(var(--bottom-bar-h) + env(safe-area-inset-bottom))",
           background: "#000000",
-          // Ambient glow only — no chunky border-shadow
           boxShadow: "0 -20px 60px rgba(212,175,55,0.18), 0 -40px 80px rgba(0,0,0,0.95)",
         }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        {/* 1px gold gradient top-edge line — SectionFrame DNA (replaces chunky shadow-border) */}
+        {/* 1px gold gradient top-edge line */}
         <div
           className="absolute top-0 left-0 right-0 h-[1px] pointer-events-none z-10"
           style={{
             background: "linear-gradient(to right, transparent 0%, rgba(212,175,55,0.60) 30%, rgba(212,175,55,0.80) 50%, rgba(212,175,55,0.60) 70%, transparent 100%)",
-          }}
-        />
-
-        {/* Gold left accent bar — SectionFrame DNA */}
-        <div
-          className="absolute left-0 top-0 bottom-0 w-[3px] pointer-events-none"
-          style={{
-            background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.35) 40%, rgba(212,175,55,0.10) 80%, transparent)",
+            borderRadius: "16px 16px 0 0",
           }}
         />
 
@@ -256,7 +248,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
               {ogMessages.length > 0 && (
                 <button
                   onClick={handleReset}
-                  className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.15em] transition-colors"
+                  className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.15em] transition-colors tabular-nums"
                   style={{ color: "rgba(255,255,255,0.30)" }}
                   onMouseEnter={e => (e.currentTarget.style.color = "rgba(212,175,55,0.70)")}
                   onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.30)")}
@@ -294,7 +286,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     key={chip}
                     onClick={() => handleAsk(chip)}
                     disabled={ogLoading}
-                    className="font-mono text-[13px] uppercase tracking-[0.18em] px-5 py-3 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
+                    className="font-bebas text-[15px] tracking-[0.10em] px-5 py-3 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
                     onMouseEnter={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.14)";
@@ -314,7 +306,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       e.currentTarget.style.background = "rgba(212,175,55,0.08)";
                     }}
                     style={{
-                      borderRadius: 0,
+                      borderRadius: "10px",
                       borderColor: "rgba(212,175,55,0.30)",
                       background: "rgba(212,175,55,0.08)",
                       color: "rgba(212,175,55,0.85)",
@@ -330,55 +322,45 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           {/* Message thread */}
           {ogMessages.map(msg => (
             <div key={msg.id} className="space-y-3">
-              {/* Question bubble — manifesto card style */}
+              {/* Question bubble */}
               <div className="flex justify-end">
                 <div
-                  className="relative max-w-[85%] px-4 py-3 pl-5 border overflow-hidden"
+                  className="relative max-w-[85%] px-4 py-3 border overflow-hidden"
                   style={{
-                    borderRadius: 0,
+                    borderRadius: "12px",
                     background: "rgba(255,255,255,0.04)",
-                    borderColor: "rgba(255,255,255,0.10)",
+                    borderColor: "rgba(212,175,55,0.20)",
                   }}
                 >
-                  {/* Gold left accent */}
-                  <div
-                    className="absolute left-0 top-0 bottom-0 w-[3px]"
-                    style={{
-                      background: "linear-gradient(to bottom, rgba(212,175,55,0.70), rgba(212,175,55,0.30))",
-                    }}
-                  />
                   <p className="text-base text-white leading-relaxed">{msg.question}</p>
                 </div>
               </div>
 
-              {/* Answer card — SectionFrame match */}
+              {/* Answer card */}
               <div className="flex justify-start">
                 <div
                   className="max-w-[95%] border overflow-hidden"
                   style={{
-                    borderRadius: 0,
+                    borderRadius: "12px",
                     background: "#000000",
                     borderColor: "rgba(212,175,55,0.15)",
                     boxShadow: "0 0 30px rgba(212,175,55,0.08)",
                   }}
                 >
-                  {/* Gold header band */}
-                  <div
-                    className="flex items-center gap-2.5 px-4 py-2"
-                    style={{ background: "rgba(212,175,55,1)" }}
-                  >
-                    <img src={filmmakerFIcon} alt="OG" className="w-3 h-3 object-contain" />
-                    <span className="font-bebas text-xs tracking-[0.22em] text-black leading-none">THE OG</span>
-                    {msg.streaming && (
-                      <div className="flex gap-1 ml-auto">
-                        <div className="w-1.5 h-1.5 bg-black/50 animate-bounce" style={{ animationDelay: "0ms", borderRadius: 0 }} />
-                        <div className="w-1.5 h-1.5 bg-black/50 animate-bounce" style={{ animationDelay: "150ms", borderRadius: 0 }} />
-                        <div className="w-1.5 h-1.5 bg-black/50 animate-bounce" style={{ animationDelay: "300ms", borderRadius: 0 }} />
-                      </div>
-                    )}
-                  </div>
                   {/* Answer body */}
                   <div className="px-4 py-4">
+                    {/* Inline attribution header */}
+                    <div className="flex items-center gap-2 mb-3">
+                      <img src={filmmakerFIcon} alt="OG" className="w-4 h-4 object-contain" />
+                      <span className="font-bebas text-[14px] tracking-[0.14em] leading-none" style={{ color: "rgba(212,175,55,1)" }}>OG</span>
+                      {msg.streaming && (
+                        <div className="flex gap-1 ml-1">
+                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "0ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "150ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "300ms" }} />
+                        </div>
+                      )}
+                    </div>
                     {msg.error ? (
                       <p className="text-[15px] leading-relaxed" style={{ color: "rgba(212,175,55,0.60)" }}>{msg.error}</p>
                     ) : (
@@ -406,12 +388,11 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
             <div
               className="flex gap-0 border transition-colors"
               style={{
-                borderLeft: "3px solid rgba(212,175,55,0.80)",
-                borderColor: "rgba(212,175,55,0.45)",
-                borderLeftColor: "rgba(212,175,55,0.80)",
+                borderRadius: "12px",
+                border: "1px solid rgba(212,175,55,0.30)",
               }}
-              onFocus={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.85)")}
-              onBlur={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.45)")}
+              onFocus={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)")}
+              onBlur={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)")}
             >
               <textarea
                 ref={inputRef}
@@ -425,11 +406,10 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 disabled={ogLoading}
                 className="flex-1 px-4 py-3 focus:outline-none text-base text-white resize-none disabled:opacity-50 min-h-[52px]"
                 style={{
-                  borderRadius: 0,
+                  borderRadius: "12px 0 0 12px",
                   background: "transparent",
                   color: "#FFFFFF",
                 }}
-                // inline placeholder style override via CSS
               />
                 <button
                   type="submit"
@@ -439,7 +419,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   onMouseLeave={e => (e.currentTarget.style.background = "rgba(212,175,55,1)")}
                   onTouchStart={e => !e.currentTarget.disabled && (e.currentTarget.style.background = "rgba(212,175,55,0.80)")}
                   onTouchEnd={e => (e.currentTarget.style.background = "rgba(212,175,55,1)")}
-                  style={{ background: "rgba(212,175,55,1)", color: "#000", borderRadius: 0 }}
+                  style={{ background: "rgba(212,175,55,1)", color: "#000", borderRadius: "0 11px 11px 0" }}
                 >
                 <SendHorizonal className="w-4 h-4" />
                 <span className="text-base hidden sm:block">ASK</span>
@@ -447,7 +427,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
             </div>
             <div className="flex items-center justify-end mt-1.5 px-1">
               <span className={cn(
-                "text-[10px] font-mono tabular-nums",
+                "text-[10px] tabular-nums",
                 ogInput.length > 1350 ? "text-gold/60" : "text-white/25"
               )}>
                 {ogInput.length}/1500

--- a/src/index.css
+++ b/src/index.css
@@ -667,7 +667,7 @@
     border: 1px solid rgba(255, 232, 160, 0.40);
     color: #000000;
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 18px;
+    font-size: 22px;
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -723,7 +723,7 @@
     border: 1px solid rgba(147, 51, 234, 0.50);
     color: #FFFFFF;
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 18px;
+    font-size: 22px;
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -283,6 +283,18 @@ const Index = () => {
                 background: `radial-gradient(ellipse 25% 40% at 50% 0%, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.03) 30%, rgba(212,175,55,0.02) 50%, transparent 70%)`,
                 clipPath: 'polygon(42% 0%, 58% 0%, 72% 100%, 28% 100%)',
               }} />
+            {/* Left focused beam */}
+            <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none"
+              style={{
+                background: `radial-gradient(ellipse 18% 35% at 38% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
+                clipPath: 'polygon(30% 0%, 46% 0%, 58% 100%, 20% 100%)',
+              }} />
+            {/* Right focused beam */}
+            <div className="absolute top-0 left-0 right-0 bottom-0 pointer-events-none"
+              style={{
+                background: `radial-gradient(ellipse 18% 35% at 62% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.03) 40%, transparent 70%)`,
+                clipPath: 'polygon(54% 0%, 70% 0%, 80% 100%, 42% 100%)',
+              }} />
             <div className="relative px-6 py-4 max-w-xl mx-auto text-center">
               <div className="mb-5 relative inline-block">
                 <div className="absolute inset-0 -m-10 animate-logo-breathe" style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.45) 0%, transparent 70%)', filter: 'blur(18px)' }} />
@@ -317,8 +329,7 @@ const Index = () => {
             <div ref={revWater.ref} className={cn("transition-all duration-700 ease-out", revWater.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
 
               <h2 className="font-bebas text-[36px] md:text-[44px] text-gold tracking-[0.08em] text-center">THE WATERFALL</h2>
-              <p className="text-[14px] text-white/40 tracking-[0.12em] uppercase text-center">Your recoupment structure</p>
-              <p className="text-white/50 text-[15px] text-center mb-6 mt-4">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
+              <p className="text-[14px] text-gold/40 tracking-[0.12em] uppercase text-center">Your recoupment structure</p>
 
               <div ref={waterBarRef} className="max-w-md mx-auto">
                 {/* Waterfall rows — unified financial table */}
@@ -369,7 +380,7 @@ const Index = () => {
                 {/* Net Profits */}
                 <div className="mt-4 border border-gold/25 bg-black px-5 py-4 text-center rounded-lg">
                   <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/60 mb-1">Net Profits</p>
-                  <span className="font-mono text-[22px] font-bold text-gold">
+                  <span className="font-mono text-[22px] font-bold text-white">
                     ${countVal.toLocaleString()}
                   </span>
                 </div>
@@ -391,17 +402,18 @@ const Index = () => {
                 <div className="grid grid-cols-2 gap-4">
                   <div className="border border-gold/25 bg-black px-4 py-5 text-center rounded-lg">
                     <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/70 mb-1">Producer Corridor</p>
-                    <span className="font-mono text-[18px] font-bold text-gold">
+                    <span className="font-mono text-[18px] font-bold text-white">
                       ${producerVal.toLocaleString()}
                     </span>
                   </div>
                   <div className="border border-gold/25 bg-black px-4 py-5 text-center rounded-lg">
                     <p className="text-[10px] tracking-[0.2em] uppercase font-semibold text-gold/60 mb-1">Investor Corridor</p>
-                    <span className="font-mono text-[18px] font-bold text-gold">
+                    <span className="font-mono text-[18px] font-bold text-white">
                       ${investorVal.toLocaleString()}
                     </span>
                   </div>
                 </div>
+                <p className="text-white/50 text-[15px] text-center mt-5">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
               </div>
             </div>
           </SectionFrame>
@@ -413,8 +425,8 @@ const Index = () => {
           <SectionFrame id="evidence">
             <div ref={revEvidence.ref} className={cn("transition-all duration-700 ease-out", revEvidence.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
 
-              {/* Section header — large, confident, no eyebrow */}
               <div className="text-center mb-10">
+                <p className="text-white/40 text-[11px] tracking-[0.25em] uppercase font-semibold mb-3 text-center">The Problem</p>
                 <h2
                   className="font-bebas text-[40px] md:text-[52px] tracking-[0.06em] leading-[0.95] text-gold"
                   style={{
@@ -625,7 +637,7 @@ const Index = () => {
                   >
                     {/* Lock watermark — centered behind content */}
                     <LockKeyhole
-                      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 text-white/[0.04]"
+                      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 text-gold/[0.08]"
                       strokeWidth={1.5}
                     />
                     {/* Content */}
@@ -657,7 +669,10 @@ const Index = () => {
             <div ref={revDecl.ref} className={cn("max-w-md mx-auto relative transition-all duration-700 ease-out", revDecl.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5")}>
               <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
               <div className="py-12 px-4 text-center">
-                <h3 className="font-bebas text-[32px] md:text-[40px] tracking-[0.08em] uppercase text-gold leading-tight">
+                <h3
+                  className="font-bebas text-[32px] md:text-[40px] tracking-[0.08em] uppercase text-gold leading-tight"
+                  style={{ textShadow: revDecl.visible ? '0 0 30px rgba(212,175,55,0.4), 0 0 60px rgba(212,175,55,0.15)' : 'none' }}
+                >
                   We Built The Toolkit They Didn{"\u2019"}t Teach You In Film{"\u00A0"}<span className="text-white">School</span>.
                 </h3>
               </div>


### PR DESCRIPTION
- Hero: add left/right focused spotlight beams for logo presence
- Waterfall: subtitle to gold/40, move budget footnote below corridor boxes, corridor numbers to white (labels stay gold)
- Problem section: add "The Problem" eyebrow above headline
- Toolkit interstitial: add textShadow glow matching "Until now."
- Closed Doors: lock icons to gold/[0.08] for visibility
- OgBotFab: remove "bot" label, move sparkle inside (6px,6px), bump OG to 22px
- OgBotSheet full redesign: add rounded-t-2xl, remove gold left accent bar, round all corners (chips 10px, bubbles/cards/input 12px, send 0 12px 12px 0), chips from font-mono to font-bebas, replace solid gold header band with inline OG attribution, remove question bubble accent bar (gold-tinted border), input area uniform 1px border with 12px radius, character counter drop font-mono
- MobileMenu: "Packages" -> "Shop", Book -> ShoppingBag icon, reorder to match bottom tab bar (Home/Calculator/Shop/Resources), remove all featured logic (accent bars, special borders/backgrounds/shadows)
- CTA buttons: font-size 18px -> 22px for both primary and final

https://claude.ai/code/session_01WVhNWbriE8NCU5UULFj2o6