### PR TITLE
Increase visibility of X-mark tiles in value section

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -385,8 +385,8 @@ const Index = () => {
                         key={item.title}
                         className="flex items-start gap-4 rounded-lg px-4 py-4"
                         style={{
-                          background: 'rgba(255,255,255,0.02)',
-                          border: '1px solid rgba(255,255,255,0.05)',
+                          background: 'rgba(255,255,255,0.03)',
+                          border: '1px solid rgba(255,255,255,0.08)',
                           opacity: valueVisible ? 1 : 0,
                           transform: valueVisible ? 'translateY(0)' : 'translateY(12px)',
                           transition: 'opacity 500ms ease-out, transform 500ms ease-out',
@@ -396,15 +396,15 @@ const Index = () => {
                         <div
                           className="flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center mt-0.5"
                           style={{
-                            background: 'rgba(255,255,255,0.06)',
-                            border: '1px solid rgba(255,255,255,0.08)',
+                            background: 'rgba(255,255,255,0.10)',
+                            border: '1px solid rgba(255,255,255,0.12)',
                           }}
                         >
-                          <span className="text-ink-secondary text-[14px] leading-none">{"\u2717"}</span>
+                          <span className="text-[14px] font-bold leading-none" style={{ color: 'rgba(255,255,255,0.45)' }}>{"\u2717"}</span>
                         </div>
                         <div>
-                          <p className="text-[15px] font-semibold text-ink-secondary leading-snug">{item.title}</p>
-                          <p className="text-[13px] text-ink-ghost leading-snug mt-1">{item.desc}</p>
+                          <p className="text-[15px] font-semibold leading-snug" style={{ color: 'rgba(255,255,255,0.55)' }}>{item.title}</p>
+                          <p className="text-[13px] leading-snug mt-1" style={{ color: 'rgba(255,255,255,0.35)' }}>{item.desc}</p>
                         </div>
                       </div>
                     ))}


### PR DESCRIPTION
Bump opacity on X badge background, icon, title, and description text so the "Without it" items are clearly readable while still visually subordinate to the gold check tiles.

https://claude.ai/code/session_0187y5kGLY12RSrb4vqv3uuE