### PR TITLE
fix: add Vercel SPA rewrites for client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
Magic link redirects were hitting 404s because Vercel didn't know to serve index.html for all routes. This catch-all rewrite fixes it.

https://claude.ai/code/session_019MBwLhm442aNELWhVW8eQo