### PR TITLE
Rewrite section 3 as clean ledger with column headers

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useHaptics } from "@/hooks/use-haptics";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import { cn } from "@/lib/utils";
+import SectionFrame from "@/components/SectionFrame";
 /* ═══════════════════════════════════════════════════════════════════
    WATERFALL TIERS — proportional bars ($3M cascade)
    ═══════════════════════════════════════════════════════════════════ */
@@ -121,18 +122,18 @@ const Index = () => {
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
-  // Scroll-triggered reveals — earned entrances for mid-page sections
+  // Scroll-triggered reveal for Cost of Access + Evidence sections
   const costRef = useRef<HTMLDivElement>(null);
   const [costVisible, setCostVisible] = useState(false);
   const evidenceRef = useRef<HTMLDivElement>(null);
   const [evidenceVisible, setEvidenceVisible] = useState(false);
   useEffect(() => {
-    const reveals = [
+    const sections = [
       { el: costRef.current, setter: setCostVisible },
       { el: evidenceRef.current, setter: setEvidenceVisible },
     ];
     const observers: IntersectionObserver[] = [];
-    reveals.forEach(({ el, setter }) => {
+    sections.forEach(({ el, setter }) => {
       if (!el) return;
       const obs = new IntersectionObserver(
         ([entry]) => {
@@ -141,12 +142,12 @@ const Index = () => {
             obs.disconnect();
           }
         },
-        { threshold: 0.3 }
+        { threshold: 0.2 }
       );
       obs.observe(el);
       observers.push(obs);
     });
-    return () => observers.forEach(o => o.disconnect());
+    return () => observers.forEach(obs => obs.disconnect());
   }, []);
   return (
     <>
@@ -307,10 +308,8 @@ const Index = () => {
                   THE COST OF ACCESS
                 </h2>
               </div>
-
               <div className="border border-gold-border bg-black overflow-hidden rounded-xl"
                 style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}>
-
                 <div className="px-6 py-5 flex gap-4">
                   <span className="font-mono text-[18px] font-bold text-gold w-[88px] shrink-0 tabular-nums">$800/hr</span>
                   <div className="min-w-0">
@@ -318,7 +317,6 @@ const Index = () => {
                     <p className="text-[13px] text-ink-secondary mt-1">Retainer required</p>
                   </div>
                 </div>
-
                 <div className="px-6 py-5 flex gap-4 border-t border-bg-card-rule">
                   <span className="font-mono text-[18px] font-bold text-gold w-[88px] shrink-0 tabular-nums">$5,000+</span>
                   <div className="min-w-0">
@@ -326,7 +324,6 @@ const Index = () => {
                     <p className="text-[13px] text-ink-secondary mt-1">If available</p>
                   </div>
                 </div>
-
                 <div className="px-6 py-5 flex gap-4 border-t border-bg-card-rule">
                   <span className="font-mono text-[18px] font-bold text-gold w-[88px] shrink-0 tabular-nums">$200K</span>
                   <div className="min-w-0">
@@ -334,7 +331,6 @@ const Index = () => {
                     <p className="text-[13px] text-ink-secondary mt-1">3{"\u2013"}4 years</p>
                   </div>
                 </div>
-
                 <div className="px-6 py-5 flex gap-4 border-t border-bg-card-rule"
                   style={{ background: 'rgba(255,255,255,0.02)' }}>
                   <span className="font-mono text-[18px] font-bold text-gold-label w-[88px] shrink-0">{"\u2014"}</span>
@@ -343,9 +339,7 @@ const Index = () => {
                     <p className="text-[13px] text-ink-secondary mt-1">Non-recoverable</p>
                   </div>
                 </div>
-
               </div>
-
               <p className="text-center text-ink-secondary text-[15px] leading-relaxed mt-6 max-w-[300px] mx-auto">
                 You shouldn{"\u2019"}t need <span className="text-white font-medium">$200K</span> to understand your own deal.
               </p>
@@ -353,7 +347,7 @@ const Index = () => {
           </section>
           {/* ──────────────────────────────────────────────────────────
                § 3  MOST FILMS LOSE MONEY
-               One contained card: problem → evidence → punchline.
+               Asset class comparison. Same ledger language as §2.
              ────────────────────────────────────────────────────────── */}
           <section id="evidence" className="py-14 md:py-20 px-6">
             <div
@@ -365,77 +359,51 @@ const Index = () => {
                 transition: 'opacity 700ms ease-out, transform 700ms ease-out',
               }}
             >
-              <div className="text-center mb-8">
+              <div className="text-center mb-3">
                 <h2 className="font-bebas text-[40px] tracking-[0.08em] leading-[0.95] text-gold">
                   MOST FILMS LOSE <span className="text-white">MONEY.</span>
                 </h2>
               </div>
-
-              <div
-                className="rounded-2xl overflow-hidden"
-                style={{
-                  border: '1px solid rgba(212,175,55,0.15)',
-                  background: 'rgba(255,255,255,0.02)',
-                  boxShadow: '0 0 40px rgba(212,175,55,0.03), inset 0 1px 0 rgba(255,255,255,0.05)',
-                }}
-              >
-                {/* Problem statement */}
-                <div className="px-7 pt-7 pb-6 text-center">
-                  <p className="font-bebas text-[24px] tracking-[0.04em] leading-tight text-white mb-3">
-                    Your film can make money{"\u00A0"}<span className="text-gold">&</span>{"\u00A0"}you still lose.
-                  </p>
-                  <p className="text-[15px] text-ink-secondary leading-relaxed max-w-[300px] mx-auto">
-                    Not because it didn{"\u2019"}t recoup.{" "}
-                    <span className="text-ink-body font-medium">Because of how the deal was structured.</span>
-                  </p>
+              <p className="text-center text-ink-secondary text-[15px] leading-relaxed mb-8 max-w-[320px] mx-auto">
+                Not because they don{"\u2019"}t recoup.{" "}
+                <span className="text-ink-body font-medium">Because of how the deal was structured.</span>
+              </p>
+              {/* Comparison ledger — same container as Cost of Access */}
+              <div className="border border-gold-border bg-black overflow-hidden rounded-xl"
+                style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}>
+                {/* Column header */}
+                <div className="px-6 py-3 flex items-baseline justify-between">
+                  <span className="font-mono text-[11px] tracking-[0.15em] uppercase text-ink-secondary">Asset Class</span>
+                  <span className="font-mono text-[11px] tracking-[0.15em] uppercase text-ink-secondary">Infrastructure</span>
                 </div>
-
-                {/* Gold divider */}
-                <div className="mx-7 h-[1px]" style={{ background: 'linear-gradient(90deg, transparent, rgba(212,175,55,0.30), transparent)' }} />
-
-                {/* Asset class comparison */}
-                <div className="px-7 pt-5 pb-3">
-                  <p className="font-mono text-[11px] tracking-[0.15em] uppercase text-ink-secondary mb-4">
-                    Every other asset class has infrastructure
-                  </p>
-
-                  {[
-                    { asset: "Real Estate", tools: "Comps \u00B7 Cap rates \u00B7 Appraisals" },
-                    { asset: "Private Equity", tools: "Carry structures \u00B7 IRR models" },
-                    { asset: "Venture Capital", tools: "Term sheets \u00B7 Valuations" },
-                  ].map((row) => (
-                    <div key={row.asset} className="flex items-baseline justify-between py-3 border-t border-bg-card-rule">
-                      <span className="text-[14px] font-semibold text-ink-body">{row.asset}</span>
-                      <span className="text-[12px] text-ink-secondary text-right ml-4">{row.tools}</span>
-                    </div>
-                  ))}
+                {/* Row 1 */}
+                <div className="px-6 py-4 flex items-baseline justify-between border-t border-bg-card-rule">
+                  <span className="font-bebas text-[18px] tracking-[0.06em] text-white leading-tight">Real Estate</span>
+                  <span className="text-[13px] text-ink-secondary text-right ml-4">Comps {"\u00B7"} Cap rates {"\u00B7"} Appraisals</span>
                 </div>
-
-                {/* Film row — the void, promoted */}
-                <div
-                  className="mx-5 mb-5 rounded-lg px-5 py-3.5 flex items-baseline justify-between"
-                  style={{
-                    background: 'rgba(212,175,55,0.05)',
-                    border: '1px solid rgba(212,175,55,0.15)',
-                  }}
-                >
-                  <span className="text-[15px] font-bold text-white">Film</span>
-                  <span className="font-mono text-[14px] text-gold">{"\u2014"}</span>
+                {/* Row 2 */}
+                <div className="px-6 py-4 flex items-baseline justify-between border-t border-bg-card-rule">
+                  <span className="font-bebas text-[18px] tracking-[0.06em] text-white leading-tight">Private Equity</span>
+                  <span className="text-[13px] text-ink-secondary text-right ml-4">Carry structures {"\u00B7"} IRR models</span>
                 </div>
-
-                {/* Punchline */}
-                <div
-                  className="px-7 py-6 text-center"
-                  style={{
-                    borderTop: '1px solid rgba(255,255,255,0.06)',
-                    background: 'rgba(255,255,255,0.02)',
-                  }}
-                >
-                  <p className="font-bebas text-[22px] tracking-[0.06em] text-gold leading-tight">
-                    Nobody teaches the business of film.
-                  </p>
+                {/* Row 3 */}
+                <div className="px-6 py-4 flex items-baseline justify-between border-t border-bg-card-rule">
+                  <span className="font-bebas text-[18px] tracking-[0.06em] text-white leading-tight">Venture Capital</span>
+                  <span className="text-[13px] text-ink-secondary text-right ml-4">Term sheets {"\u00B7"} Valuations</span>
+                </div>
+                {/* Row 4 — Film: the void */}
+                <div className="px-6 py-4 flex items-baseline justify-between border-t border-bg-card-rule"
+                  style={{ background: 'rgba(255,255,255,0.02)' }}>
+                  <span className="font-bebas text-[18px] tracking-[0.06em] text-white leading-tight">Film</span>
+                  <span className="font-mono text-[13px] text-gold-label">{"\u2014"}</span>
                 </div>
               </div>
+              {/* Punchline — outside the card, standalone */}
+              <p className="text-center mt-6">
+                <span className="font-bebas text-[24px] tracking-[0.06em] text-gold leading-tight">
+                  Nobody teaches the business of film.
+                </span>
+              </p>
             </div>
           </section>
           {/* ── INTERSTITIAL: Until Now — the pivot ── */}


### PR DESCRIPTION
Section 3 now uses the same visual language as section 2: bordered rounded-xl card, consistent px-6 py-4 rows, Bebas font for asset names, and mono column headers (Asset Class / Infrastructure). Problem statement moved above the card as body text. Punchline below the card as standalone text. Film void row uses same highlighted-row treatment as section 2's Trial & Error row.

https://claude.ai/code/session_01Mo5EZu8NYBv7yNBGKhKQkc