### PR TITLE
Final polish: white splits, FAB redesign, typography and spacing refi…

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -61,7 +61,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
   /* ─── Section label ─────────────────────────────────────────── */
   const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-    <p className="font-bebas text-[13px] text-gold/50 uppercase tracking-[0.20em] mb-3 pl-1">{children}</p>
+    <p className="font-bebas text-[16px] text-white/70 uppercase tracking-[0.20em] mb-3 pl-1">{children}</p>
   );
 
   return (

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from "lucide-react";
+import filmmakerFIcon from "@/assets/filmmaker-f-icon.png";
 
 interface OgBotFabProps {
   onClick: () => void;
@@ -10,7 +11,7 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
     <button
       onClick={onClick}
       aria-label="Ask the OG Bot"
-      className="fixed z-[145] flex flex-col items-center justify-center transition-all duration-200 active:scale-90"
+      className="fixed z-[145] flex items-center justify-center transition-all duration-200 active:scale-90"
       style={{
         bottom: "calc(78px + env(safe-area-inset-bottom))",
         right: "16px",
@@ -28,30 +29,33 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
           : "0 0 20px rgba(212,175,55,0.15), 0 4px 16px rgba(0,0,0,0.60)",
       }}
     >
-      {/* Sparkle accent — inside top-right */}
+      {/* Sparkle AI indicator — top right corner */}
       <Sparkles
         className="absolute pointer-events-none"
         style={{
-          top: "6px",
-          right: "6px",
-          width: "11px",
-          height: "11px",
-          color: "rgba(212,175,55,0.60)",
+          top: "5px",
+          right: "5px",
+          width: "12px",
+          height: "12px",
+          color: isActive ? "rgba(0,0,0,0.40)" : "rgba(212,175,55,0.65)",
         }}
         strokeWidth={2}
       />
 
-      {/* OG text */}
-      <span
-        className="relative font-bebas leading-none"
+      {/* F brand icon */}
+      <img
+        src={filmmakerFIcon}
+        alt=""
+        className="pointer-events-none"
         style={{
-          fontSize: "22px",
-          letterSpacing: "0.16em",
-          color: isActive ? "#000000" : "rgba(255,255,255,0.95)",
+          width: "32px",
+          height: "32px",
+          objectFit: "contain",
+          filter: isActive
+            ? "brightness(0.3)"
+            : "brightness(1.25) saturate(1.1)",
         }}
-      >
-        OG
-      </span>
+      />
     </button>
   );
 };

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -290,12 +290,12 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     onMouseEnter={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.14)";
-                      e.currentTarget.style.color = "rgba(212,175,55,1)";
+                      e.currentTarget.style.color = "rgba(255,255,255,1)";
                     }}
                     onMouseLeave={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.08)";
-                      e.currentTarget.style.color = "rgba(212,175,55,0.85)";
+                      e.currentTarget.style.color = "rgba(255,255,255,0.80)";
                     }}
                     onTouchStart={e => {
                       e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
@@ -309,7 +309,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       borderRadius: "10px",
                       borderColor: "rgba(212,175,55,0.30)",
                       background: "rgba(212,175,55,0.08)",
-                      color: "rgba(212,175,55,0.85)",
+                      color: "rgba(255,255,255,0.80)",
                     }}
                   >
                     {chip}
@@ -422,7 +422,6 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   style={{ background: "rgba(212,175,55,1)", color: "#000", borderRadius: "0 11px 11px 0" }}
                 >
                 <SendHorizonal className="w-4 h-4" />
-                <span className="text-base hidden sm:block">ASK</span>
               </button>
             </div>
             <div className="flex items-center justify-end mt-1.5 px-1">

--- a/src/index.css
+++ b/src/index.css
@@ -95,7 +95,7 @@
     --shadow-modal: 0 20px 50px rgba(0, 0, 0, 0.8);
 
     /* LAYOUT */
-    --appbar-h: 56px;
+    --appbar-h: 54px;
     --tabbar-h: 62px;
     --bottom-bar-h: 82px;
     --container-max: 460px;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -328,7 +328,7 @@ const Index = () => {
           <SectionFrame id="waterfall">
             <div ref={revWater.ref} className={cn("transition-all duration-700 ease-out", revWater.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
 
-              <h2 className="font-bebas text-[36px] md:text-[44px] text-gold tracking-[0.08em] text-center mb-1">THE WATERFALL</h2>
+              <h2 className="font-bebas text-[36px] md:text-[44px] text-gold tracking-[0.08em] text-center mb-1">THE <span className="text-white">WATERFALL</span></h2>
               <p className="text-[15px] text-white/50 tracking-[0.12em] uppercase text-center mb-2">Your recoupment structure</p>
 
               <div ref={waterBarRef} className="max-w-md mx-auto">
@@ -413,7 +413,7 @@ const Index = () => {
                     </span>
                   </div>
                 </div>
-                <p className="text-white/50 text-[15px] text-center mt-5">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
+                <p className="font-mono text-[12px] text-white/35 text-center mt-5">Based on a hypothetical $1.8M budget and a $3M acquisition.</p>
               </div>
             </div>
           </SectionFrame>
@@ -426,7 +426,7 @@ const Index = () => {
             <div ref={revEvidence.ref} className={cn("transition-all duration-700 ease-out", revEvidence.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
 
               <div className="text-center mb-10">
-                <p className="text-white/40 text-[11px] tracking-[0.25em] uppercase font-semibold mb-3 text-center">The Problem</p>
+                <p className="text-white/40 text-[12px] tracking-[0.25em] uppercase font-semibold mb-5 text-center">The Problem</p>
                 <h2
                   className="font-bebas text-[40px] md:text-[52px] tracking-[0.06em] leading-[0.95] text-gold"
                   style={{
@@ -627,7 +627,7 @@ const Index = () => {
               <div className="text-center mb-8">
                 <h2 className="font-bebas text-[36px] md:text-[44px] tracking-[0.08em] text-gold"
                   style={{ textShadow: revCost.visible ? '0 0 30px rgba(212,175,55,0.4), 0 0 60px rgba(212,175,55,0.15)' : 'none' }}>
-                  THE REALITY
+                  THE <span className="text-white">REALITY</span>
                 </h2>
               </div>
 
@@ -676,7 +676,6 @@ const Index = () => {
             <div className="absolute inset-0 pointer-events-none"
               style={{ background: 'radial-gradient(ellipse 320px 55% at 50% 50%, rgba(212,175,55,0.07) 0%, transparent 70%)' }} />
             <div ref={revDecl.ref} className={cn("max-w-md mx-auto relative transition-all duration-700 ease-out", revDecl.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5")}>
-              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
               <div className="py-12 px-4 text-center">
                 <h3
                   className="font-bebas text-[32px] md:text-[40px] tracking-[0.08em] uppercase text-gold leading-tight"
@@ -685,7 +684,6 @@ const Index = () => {
                   We Built The Toolkit They Didn{"\u2019"}t Teach You In Film{"\u00A0"}<span className="text-white">School</span>.
                 </h3>
               </div>
-              <div className="h-[1px] bg-gradient-to-r from-transparent via-gold/60 to-transparent" />
               <div className="flex justify-center mt-6 cursor-pointer active:scale-[0.97]"
                 onClick={() => { haptics.light(); document.getElementById('final-cta')?.scrollIntoView({ behavior: 'smooth' }); }}>
                 <ChevronDown className="w-5 h-5 text-gold/50 animate-bounce-subtle" />
@@ -715,8 +713,8 @@ const Index = () => {
 
               <div className="relative p-10 md:p-16 max-w-md mx-auto text-center">
                 <p className="text-white/50 text-[13px] tracking-[0.3em] uppercase font-semibold mb-5">The Moment of Truth</p>
-                <h2 className="font-bebas text-4xl md:text-5xl leading-[1.1] tracking-[0.08em] text-gold mb-8">
-                  YOUR INVESTOR WILL ASK<br />HOW THE MONEY FLOWS <span className="text-white">BACK</span>.
+                <h2 className="font-bebas text-[34px] md:text-[44px] leading-[1.1] tracking-[0.08em] text-gold mb-8">
+                  YOUR INVESTOR WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-white">BACK</span>.
                 </h2>
                 <button onClick={handleStartClick}
                   className="w-full max-w-[320px] h-14 btn-cta-final mx-auto">


### PR DESCRIPTION
…nements

- Add white text splits to "THE WATERFALL" and "THE REALITY" headings
- Fix hypothetical footnote to mono 12px at 35% opacity
- Increase "The Problem" eyebrow size and spacing
- Remove top/bottom dividers from Declaration section
- Fix CTA headline orphan with non-breaking space, adjust sizes
- Redesign OgBotFab with F brand icon replacing OG text
- Remove ASK label from send button, change chip text to white
- Update MobileMenu SectionLabel to 16px white/70
- Reduce header bar height from 56px to 54px

https://claude.ai/code/session_01K1fhHsdGtzciZeoxC4YKH8