### PR TITLE
Restore gold-bar SectionFrame, full-width AppHeader, kill cinematic i…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, ReactNode, Suspense, useState } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -8,7 +8,7 @@ import BottomTabBar from "./components/BottomTabBar";
 import OgBotSheet from "./components/OgBotSheet";
 import OgBotFab from "./components/OgBotFab";
 import MobileMenu from "./components/MobileMenu";
-import AppHeader from "./components/AppHeader";
+import AppHeader, { HeaderCtaContext } from "./components/AppHeader";
 
 /* ═══════════════════════════════════════════════════════════════════
    Lazy-loaded pages — only the landing page is eagerly loaded.
@@ -48,9 +48,10 @@ const queryClient = new QueryClient();
 const AppShell = () => {
   const [isBotOpen, setIsBotOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [ctaSlot, setCtaSlot] = useState<ReactNode>(null);
 
   return (
-    <>
+    <HeaderCtaContext.Provider value={{ ctaSlot, setCtaSlot }}>
       <AppHeader
         onMoreOpen={() => setIsMenuOpen(true)}
       />
@@ -80,7 +81,7 @@ const AppShell = () => {
       <MobileMenu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen} />
       <OgBotFab onClick={() => setIsBotOpen(true)} isActive={isBotOpen} />
       <BottomTabBar />
-    </>
+    </HeaderCtaContext.Provider>
   );
 };
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,10 +1,23 @@
+import { ReactNode, createContext, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
+   HeaderCtaContext — allows any page to inject a CTA into the header
+   ═══════════════════════════════════════════════════════════════════ */
+interface HeaderCtaContextType {
+  ctaSlot: ReactNode;
+  setCtaSlot: (node: ReactNode) => void;
+}
+
+export const HeaderCtaContext = createContext<HeaderCtaContextType>({ ctaSlot: null, setCtaSlot: () => {} });
+export const useHeaderCta = () => useContext(HeaderCtaContext);
+
+/* ═══════════════════════════════════════════════════════════════════
    AppHeader — unified global header for all pages
    Left:   FILMMAKER.OG (→ home)
+   Center: optional CTA slot
    Right:  kebab menu (→ MobileMenu)
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
@@ -16,56 +29,41 @@ const GOLD_FULL = "rgba(212,175,55,1)";
 const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
   const navigate = useNavigate();
   const haptics = useHaptics();
+  const { ctaSlot } = useHeaderCta();
 
   return (
     <>
       <header
-        className="fixed top-0 left-0 right-0 z-[150] flex justify-center"
-        style={{ background: "transparent", pointerEvents: "none" }}
+        className="fixed top-0 left-0 right-0 z-[150]"
+        style={{ background: "var(--bg-header)" }}
       >
-        {/* Floating centered bar */}
-        <nav
-          className="relative flex items-center justify-between overflow-hidden"
-          style={{
-            pointerEvents: "auto",
-            width: "100%",
-            maxWidth: "300px",
-            height: "var(--appbar-h)",
-            marginTop: "12px",
-            borderRadius: "16px",
-            background: "rgba(10,10,10,0.92)",
-            backdropFilter: "blur(16px)",
-            WebkitBackdropFilter: "blur(16px)",
-            border: "1.5px solid rgba(212,175,55,0.50)",
-            boxShadow:
-              "0 8px 32px rgba(0,0,0,0.90), 0 0 0 1px rgba(212,175,55,0.14), 0 0 20px rgba(212,175,55,0.12)",
-            paddingLeft: "16px",
-            paddingRight: "12px",
-          }}
+        <div
+          className="flex items-center justify-between px-4"
+          style={{ height: "var(--appbar-h)" }}
         >
-          {/* Gold top edge line inside the bar */}
-          <div
-            className="absolute top-0 left-0 right-0 h-[1px] pointer-events-none"
-            style={{
-              background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.45) 30%, rgba(212,175,55,0.60) 50%, rgba(212,175,55,0.45) 70%, transparent 100%)",
-            }}
-          />
-
           {/* Left — FILMMAKER.OG wordmark */}
           <button
             onClick={() => { haptics.light(); navigate("/"); }}
             className="flex items-center gap-2.5 hover:opacity-80 transition-opacity group flex-shrink-0"
             aria-label="Go home"
           >
-            <span className="font-bebas text-[22px] tracking-[0.2em] group-hover:opacity-80 transition-opacity duration-200"
+            <span
+              className="font-bebas text-[22px] tracking-[0.2em] group-hover:opacity-80 transition-opacity duration-200"
               style={{ color: GOLD_FULL }}
             >
               FILMMAKER
-              <span style={{ color: "rgba(255,255,255,1)" }}>
+              <span style={{ color: "rgba(255,255,255,0.90)" }}>
                 .OG
               </span>
             </span>
           </button>
+
+          {/* Center — optional CTA slot */}
+          {ctaSlot && (
+            <div className="flex-1 flex justify-center px-3 overflow-hidden">
+              {ctaSlot}
+            </div>
+          )}
 
           {/* Right — kebab menu */}
           <button
@@ -79,14 +77,17 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
           >
             <MoreVertical
               className="w-5 h-5"
-              style={{ color: GOLD_FULL }}
+              style={{ color: "rgba(212,175,55,0.65)" }}
             />
           </button>
-        </nav>
+        </div>
+
+        {/* Gold line separator */}
+        <div className="h-[1px] w-full bg-gradient-to-r from-transparent via-gold/45 to-transparent" />
       </header>
 
-      {/* Spacer for fixed header — accounts for margin-top + bar height */}
-      <div style={{ height: "calc(var(--appbar-h) + 12px)" }} className="flex-shrink-0" />
+      {/* Spacer for fixed header */}
+      <div style={{ height: "var(--appbar-h)" }} className="flex-shrink-0" />
     </>
   );
 };

--- a/src/components/SectionFrame.tsx
+++ b/src/components/SectionFrame.tsx
@@ -4,6 +4,7 @@ const SectionFrame = ({
   id,
   children,
   className,
+  alt: _alt,
 }: {
   id?: string;
   children: React.ReactNode;
@@ -11,8 +12,15 @@ const SectionFrame = ({
   alt?: boolean;
 }) => (
   <section id={id} className="snap-section px-4 py-4">
-    <div className={cn("px-7 py-5 md:px-10 md:py-7", className)}>
-      {children}
+    <div className="flex overflow-hidden border border-white/[0.06]">
+      <div
+        className="w-1 flex-shrink-0 bg-gradient-to-b from-gold via-gold/60 to-gold/20"
+        style={{ boxShadow: "0 0 16px rgba(212,175,55,0.30)" }}
+      />
+      <div className={cn("flex-1 min-w-0 bg-black", className)}>
+        <div className="h-[2px] bg-gradient-to-r from-transparent via-gold/25 to-transparent" />
+        <div className="px-7 py-5 md:px-10 md:py-7">{children}</div>
+      </div>
     </div>
   </section>
 );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { useHaptics } from "@/hooks/use-haptics";
 import {
@@ -12,8 +12,6 @@ import filmmakerLogo from "@/assets/filmmaker-f-icon.png";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import { cn } from "@/lib/utils";
 import SectionFrame from "@/components/SectionFrame";
-
-const CINEMATIC_SEEN_KEY = "filmmaker_og_intro_seen";
 
 /* ═══════════════════════════════════════════════════════════════════
    CLOSED DOORS — the reality of what's available
@@ -64,7 +62,6 @@ const useReveal = (threshold = 0.15) => {
    ═══════════════════════════════════════════════════════════════════ */
 const Index = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const haptics = useHaptics();
 
 
@@ -92,14 +89,9 @@ const Index = () => {
     }
   }, [hasSession, navigate]);
 
-  // Intro skip
-  const introTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-  const [showSkipHint, setShowSkipHint] = useState(false);
-
   // Reveals
   const revEvidence    = useReveal();
   const revMission     = useReveal();
-  const revWater       = useReveal();
   const revCost        = useReveal();
   const revDecl        = useReveal();
   const revFinal       = useReveal();
@@ -161,50 +153,7 @@ const Index = () => {
     return () => clearTimeout(delay);
   }, [barsRevealed]);
 
-  // Cinematic intro
-  const hasSeenCinematic = useMemo(() => {
-    try { return localStorage.getItem(CINEMATIC_SEEN_KEY) === "true"; } catch { return false; }
-  }, []);
-  const shouldSkip = searchParams.get("skipIntro") === "true" || hasSeenCinematic;
-  const [phase, setPhase] = useState<'dark'|'beam'|'logo'|'pulse'|'tagline'|'complete'>(shouldSkip ? 'complete' : 'dark');
-
-  useEffect(() => {
-    if (shouldSkip) return;
-    introTimersRef.current = [
-      setTimeout(() => setPhase('beam'), 300),
-      setTimeout(() => setPhase('logo'), 800),
-      setTimeout(() => setPhase('pulse'), 1300),
-      setTimeout(() => setPhase('tagline'), 1800),
-      setTimeout(() => setPhase('complete'), 2600),
-    ];
-    return () => introTimersRef.current.forEach(clearTimeout);
-  }, [shouldSkip]);
-
-  // Show "tap to skip" hint after 1s
-  useEffect(() => {
-    if (shouldSkip || phase === 'complete') return;
-    const t = setTimeout(() => setShowSkipHint(true), 1000);
-    return () => clearTimeout(t);
-  }, [shouldSkip, phase]);
-
-  const handleSkipIntro = useCallback(() => {
-    introTimersRef.current.forEach(clearTimeout);
-    setPhase('complete');
-  }, []);
-
-  useEffect(() => {
-    if (phase === 'complete' && !hasSeenCinematic) {
-      try { localStorage.setItem(CINEMATIC_SEEN_KEY, "true"); } catch {}
-    }
-  }, [phase, hasSeenCinematic]);
-
   const handleStartClick    = () => { haptics.medium(); gatedNavigate("/calculator?tab=budget"); };
-
-  const isComplete = phase === 'complete';
-  const showBeam = phase !== 'dark' && !shouldSkip;
-  const showLogo = (phase !== 'dark' && phase !== 'beam') || shouldSkip;
-  const isPulsed = ['pulse','tagline','complete'].includes(phase) || shouldSkip;
-  const showTagline = ['tagline','complete'].includes(phase) || shouldSkip;
 
   return (
     <>
@@ -222,54 +171,8 @@ const Index = () => {
 
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black">
 
-        {/* ═══════ CINEMATIC INTRO ═══════ */}
-        {!shouldSkip && (
-          <div
-            className={cn("fixed inset-0 z-[100] flex items-center justify-center transition-opacity duration-1000 cursor-pointer", isComplete ? "opacity-0 pointer-events-none" : "opacity-100")}
-            style={{ backgroundColor: '#000' }}
-            onClick={handleSkipIntro}
-            role="button"
-            aria-label="Skip intro"
-          >
-            <div className={cn("absolute inset-0 pointer-events-none transition-all duration-1000", showBeam ? "opacity-100" : "opacity-0")}
-              style={{ background: `radial-gradient(ellipse 70% 60% at 50% 0%, rgba(212,175,55,0.08) 0%, rgba(255,255,255,0.12) 20%, rgba(255,255,255,0.05) 40%, rgba(255,255,255,0.01) 60%, transparent 80%)`, clipPath: showBeam ? 'polygon(25% 0%,75% 0%,95% 100%,5% 100%)' : 'polygon(48% 0%,52% 0%,52% 30%,48% 30%)', transition: 'clip-path 1.2s cubic-bezier(0.22,1,0.36,1), opacity 0.8s ease' }} />
-            <div className={cn("absolute inset-0 pointer-events-none transition-all duration-1000", showBeam ? "opacity-100" : "opacity-0")}
-              style={{ background: `radial-gradient(ellipse 30% 45% at 50% 0%, rgba(255,255,255,0.35) 0%, rgba(255,255,255,0.15) 30%, rgba(212,175,55,0.05) 50%, transparent 70%)`, clipPath: showBeam ? 'polygon(38% 0%,62% 0%,78% 100%,22% 100%)' : 'polygon(48% 0%,52% 0%,52% 30%,48% 30%)', transition: 'clip-path 1s cubic-bezier(0.22,1,0.36,1) 0.1s, opacity 0.8s ease' }} />
-            <div className={cn("absolute left-1/2 top-1/2 w-[400px] h-[400px] pointer-events-none transition-all duration-700", showLogo ? "opacity-100" : "opacity-0")}
-              style={{ background: `radial-gradient(circle, rgba(212,175,55,0.12) 0%, rgba(255,255,255,0.08) 30%, transparent 70%)`, transform: 'translate(-50%,-50%)', filter: 'blur(40px)', animation: isPulsed ? 'focal-pulse 3s ease-in-out infinite' : 'none' }} />
-            <div className="relative z-10 flex flex-col items-center">
-              <div className={cn("relative transition-all duration-1000 ease-out", showLogo ? "opacity-100 scale-100 translate-y-0" : "opacity-0 scale-90 translate-y-6")}>
-                <div className={cn("absolute inset-0 -m-4 transition-opacity duration-700", isPulsed ? "opacity-100" : "opacity-0")}
-                  style={{ background: 'radial-gradient(circle, rgba(212,175,55,0.5) 0%, transparent 70%)', filter: 'blur(15px)' }} />
-                <img src={filmmakerLogo} alt="Filmmaker.OG" className="w-32 h-32 object-contain relative z-10"
-                  style={{ filter: 'brightness(1.25) saturate(1.1)', transition: 'filter 0.7s ease' }} />
-              </div>
-              <p className={cn("mt-8 text-sm tracking-[0.4em] uppercase font-semibold transition-all duration-700", showTagline ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3")}
-                style={{ color: '#D4AF37', textShadow: '0 0 20px rgba(212,175,55,0.4)' }}>Know Your Numbers</p>
-              <div className="mt-6 w-32 h-[2px] overflow-hidden bg-white/10">
-                <div className={cn("h-full bg-gold", showTagline ? "animate-progress-draw" : "")}
-                  style={{ boxShadow: '0 0 15px rgba(212,175,55,0.7)', width: showTagline ? undefined : '0%' }} />
-              </div>
-            </div>
-
-            {/* Tap to skip hint */}
-            <p
-              className={cn(
-                "absolute bottom-10 left-1/2 -translate-x-1/2",
-                "text-[11px] tracking-[0.3em] uppercase text-white/25",
-                "transition-all duration-500 select-none pointer-events-none",
-                showSkipHint && !isComplete
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-1"
-              )}
-            >
-              tap to skip
-            </p>
-          </div>
-        )}
-
         {/* ═══════ LANDING PAGE ═══════ */}
-        <main aria-label="Film Finance Simulator" className={cn("flex-1 flex flex-col transition-all duration-700", isComplete ? "opacity-100" : "opacity-0")} style={{ paddingBottom: "calc(var(--bottom-bar-h) + env(safe-area-inset-bottom))" }}>
+        <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "calc(var(--bottom-bar-h) + env(safe-area-inset-bottom))" }}>
 
           {/* ──────────────────────────────────────────────────────────
                § 1  HERO
@@ -326,7 +229,7 @@ const Index = () => {
                § 2  THE WATERFALL — immediately after hero
              ────────────────────────────────────────────────────────── */}
           <SectionFrame id="waterfall">
-            <div ref={revWater.ref} className={cn("transition-all duration-700 ease-out", revWater.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6")}>
+            <div>
 
               <h2 className="font-bebas text-[36px] md:text-[44px] text-gold tracking-[0.08em] text-center mb-1">THE <span className="text-white">WATERFALL</span></h2>
               <p className="text-[15px] text-white/50 tracking-[0.12em] uppercase text-center mb-2">Your recoupment structure</p>


### PR DESCRIPTION
…ntro

SectionFrame: restore gold left-bar with glow, top gold line, proper border/overflow structure (was gutted to a plain padding wrapper).

AppHeader: replace floating 300px pill with full-width solid bar. Add HeaderCtaContext/useHeaderCta exports for page-injected CTA slots. Use var(--bg-header) background, gold/45 separator line, gold/65 kebab.

App.tsx: wire HeaderCtaContext.Provider around AppShell children so any page can inject a CTA into the header center slot.

Index.tsx: remove cinematic intro (CINEMATIC_SEEN_KEY, all phase/timer state, skip logic, overlay JSX). Remove revWater scroll-reveal wrapper from waterfall section (bar animations via barsRevealed untouched). Clean dead imports (useMemo, useSearchParams). Remove conditional opacity class from main tag.

https://claude.ai/code/session_01K1fhHsdGtzciZeoxC4YKH8