### PR TITLE
fix: revert SectionFrame to single-div, remove "The Ask" label

### DIFF
--- a/src/components/SectionFrame.tsx
+++ b/src/components/SectionFrame.tsx
@@ -16,32 +16,41 @@ const SectionFrame = ({
 
   return (
     <section id={id} className="snap-section px-4 py-10 md:py-14">
-      {/* Gradient border wrapper — 1px padding reveals the gradient as a border */}
       <div
-        className="max-w-md mx-auto rounded-2xl"
+        className={cn(
+          "px-7 py-8 md:px-10 md:py-10 max-w-md mx-auto rounded-2xl",
+          isGold && "px-8 py-10 md:px-11 md:py-12",
+          className,
+        )}
         style={{
-          padding: '1px',
-          background: isGold
-            ? 'linear-gradient(to bottom, rgba(212,175,55,0.30), rgba(212,175,55,0.10))'
-            : 'linear-gradient(to bottom, rgba(255,255,255,0.14), rgba(255,255,255,0.06))',
+          background: 'transparent',
+          borderTop: isGold
+            ? '1px solid rgba(212,175,55,0.30)'
+            : '1px solid rgba(255,255,255,0.14)',
+          borderLeft: isGold
+            ? '1px solid rgba(212,175,55,0.18)'
+            : '1px solid rgba(255,255,255,0.09)',
+          borderRight: isGold
+            ? '1px solid rgba(212,175,55,0.18)'
+            : '1px solid rgba(255,255,255,0.09)',
+          borderBottom: isGold
+            ? '1px solid rgba(212,175,55,0.10)'
+            : '1px solid rgba(255,255,255,0.06)',
           boxShadow: isGold
-            ? '0 2px 8px rgba(0,0,0,0.40), 0 8px 32px rgba(0,0,0,0.25), 0 0 20px rgba(212,175,55,0.06)'
-            : '0 2px 8px rgba(0,0,0,0.40), 0 8px 32px rgba(0,0,0,0.25)',
+            ? [
+                'inset 0 1px 0 rgba(255,255,255,0.06)',
+                '0 2px 8px rgba(0,0,0,0.40)',
+                '0 8px 32px rgba(0,0,0,0.25)',
+                '0 0 20px rgba(212,175,55,0.06)',
+              ].join(', ')
+            : [
+                'inset 0 1px 0 rgba(255,255,255,0.06)',
+                '0 2px 8px rgba(0,0,0,0.40)',
+                '0 8px 32px rgba(0,0,0,0.25)',
+              ].join(', '),
         }}
       >
-        <div
-          className={cn(
-            "px-7 py-8 md:px-10 md:py-10 rounded-[15px]",
-            isGold && "px-8 py-10 md:px-11 md:py-12",
-            className,
-          )}
-          style={{
-            background: 'rgb(18, 18, 18)',
-            boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
-          }}
-        >
-          {children}
-        </div>
+        {children}
       </div>
     </section>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -533,7 +533,6 @@ const Index = () => {
                   ].join(', '),
                 }}
               >
-                <p className="text-[14px] tracking-[0.20em] uppercase font-semibold text-ink-secondary mb-5">The Ask</p>
                 <h2 className="font-bebas text-[40px] leading-[1.1] tracking-[0.08em] text-gold mb-10">
                   YOUR INVESTOR WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-white">BACK</span>.
                 </h2>


### PR DESCRIPTION
SectionFrame: Drop wrapper technique that caused text clipping inside cards. Use per-side border colors (top brighter, bottom dimmer) on a single div with transparent background so cards sit on pure black instead of matte grey.

Final CTA: Remove "The Ask" micro-label.

https://claude.ai/code/session_018BiGkAQH6mxNr7s8TKPibz