### PR TITLE
feat: landing page Part 3 — surfaces, interactions, waterfall

### DIFF
--- a/src/components/SectionFrame.tsx
+++ b/src/components/SectionFrame.tsx
@@ -1,54 +1,37 @@
 import { cn } from "@/lib/utils";
 
+const tierStyles = {
+  standard: {
+    border: '1px solid rgba(255,255,255,0.08)',
+    background: 'rgba(255,255,255,0.025)',
+    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04)',
+  },
+  elevated: {
+    border: '1px solid rgba(212,175,55,0.20)',
+    background: 'rgba(255,255,255,0.04)',
+    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06), 0 0 40px rgba(212,175,55,0.04)',
+  },
+};
+
 const SectionFrame = ({
   id,
   children,
   className,
-  variant,
+  tier = 'standard',
 }: {
   id?: string;
   children: React.ReactNode;
   className?: string;
-  alt?: boolean;
-  variant?: "default" | "gold";
+  tier?: 'standard' | 'elevated';
 }) => {
-  const isGold = variant === "gold";
-
   return (
-    <section id={id} className="snap-section px-4 py-10 md:py-14">
+    <section id={id} className="px-6 py-16 md:py-20">
       <div
         className={cn(
-          "px-7 py-8 md:px-10 md:py-10 max-w-md mx-auto rounded-2xl",
-          isGold && "px-8 py-10 md:px-11 md:py-12",
+          "p-8 md:p-10 max-w-md mx-auto rounded-2xl",
           className,
         )}
-        style={{
-          background: 'transparent',
-          borderTop: isGold
-            ? '1px solid rgba(212,175,55,0.30)'
-            : '1px solid rgba(255,255,255,0.14)',
-          borderLeft: isGold
-            ? '1px solid rgba(212,175,55,0.18)'
-            : '1px solid rgba(255,255,255,0.09)',
-          borderRight: isGold
-            ? '1px solid rgba(212,175,55,0.18)'
-            : '1px solid rgba(255,255,255,0.09)',
-          borderBottom: isGold
-            ? '1px solid rgba(212,175,55,0.10)'
-            : '1px solid rgba(255,255,255,0.06)',
-          boxShadow: isGold
-            ? [
-                'inset 0 1px 0 rgba(255,255,255,0.06)',
-                '0 2px 8px rgba(0,0,0,0.40)',
-                '0 8px 32px rgba(0,0,0,0.25)',
-                '0 0 20px rgba(212,175,55,0.06)',
-              ].join(', ')
-            : [
-                'inset 0 1px 0 rgba(255,255,255,0.06)',
-                '0 2px 8px rgba(0,0,0,0.40)',
-                '0 8px 32px rgba(0,0,0,0.25)',
-              ].join(', '),
-        }}
+        style={tierStyles[tier]}
       >
         {children}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -695,7 +695,7 @@
     letter-spacing: 0.18em;
     text-transform: uppercase;
     border-radius: 10px;
-    transition: all 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+    transition: all 180ms cubic-bezier(0.22, 1, 0.36, 1);
     box-shadow:
       0 4px 20px rgba(212, 175, 55, 0.35),
       0 8px 40px rgba(212, 175, 55, 0.15),
@@ -704,29 +704,30 @@
     overflow: hidden;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.10);
   }
-  .btn-cta-primary::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 60%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.20), transparent);
-    transition: left 0.6s ease;
-  }
-  .btn-cta-primary:hover::before {
-    left: 120%;
-  }
-  .btn-cta-primary:hover {
-    background: linear-gradient(165deg, #FFF0C0 0%, #FFE8A0 25%, #D4AF37 80%, #C4A030 100%);
-    box-shadow:
-      0 6px 28px rgba(212, 175, 55, 0.45),
-      0 12px 48px rgba(212, 175, 55, 0.20),
-      inset 0 1px 0 rgba(255, 255, 255, 0.30);
-    transform: translateY(-1px);
+  @media (hover: hover) {
+    .btn-cta-primary::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -100%;
+      width: 60%;
+      height: 100%;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.20), transparent);
+      transition: left 0.6s ease;
+    }
+    .btn-cta-primary:hover::before {
+      left: 120%;
+    }
+    .btn-cta-primary:hover {
+      background: linear-gradient(165deg, #FFF0C0 0%, #FFE8A0 25%, #D4AF37 80%, #C4A030 100%);
+      box-shadow:
+        0 6px 28px rgba(212, 175, 55, 0.45),
+        0 12px 48px rgba(212, 175, 55, 0.20),
+        inset 0 1px 0 rgba(255, 255, 255, 0.30);
+    }
   }
   .btn-cta-primary:active {
-    transform: translateY(0) scale(0.98);
+    transform: translateY(1px) scale(0.98);
     box-shadow:
       0 2px 12px rgba(212, 175, 55, 0.30),
       inset 0 1px 0 rgba(255, 255, 255, 0.20);
@@ -749,7 +750,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     border-radius: 10px;
-    transition: all var(--timing-fast) ease;
+    transition: all 180ms cubic-bezier(0.22, 1, 0.36, 1);
   }
   .btn-cta-secondary:hover {
     border-color: var(--border-active);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -144,7 +144,7 @@ const Index = () => {
           {/* ──────────────────────────────────────────────────────────
                § 1  HERO
              ────────────────────────────────────────────────────────── */}
-          <section id="hero" className="snap-section relative min-h-0 pt-24 pb-16 flex flex-col justify-center">
+          <section id="hero" className="relative min-h-0 pt-24 pb-16 flex flex-col justify-center">
             {/* Ambient warmth — single atmospheric element */}
             <div
               className="absolute inset-0 pointer-events-none"
@@ -172,11 +172,16 @@ const Index = () => {
 
 
 
+          {/* Gold structural divider */}
+          <div className="flex justify-center py-8">
+            <div className="w-12 h-px" style={{ background: "rgba(212,175,55,0.30)" }} />
+          </div>
+
           {/* ──────────────────────────────────────────────────────────
                § 2  THE PROBLEM + THESIS — with "Until now." punchline
              ────────────────────────────────────────────────────────── */}
-          <section id="evidence" className="snap-section px-6 py-16 md:py-20">
-            <div className="max-w-md mx-auto">
+          <SectionFrame id="evidence" tier="standard">
+            <div>
 
               <div className="text-center mb-8">
                 <p className="text-[14px] tracking-[0.20em] uppercase font-semibold text-gold-label mb-4">The Problem</p>
@@ -234,14 +239,14 @@ const Index = () => {
               </div>
 
             </div>
-          </section>
+          </SectionFrame>
 
 
           {/* ──────────────────────────────────────────────────────────
                § 3  THE COST — escalates the pain before the pivot
              ────────────────────────────────────────────────────────── */}
-          <section id="cost" className="snap-section px-6 py-16 md:py-20">
-            <div className="max-w-md mx-auto">
+          <SectionFrame id="cost" tier="standard">
+            <div>
 
               <div className="text-center mb-8">
                 <p className="text-[14px] tracking-[0.20em] uppercase font-semibold text-gold-label mb-4">The Cost</p>
@@ -270,12 +275,19 @@ const Index = () => {
               </div>
 
             </div>
-          </section>
+          </SectionFrame>
 
           {/* ── INTERSTITIAL: Blum Quote — authority validates the pain ── */}
           <section className="py-16 md:py-20 px-6">
             <div className="max-w-md mx-auto">
-              <div className="relative bg-bg-card border border-bg-card-border overflow-hidden rounded-xl">
+              <div
+                className="relative overflow-hidden rounded-xl"
+                style={{
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(212,175,55,0.20)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06), 0 0 30px rgba(212,175,55,0.06)',
+                }}
+              >
                 {/* Gold left accent */}
                 <div className="absolute left-0 top-0 bottom-0 w-[3px]"
                   style={{ background: 'linear-gradient(to bottom, rgba(212,175,55,0.55), rgba(212,175,55,0.25), transparent)' }} />
@@ -305,7 +317,7 @@ const Index = () => {
           {/* ──────────────────────────────────────────────────────────
                § 4  THE SOLUTION — the product reveal
              ────────────────────────────────────────────────────────── */}
-          <SectionFrame id="waterfall" variant="gold">
+          <SectionFrame id="waterfall" tier="elevated">
             <div>
 
               <p className="text-[14px] tracking-[0.20em] uppercase font-semibold text-gold-label text-center mb-4">The Solution</p>
@@ -362,7 +374,7 @@ const Index = () => {
                 <div className="mt-4 border border-gold-border bg-black px-6 py-6 text-center rounded-lg"
                   style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}>
                   <p className="text-[13px] tracking-[0.2em] uppercase font-semibold text-gold mb-1">Net Profits</p>
-                  <span className="font-mono text-[26px] font-bold text-white">
+                  <span className="font-mono text-[32px] font-bold text-white">
                     ${countVal.toLocaleString()}
                   </span>
                 </div>
@@ -406,7 +418,7 @@ const Index = () => {
           {/* ──────────────────────────────────────────────────────────
                § 6  WHAT YOU GET — the solution ladder
              ────────────────────────────────────────────────────────── */}
-          <SectionFrame id="offer">
+          <SectionFrame id="offer" tier="elevated">
             <div>
               <div className="text-center mb-8">
                 <p className="text-[14px] tracking-[0.20em] uppercase font-semibold text-gold-label mb-4">The Offer</p>
@@ -466,16 +478,22 @@ const Index = () => {
 
 
 
+          {/* Gold structural divider */}
+          <div className="flex justify-center py-8">
+            <div className="w-12 h-px" style={{ background: "rgba(212,175,55,0.30)" }} />
+          </div>
+
           {/* ──────────────────────────────────────────────────────────
                § 7  FINAL CTA — The Moment of Truth
              ────────────────────────────────────────────────────────── */}
-          <section id="final-cta" className="snap-section py-16 md:py-20 px-6">
+          <section id="final-cta" className="py-16 md:py-20 px-6">
             <div className="max-w-md mx-auto">
               <div
-                className="relative bg-bg-elevated overflow-hidden rounded-xl text-center px-8 py-14 md:px-10 md:py-16"
+                className="rounded-2xl px-8 py-16 md:py-20 text-center"
                 style={{
-                  border: '1px solid rgba(212,175,55,0.25)',
-                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 20px rgba(0,0,0,0.50), 0 12px 48px rgba(0,0,0,0.30)',
+                  border: '1px solid rgba(212,175,55,0.30)',
+                  background: 'rgba(255,255,255,0.04)',
+                  boxShadow: '0 0 60px rgba(212,175,55,0.06), 0 0 120px rgba(212,175,55,0.03), inset 0 1px 0 rgba(255,255,255,0.06)',
                 }}
               >
                 <h2 className="font-bebas text-[40px] leading-[1.1] tracking-[0.08em] text-white mb-8">


### PR DESCRIPTION
MOVE 4: Surface hierarchy through layered darkness
- SectionFrame: replace variant prop with tier prop (standard/elevated) Standard: subtle white border + barely-there background Elevated: gold-tinted border + ambient glow
- Normalize SectionFrame padding to grid (px-6 py-16 md:py-20 outer, p-8 md:p-10 inner)
- Wrap §2 Problem and §3 Cost in SectionFrame tier="standard"
- §4 Waterfall and §6 Offer use tier="elevated"
- Blum quote card: upgrade to elevated surface with gold border and ambient glow, preserve left accent bar
- Final CTA card: premium surface — strongest gold border (0.30), triple-layer shadow (60px + 120px + inset), generous py-16 md:py-20
- Two gold structural dividers: Hero→Problem, Offer→Final CTA

MOVE 5: Mechanical micro-interactions
- Global transition: 180ms cubic-bezier(0.22, 1, 0.36, 1) on both btn-cta-primary and btn-cta-secondary
- Press state: translateY(1px) for physical push-down feel
- Hover shimmer wrapped in @media (hover: hover) — no pseudo-element on mobile
- Removed translateY(-1px) from hover — institutional buttons don't bounce

MOVE 7: Waterfall as terminal readout
- Net Profits number: text-[26px] → text-[32px] for terminal readout emphasis
- Bar tracks already at 0.12 from Part 1

Dead code cleanup:
- Removed snap-section class from hero and final CTA sections (non-functional without snap-container parent)

https://claude.ai/code/session_01DVF2oG8wCU56UaLdWWihaN