### PR TITLE
feat: consolidate gold opacity tokens + enrich SEO meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,19 +11,20 @@
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-title" content="FILMMAKER.OG" />
     <title>FILMMAKER.OG — See Where Every Dollar Goes</title>
-    <meta name="description" content="Free film finance simulator. Model your budget, capital stack, and recoupment waterfall. Know who gets paid first and what's left for you." />
+    <meta name="description" content="Free film budget calculator and finance simulator. Model your production budget, capital stack, and recoupment waterfall. See who gets paid first, what equity investors earn, and what's left for you — before you sign." />
+    <meta name="keywords" content="film budget calculator, movie budget template, film finance simulator, recoupment waterfall, capital stack, indie film budget, production budget breakdown, film investor returns, movie production cost, filmmaker tools" />
     <meta name="author" content="Filmmaker.OG" />
 
     <meta property="og:title" content="FILMMAKER.OG — See Where Every Dollar Goes" />
-    <meta property="og:description" content="Before you sign a deal, see exactly who gets paid and what's left for you. Free film finance tool — no account required." />
-    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:description" content="Free film budget calculator and recoupment waterfall simulator. Model your capital stack, see investor returns, and know what's left for you — no account required." />
+    <meta property="og:image" content="/og-image.png" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Filmmaker.OG" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FILMMAKER.OG — See Where Every Dollar Goes" />
-    <meta name="twitter:description" content="Before you sign a deal, see exactly who gets paid and what's left for you. Free film finance tool — no account required." />
-    <meta name="twitter:image" content="/og-image.svg" />
+    <meta name="twitter:description" content="Free film budget calculator and recoupment waterfall simulator. Model your capital stack, see investor returns, and know what's left for you — no account required." />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
 
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,13 +1,12 @@
 {
   "name": "FILMMAKER.OG",
   "short_name": "FILMMAKER",
-  "description": "Film finance simulator. See where every dollar goes.",
+  "description": "Free film budget calculator and recoupment waterfall simulator. See where every dollar goes.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [
-    { "src": "/favicon.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/favicon.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/favicon.png", "sizes": "64x64", "type": "image/png" }
   ]
 }

--- a/src/index.css
+++ b/src/index.css
@@ -50,11 +50,14 @@
        Rule: If it's not clickable, it's NOT --gold-cta.
        ═══════════════════════════════════════════════════════════════════ */
 
-    /* Metallic Gold — non-interactive brand elements */
+    /* Metallic Gold — non-interactive brand elements (8 tiers, no drift) */
     --gold: #D4AF37;
+    --gold-label: rgba(212, 175, 55, 0.60);
     --gold-muted: rgba(212, 175, 55, 0.45);
-    --gold-subtle: rgba(212, 175, 55, 0.10);
     --gold-glow: rgba(212, 175, 55, 0.25);
+    --gold-ghost: rgba(212, 175, 55, 0.15);
+    --gold-subtle: rgba(212, 175, 55, 0.10);
+    --gold-ambient: rgba(212, 175, 55, 0.06);
 
     /* CTA Gold — buttons, links, interactive CTAs ONLY */
     --gold-cta: #F9E076;
@@ -244,7 +247,7 @@
   .chapter-card-gold-bar {
     width: 3px;
     height: 100%;
-    background: linear-gradient(180deg, var(--gold) 0%, rgba(212, 175, 55, 0.60) 60%, rgba(212, 175, 55, 0.20) 100%);
+    background: linear-gradient(180deg, var(--gold) 0%, var(--gold-label) 60%, var(--border-default) 100%);
     box-shadow: 0 0 16px rgba(212, 175, 55, 0.30);
   }
 
@@ -310,18 +313,18 @@
   }
 
   .store-card:hover {
-    border-color: rgba(212, 175, 55, 0.15);
+    border-color: var(--gold-ghost);
   }
 
   .store-card-featured {
-    background: linear-gradient(180deg, rgba(212, 175, 55, 0.06) 0%, var(--bg-card) 40%);
+    background: linear-gradient(180deg, var(--gold-ambient) 0%, var(--bg-card) 40%);
     border: 1.5px solid var(--gold-muted);
-    box-shadow: 0 0 40px rgba(212, 175, 55, 0.08), inset 0 1px 0 rgba(212, 175, 55, 0.1);
+    box-shadow: 0 0 40px rgba(212, 175, 55, 0.08), inset 0 1px 0 var(--gold-subtle);
   }
 
   .store-card-featured:hover {
     border-color: var(--gold);
-    box-shadow: 0 0 50px rgba(212, 175, 55, 0.12), inset 0 1px 0 rgba(212, 175, 55, 0.15);
+    box-shadow: 0 0 50px rgba(212, 175, 55, 0.12), inset 0 1px 0 var(--gold-ghost);
   }
 
   .store-compare-table {
@@ -343,7 +346,7 @@
   }
 
   .store-compare-table th.featured-col {
-    background: rgba(212, 175, 55, 0.06);
+    background: var(--gold-ambient);
     border-bottom: 1px solid rgba(212, 175, 55, 0.3);
   }
 
@@ -459,7 +462,7 @@
     font-size: 11px;
     font-weight: 600;
     color: rgba(212, 175, 55, 0.7);
-    background: rgba(212, 175, 55, 0.05);
+    background: var(--gold-ambient);
     cursor: pointer;
     transition: all var(--timing-fast) ease;
   }
@@ -773,7 +776,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(212, 175, 55, 0.06);
+    background: var(--gold-ambient);
     border: 1px solid rgba(212, 175, 55, 0.30);
     color: var(--gold);
     font-family: 'Bebas Neue', sans-serif;
@@ -784,8 +787,8 @@
     transition: all var(--timing-fast) ease;
   }
   .btn-cta-secondary:hover {
-    border-color: rgba(212, 175, 55, 0.50);
-    background: rgba(212, 175, 55, 0.10);
+    border-color: var(--border-active);
+    background: var(--gold-subtle);
   }
   .btn-cta-secondary:active {
     transform: scale(0.96);
@@ -864,7 +867,7 @@
      ═══════════════════════════════════════════════════════════════════ */
   button:focus-visible,
   a:focus-visible {
-    outline: 2px solid rgba(212, 175, 55, 0.5);
+    outline: 2px solid var(--border-active);
     outline-offset: 2px;
   }
 

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -24,11 +24,14 @@ export const colors = {
   borderSubtle: '#2A2A2A',                     // --border-subtle
   borderActive: 'rgba(212, 175, 55, 0.50)',    // --border-active
 
-  // Gold palette — Metallic (non-interactive brand elements)
+  // Gold palette — Metallic (non-interactive brand elements, 8 tiers)
   gold: '#D4AF37',                             // --gold (metallic)
+  goldLabel: 'rgba(212, 175, 55, 0.60)',       // --gold-label
   goldMuted: 'rgba(212, 175, 55, 0.45)',       // --gold-muted
-  goldSubtle: 'rgba(212, 175, 55, 0.10)',      // --gold-subtle
   goldGlow: 'rgba(212, 175, 55, 0.25)',        // --gold-glow
+  goldGhost: 'rgba(212, 175, 55, 0.15)',       // --gold-ghost
+  goldSubtle: 'rgba(212, 175, 55, 0.10)',      // --gold-subtle
+  goldAmbient: 'rgba(212, 175, 55, 0.06)',     // --gold-ambient
 
   // CTA Gold — EXCLUSIVELY for clickable elements
   goldCta: '#F9E076',                          // --gold-cta (bright, warm)
@@ -132,19 +135,19 @@ export const verdictStatus = {
   excellent: {
     label: 'EXCELLENT DEAL',
     color: colors.gold,
-    bgColor: 'rgba(212, 175, 55, 0.15)',
+    bgColor: colors.goldGhost,
     description: 'This return profile will attract institutional capital.',
   },
   good: {
     label: 'SOLID DEAL',
     color: colors.gold,
-    bgColor: 'rgba(212, 175, 55, 0.10)',
+    bgColor: colors.goldSubtle,
     description: 'Healthy returns for all parties involved.',
   },
   marginal: {
     label: 'MARGINAL',
     color: colors.goldMuted,
-    bgColor: 'rgba(212, 175, 55, 0.06)',
+    bgColor: colors.goldAmbient,
     description: 'Consider renegotiating terms for better returns.',
   },
   underwater: {


### PR DESCRIPTION
Design tokens:
- Add --gold-label (0.60), --gold-ghost (0.15), --gold-ambient (0.06) CSS custom properties
- Add matching goldLabel, goldGhost, goldAmbient constants to design-system.ts
- Replace 12 inline rgba(212,175,55,…) values in index.css with var() token references
- Replace 3 inline rgba values in design-system.ts verdict statuses with named constants

SEO / meta:
- Switch og:image and twitter:image from SVG to PNG (social platforms need raster)
- Enrich meta description with film-finance search terms (budget calculator, capital stack, investor returns)
- Add keywords meta tag targeting film budget / recoupment / indie finance queries
- Enrich og:description and twitter:description with same vocabulary
- Fix manifest.json icon size from 192x192 → 64x64 to match actual favicon
- Enrich manifest.json description

https://claude.ai/code/session_013bc8HGYQvEKLU3Ypc6gHUp