### PR TITLE
Remove boxShadow from containerless FAB to eliminate visible circle a…

### DIFF
--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -20,9 +20,7 @@ const OgBotFab = ({ onClick, isActive }: OgBotFabProps) => {
         borderRadius: "50%",
         background: "transparent",
         border: "none",
-        boxShadow: isActive
-          ? "0 0 24px rgba(212,175,55,0.35), 0 4px 16px rgba(0,0,0,0.50)"
-          : "0 4px 20px rgba(0,0,0,0.60)",
+        boxShadow: "none",
       }}
     >
       {/* Sparkle AI indicator — top right, overlapping icon edge */}


### PR DESCRIPTION
…rtifact

The transparent button's boxShadow was rendering a visible dark circle behind the F icon. The icon's own drop-shadow filter already provides the gold glow effect.

https://claude.ai/code/session_01K1fhHsdGtzciZeoxC4YKH8