### PR TITLE
Redesign Store, StoreCompare, and StorePackage pages

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,13 +1,15 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { Check, Mail, Instagram, Share2, Link2, X } from "lucide-react";
+import { Check, Mail, X as XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useHaptics } from "@/hooks/use-haptics";
 import {
   mainProducts,
   addOnProduct,
+  comparisonSections,
   type Product,
+  type FeatureValue,
 } from "@/lib/store-products";
 import {
   Accordion,
@@ -17,7 +19,8 @@ import {
 } from "@/components/ui/accordion";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
+
+
 
 /* ═══════════════════════════════════════════════════════════════════
    FAQ DATA
@@ -29,15 +32,15 @@ const storeFaqs = [
   },
   {
     q: "What's the difference between the three packages?",
-    a: "The Blueprint gives you the complete finance plan documentation. The Pitch Package adds investor-facing materials \u2014 a pitch deck, investor return profiles, executive summary, and deal terms summary. The Market Case adds comparable acquisition research, a defensible valuation range, and a market positioning memo.",
+    a: "The Blueprint gives you the complete finance plan documentation. The Pitch Package adds investor-facing materials — a pitch deck, investor return profiles, executive summary, and deal terms summary. The Market Case adds comparable acquisition research, a defensible valuation range, and a market positioning memo.",
   },
   {
     q: "What is The Working Model?",
-    a: "A live, formula-driven Excel workbook. Change any input and every downstream calculation updates instantly. It's the engine behind your finance plan \u2014 reusable across unlimited future projects. Add it at checkout for $79 when bundled with any package.",
+    a: "A live, formula-driven Excel workbook. Change any input and every downstream calculation updates instantly. It's the engine behind your finance plan — reusable across unlimited future projects. Add it at checkout for $79 when bundled with any package.",
   },
   {
     q: "What if the deliverables don't meet my expectations?",
-    a: "If your deliverables don't meet the institutional standard described, we'll revise them. These are the same financial models used in real production financing \u2014 if something doesn't hold up, we fix it.",
+    a: "If your deliverables don't meet the institutional standard described, we'll revise them. These are the same financial models used in real production financing — if something doesn't hold up, we fix it.",
   },
   {
     q: "Can I upgrade later?",
@@ -45,40 +48,34 @@ const storeFaqs = [
   },
 ];
 
-/* ═══════════════════════════════════════════════════════════════════
-   TRUST ANCHOR DATA
-   ═══════════════════════════════════════════════════════════════════ */
-const trustRows = [
-  { label: "Entertainment Lawyer", cost: "$5,000\u2013$15,000", isBrand: false },
-  { label: "Finance Consultant", cost: "$10,000\u2013$30,000", isBrand: false },
-  { label: "filmmaker.og", cost: "$349\u2013$1,997", isBrand: true },
-];
+
+
+
 
 /* ═══════════════════════════════════════════════════════════════════
-   SECTION REVEAL
+   SCROLL REVEAL HOOK
    ═══════════════════════════════════════════════════════════════════ */
 const useReveal = (threshold = 0.2) => {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
-
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    const observer = new IntersectionObserver(
+    const obs = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
           setVisible(true);
-          observer.disconnect();
+          obs.disconnect();
         }
       },
       { threshold }
     );
-    observer.observe(el);
-    return () => observer.disconnect();
+    obs.observe(el);
+    return () => obs.disconnect();
   }, [threshold]);
-
   return { ref, visible };
 };
+
 
 /* ═══════════════════════════════════════════════════════════════════
    WORKING MODEL POPUP
@@ -100,37 +97,35 @@ const WorkingModelPopup = ({
       onClick={loading ? undefined : onClose}
     />
     <div
-      className="relative w-full max-w-md rounded-xl p-6 space-y-5 animate-fade-in"
+      className="relative w-full max-w-md p-6 space-y-5 rounded-xl"
       style={{
-        border: "1px solid rgba(212,175,55,0.3)",
-        background: "linear-gradient(145deg, rgba(20,20,20,0.98), rgba(10,10,10,0.98))",
-        boxShadow: "0 0 40px rgba(212,175,55,0.08)",
+        border: '1px solid rgba(212,175,55,0.25)',
+        background: '#000',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06), 0 0 60px rgba(212,175,55,0.06)',
       }}
     >
       <button
         onClick={onClose}
         disabled={loading}
-        className="absolute top-4 right-4 text-ink-secondary hover:text-ink-body transition-colors"
+        className="absolute top-4 right-4 text-ink-secondary hover:text-white transition-colors"
       >
-        <X className="w-5 h-5" />
+        <XIcon className="w-5 h-5" />
       </button>
 
       <div>
-        <h3 className="font-bebas text-2xl tracking-[0.06em] text-gold mb-1">
+        <h3 className="font-bebas text-[28px] tracking-[0.06em] text-gold mb-1">
           ADD THE LIVE EXCEL MODEL
         </h3>
-        <p className="text-ink-body text-[14px]">Save $70 when you bundle now</p>
+        <p className="text-ink-secondary text-[14px]">Save $70 when you bundle now</p>
       </div>
 
-      <div className="flex items-baseline gap-2">
-        <span className="font-mono text-lg text-ink-secondary line-through">
-          $149
-        </span>
-        <span className="font-mono text-3xl font-medium text-white">$79</span>
+      <div className="flex items-baseline gap-3">
+        <span className="font-mono text-[16px] text-ink-secondary line-through">$149</span>
+        <span className="font-mono text-[26px] font-bold text-white">$79</span>
       </div>
 
-      <p className="text-ink-secondary text-[14px] leading-relaxed">
-        Get the formula-driven Excel engine behind your finance plan. Change any
+      <p className="text-ink-secondary text-[16px] leading-relaxed">
+        The formula-driven Excel engine behind your finance plan. Change any
         input — watch every investor's return recalculate instantly. Reuse on
         every project.
       </p>
@@ -139,7 +134,7 @@ const WorkingModelPopup = ({
         <button
           onClick={onAccept}
           disabled={loading}
-          className="w-full h-14 text-base btn-cta-primary"
+          className="w-full h-14 btn-cta-primary"
         >
           {loading ? "CONNECTING..." : "YES, ADD FOR $79"}
         </button>
@@ -154,6 +149,7 @@ const WorkingModelPopup = ({
     </div>
   </div>
 );
+
 
 /* ═══════════════════════════════════════════════════════════════════
    PRODUCT CARD
@@ -174,69 +170,63 @@ const ProductCard = ({
 
   return (
     <div
-      className={cn(
-        "flex flex-col p-6 rounded-xl transition-all duration-400 ease-out",
-        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
-      )}
+      className="flex flex-col p-6 rounded-xl"
       style={{
-        transitionDelay: visible ? `${index * 120}ms` : "0ms",
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(20px)',
+        transition: 'opacity 700ms ease-out, transform 700ms ease-out',
+        transitionDelay: `${index * 120}ms`,
         border: isFeatured
-          ? "2px solid var(--gold)"
+          ? '2px solid rgba(212,175,55,0.50)'
           : isPremium
-          ? "1px solid rgba(212,175,55,0.5)"
-          : "1px solid var(--gold-border)",
+          ? '1px solid rgba(212,175,55,0.30)'
+          : '1px solid rgba(212,175,55,0.25)',
         background: isFeatured
-          ? "linear-gradient(145deg, rgba(212,175,55,0.06), rgba(10,10,10,0.98))"
-          : isPremium
-          ? "linear-gradient(145deg, rgba(212,175,55,0.04), rgba(10,10,10,0.98))"
-          : "rgba(15,15,15,0.6)",
+          ? 'rgba(212,175,55,0.04)'
+          : '#000',
         boxShadow: isFeatured
-          ? "0 0 48px rgba(212,175,55,0.14)"
-          : isPremium
-          ? "0 0 32px rgba(212,175,55,0.08)"
-          : "none",
+          ? '0 0 48px rgba(212,175,55,0.12), inset 0 1px 0 rgba(255,255,255,0.06)'
+          : 'inset 0 1px 0 rgba(255,255,255,0.06)',
       }}
     >
       {/* Badge */}
-      {isFeatured && (
+      {product.badge && (
         <div className="mb-4">
-          <span className="inline-block px-3 py-1.5 bg-gold/20 border border-gold/40 text-gold text-[12px] tracking-[0.15em] uppercase font-bold rounded-full">
-            RECOMMENDED
-          </span>
-        </div>
-      )}
-      {product.badge && !isFeatured && (
-        <div className="mb-4">
-          <span className="inline-block px-3 py-1.5 bg-white/[0.04] border border-gold-border text-ink-secondary text-[12px] tracking-[0.15em] uppercase font-bold rounded-full">
+          <span className={cn(
+            "inline-block px-3 py-1.5 text-[12px] tracking-[0.15em] uppercase font-bold rounded",
+            isFeatured
+              ? "bg-gold/20 border border-gold/40 text-gold"
+              : isPremium
+              ? "bg-gold/10 border border-gold/25 text-gold"
+              : "border border-gold-border text-ink-secondary"
+          )}>
             {product.badge}
           </span>
         </div>
       )}
 
       {/* Name */}
-      <h3 className="font-bebas text-2xl tracking-[0.06em] text-white mb-2">
+      <h3 className="font-bebas text-[28px] tracking-[0.06em] text-white mb-2">
         {product.name.toUpperCase()}
       </h3>
 
       {/* Price */}
       <div className="mb-3">
         {product.originalPrice && (
-          <span className="font-mono text-lg text-ink-secondary line-through mr-2">
-            ${product.originalPrice.toLocaleString()}
+          <span className="font-mono text-[16px] text-ink-secondary line-through mr-2">
+            ${product.originalPrice}
           </span>
         )}
-        <span
-          className={cn(
-            "font-mono font-medium text-white",
-            isFeatured ? "text-5xl" : "text-3xl"
-          )}
-        >
+        <span className={cn(
+          "font-mono font-bold text-white",
+          isFeatured ? "text-[40px]" : isPremium ? "text-[40px]" : "text-[26px]"
+        )}>
           ${product.price.toLocaleString()}
         </span>
       </div>
 
       {/* Short description */}
-      <p className="text-ink-secondary text-[14px] leading-relaxed mb-5">
+      <p className="text-ink-secondary text-[16px] leading-relaxed mb-5">
         {product.shortDescription}
       </p>
 
@@ -256,18 +246,16 @@ const ProductCard = ({
       <button
         onClick={onBuy}
         className={cn(
-          "w-full h-14",
+          "w-full h-14 uppercase tracking-[0.06em]",
           isFeatured
-            ? "text-base btn-cta-primary animate-cta-glow-pulse"
-            : isPremium
-            ? "text-[14px] btn-cta-primary"
-            : "text-[14px] btn-cta-secondary"
+            ? "btn-cta-primary animate-cta-glow-pulse"
+            : "btn-cta-secondary"
         )}
       >
-        {isFeatured
+        {isPremium
           ? "GET THE FULL PACKAGE"
-          : isPremium
-          ? "GET THE FULL PACKAGE"
+          : isFeatured
+          ? "GET THE PITCH PACKAGE"
           : "START WITH THE BLUEPRINT"}
       </button>
 
@@ -277,13 +265,33 @@ const ProductCard = ({
           e.stopPropagation();
           window.location.href = `/store/${product.slug}`;
         }}
-        className="text-ink-secondary text-[12px] tracking-wider hover:text-ink-body transition-colors text-center mt-3"
+        className="text-ink-secondary text-[12px] tracking-[0.08em] hover:text-ink-body transition-colors text-center mt-3"
       >
-        See full details →
+        See full details {"\u2192"}
       </button>
     </div>
   );
 };
+
+
+/* ═══════════════════════════════════════════════════════════════════
+   COMPARE CELL — for inline comparison table
+   ═══════════════════════════════════════════════════════════════════ */
+const CompareCell = ({ value, featured }: { value: FeatureValue; featured?: boolean }) => {
+  if (typeof value === "boolean") {
+    return value ? (
+      <Check className={cn("w-4 h-4 mx-auto", featured ? "text-gold" : "text-ink-body")} />
+    ) : (
+      <XIcon className="w-3.5 h-3.5 mx-auto text-ink-ghost" />
+    );
+  }
+  return (
+    <span className={cn("text-[12px] leading-snug", featured ? "text-white" : "text-ink-body")}>
+      {value}
+    </span>
+  );
+};
+
 
 /* ═══════════════════════════════════════════════════════════════════
    MAIN STORE COMPONENT
@@ -291,46 +299,19 @@ const ProductCard = ({
 const Store = () => {
   const navigate = useNavigate();
   const haptics = useHaptics();
-  const [linkCopied, setLinkCopied] = useState(false);
   const [showPopup, setShowPopup] = useState<Product | null>(null);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
 
-  // Mobile-sorted products: featured first, then by tier desc
-  const mobileProducts = [...mainProducts].sort(
-    (a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0) || b.tier - a.tier
-  );
+  // Mobile-sorted products: featured first, then premium, then base
+  const mobileProducts = [...mainProducts].sort((a, b) => {
+    if (a.featured) return -1;
+    if (b.featured) return 1;
+    return b.tier - a.tier;
+  });
 
   // Reveal refs
-  const revealTrust = useReveal();
   const revealProducts = useReveal();
   const revealFaq = useReveal();
-
-  /* ─── SHARE HELPERS ─── */
-  const handleCopyLink = useCallback(() => {
-    haptics.light();
-    navigator.clipboard
-      .writeText(`${SHARE_TEXT}\n\n${getShareUrl()}`)
-      .then(() => {
-        setLinkCopied(true);
-        setTimeout(() => setLinkCopied(false), 2000);
-      })
-      .catch(() => {});
-  }, [haptics]);
-
-  const handleShare = useCallback(async () => {
-    haptics.light();
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: SHARE_TITLE,
-          text: SHARE_TEXT,
-          url: getShareUrl(),
-        });
-        return;
-      } catch {}
-    }
-    handleCopyLink();
-  }, [handleCopyLink, haptics]);
 
   /* ─── CHECKOUT — DIRECT TO STRIPE ─── */
   const startCheckout = async (productId: string, addonId?: string) => {
@@ -392,82 +373,18 @@ const Store = () => {
         </div>
       )}
 
-      <main className="flex-1 animate-fade-in">
-        {/* ═══════════════════════════════════════════════════════════
-            1. TRUST ANCHOR — ledger-style data cards
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="trust" className="px-6 py-12">
-          <div
-            ref={revealTrust.ref}
-            className={cn(
-              "max-w-lg mx-auto transition-all duration-500 ease-out",
-              revealTrust.visible
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-            )}
-          >
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-6 font-semibold">
-              What this costs everywhere else
-            </p>
+      <main className="flex-1" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-            <div className="rounded-xl border border-gold-border overflow-hidden">
-              {trustRows.map((item, i) => (
-                <div
-                  key={item.label}
-                  className={cn(
-                    "flex items-center justify-between px-5 py-3.5 transition-all duration-400 ease-out",
-                    revealTrust.visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
-                    i < trustRows.length - 1 && "border-b border-bg-card-rule",
-                    item.isBrand
-                      ? "bg-gold/[0.06]"
-                      : "bg-transparent"
-                  )}
-                  style={{
-                    transitionDelay: revealTrust.visible ? `${i * 120}ms` : "0ms",
-                  }}
-                >
-                  <span
-                    className={cn(
-                      "text-[14px] font-medium",
-                      item.isBrand ? "text-gold" : "text-ink-body"
-                    )}
-                  >
-                    {item.label}
-                  </span>
-                  <span
-                    className={cn(
-                      "font-mono text-base font-medium",
-                      item.isBrand
-                        ? "text-gold"
-                        : "text-ink-secondary line-through decoration-ink-secondary/30"
-                    )}
-                  >
-                    {item.cost}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            <p className="text-ink-secondary text-[14px] text-center mt-5 italic">
-              Same financial models. Fraction of the cost.
-            </p>
-          </div>
-        </section>
-
-        {/* ═══════════════════════════════════════════════════════════
-            2. PRODUCT CARDS — single column, max-w-md
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="products" className="px-6 py-12">
+        {/* ──────────────────────────────────────────────────────────
+             § 1  PRODUCT CARDS — first thing they see
+             Three tiers + add-on. No preamble.
+           ────────────────────────────────────────────────────────── */}
+        <section id="products" className="pt-14 pb-14 md:pb-20 px-6">
           <div
             ref={revealProducts.ref}
-            className={cn(
-              "max-w-md mx-auto transition-all duration-500 ease-out",
-              revealProducts.visible
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-            )}
+            className="max-w-md mx-auto"
           >
-            {/* Mobile: featured first, then by tier desc */}
+            {/* Mobile: featured first, then stack */}
             <div className="space-y-5">
               {mobileProducts.map((product, i) => (
                 <ProductCard
@@ -480,20 +397,28 @@ const Store = () => {
               ))}
             </div>
 
-            {/* ADD-ON: Working Model — slim horizontal upsell bar */}
+            {/* ADD-ON: Working Model — bundled upsell note */}
             {addOnProduct && (
-              <div className="mt-5 rounded-xl border border-gold/20 bg-gold/[0.03] px-5 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+              <div
+                className="mt-5 px-5 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-xl"
+                style={{
+                  border: '1px solid rgba(212,175,55,0.15)',
+                  background: 'rgba(212,175,55,0.03)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
+                }}
+              >
                 <div className="flex items-center gap-3 flex-1 min-w-0">
-                  <span className="px-2 py-0.5 text-[9px] tracking-[0.12em] uppercase font-bold text-gold border border-gold/30 flex-shrink-0 rounded">
+                  <span className="px-2 py-0.5 text-[12px] tracking-[0.12em] uppercase font-bold text-gold border border-gold-border rounded flex-shrink-0">
                     Add-on
                   </span>
-                  <span className="font-bebas text-lg tracking-[0.06em] text-white truncate">
+                  <span className="font-bebas text-[16px] tracking-[0.06em] text-white truncate">
                     {addOnProduct.name.toUpperCase()}
                   </span>
                 </div>
-                <span className="text-gold font-mono text-[14px] font-medium flex-shrink-0">
-                  Add for $79 at checkout
-                </span>
+                <div className="flex items-baseline gap-2 flex-shrink-0">
+                  <span className="font-mono text-[14px] text-gold font-medium">$79 at checkout</span>
+                  <span className="font-mono text-[12px] text-ink-secondary line-through">$149</span>
+                </div>
               </div>
             )}
 
@@ -501,38 +426,123 @@ const Store = () => {
             <div className="text-center mt-6">
               <button
                 onClick={() => { haptics.light(); navigate("/store/compare"); }}
-                className="text-ink-secondary text-[14px] hover:text-gold transition-colors tracking-wider"
+                className="text-ink-secondary text-[14px] hover:text-gold transition-colors tracking-[0.04em]"
               >
-                Compare packages side by side →
+                Compare packages side by side {"\u2192"}
               </button>
             </div>
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            3. FAQ
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="faq" className="px-6 py-12">
+
+        {/* ──────────────────────────────────────────────────────────
+             § 2  INLINE COMPARISON TABLE
+             What's in each tier at a glance. No separate page needed.
+           ────────────────────────────────────────────────────────── */}
+        <section id="compare" className="py-14 md:py-20 px-4">
+          <div className="max-w-md mx-auto">
+            <div className="text-center mb-8">
+              <h2 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                WHAT{"\u2019"}S IN <span className="text-white">EACH TIER</span>
+              </h2>
+            </div>
+
+            <div
+              className="border border-gold-border bg-black overflow-hidden rounded-xl"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}
+            >
+              {/* Column headers */}
+              <div className="grid grid-cols-4 gap-0 px-3 py-4 border-b" style={{ borderColor: 'rgba(255,255,255,0.06)' }}>
+                <div />
+                {mainProducts.map((p) => (
+                  <div key={p.id} className="text-center">
+                    <p className={cn(
+                      "font-bebas text-[12px] tracking-[0.06em] leading-tight",
+                      p.featured ? "text-gold" : "text-white"
+                    )}>
+                      {p.name.split(" ").slice(-1)[0].toUpperCase()}
+                    </p>
+                    <p className={cn(
+                      "font-mono text-[12px] mt-0.5",
+                      p.featured ? "text-gold" : "text-ink-secondary"
+                    )}>
+                      ${p.price.toLocaleString()}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              {/* Sections + rows */}
+              {comparisonSections.map((section) => (
+                <div key={section.title}>
+                  <div className="px-3 pt-5 pb-2">
+                    <span className="font-mono text-[12px] tracking-[0.15em] uppercase text-gold font-bold">
+                      {section.title}
+                    </span>
+                  </div>
+
+                  {section.features.map((feat) => (
+                    <div
+                      key={feat.label}
+                      className="grid grid-cols-4 gap-0 px-3 py-3 items-center"
+                      style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+                    >
+                      <span className="text-[12px] text-ink-secondary leading-snug pr-2">
+                        {feat.label}
+                      </span>
+                      <div className="text-center">
+                        <CompareCell value={feat.theBlueprint} />
+                      </div>
+                      <div className="text-center">
+                        <CompareCell value={feat.thePitchPackage} featured />
+                      </div>
+                      <div className="text-center">
+                        <CompareCell value={feat.theMarketCase} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+
+        {/* ──────────────────────────────────────────────────────────
+             § 3  FAQ — clean accordion, no wrappers
+           ────────────────────────────────────────────────────────── */}
+        <section id="faq" className="py-14 md:py-20 px-6">
           <div
             ref={revealFaq.ref}
-            className={cn(
-              "max-w-2xl mx-auto transition-all duration-500 ease-out",
-              revealFaq.visible
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-            )}
+            className="max-w-md mx-auto"
+            style={{
+              opacity: revealFaq.visible ? 1 : 0,
+              transform: revealFaq.visible ? 'translateY(0)' : 'translateY(20px)',
+              transition: 'opacity 700ms ease-out, transform 700ms ease-out',
+            }}
           >
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-6 font-semibold">
-              Common Questions
-            </p>
-            <div className="rounded-xl border border-gold-border bg-transparent px-5">
+            <div className="text-center mb-8">
+              <h2 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                COMMON <span className="text-white">QUESTIONS</span>
+              </h2>
+            </div>
+
+            <div
+              className="border border-gold-border bg-black overflow-hidden rounded-xl px-6"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}
+            >
               <Accordion type="single" collapsible className="w-full">
                 {storeFaqs.map((faq, i) => (
-                  <AccordionItem key={faq.q} value={`faq-${i}`}>
-                    <AccordionTrigger className="font-bebas text-xl tracking-[0.06em] uppercase text-gold hover:text-gold/70 hover:no-underline text-left">
+                  <AccordionItem
+                    key={faq.q}
+                    value={`faq-${i}`}
+                    className={cn(i > 0 && "border-t border-bg-card-rule")}
+                    style={{ borderBottom: 'none' }}
+                  >
+                    <AccordionTrigger className="font-bebas text-[16px] tracking-[0.06em] uppercase text-gold hover:text-gold/70 hover:no-underline text-left py-5">
                       {faq.q}
                     </AccordionTrigger>
-                    <AccordionContent className="text-ink-secondary text-[14px] leading-relaxed normal-case font-sans">
+                    <AccordionContent className="text-ink-secondary text-[16px] leading-relaxed normal-case font-sans pb-5">
                       {faq.a}
                     </AccordionContent>
                   </AccordionItem>
@@ -541,11 +551,18 @@ const Store = () => {
             </div>
 
             {/* Custom work prompt */}
-            <div className="mt-5 rounded-xl border border-gold-border bg-transparent p-5">
-              <h3 className="font-bebas text-lg tracking-[0.08em] text-gold mb-2">
+            <div
+              className="mt-5 p-6 rounded-xl"
+              style={{
+                border: '1px solid rgba(212,175,55,0.15)',
+                background: 'rgba(255,255,255,0.02)',
+                boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
+              }}
+            >
+              <h3 className="font-bebas text-[16px] tracking-[0.08em] text-gold mb-2">
                 NEED SOMETHING CUSTOM?
               </h3>
-              <p className="text-ink-body text-[14px] leading-relaxed mb-3">
+              <p className="text-ink-secondary text-[16px] leading-relaxed mb-3">
                 If your project requires bespoke financial modeling, custom comp
                 research, or institutional-grade investor materials beyond what
                 these packages cover — get in touch.
@@ -555,73 +572,22 @@ const Store = () => {
                 className="inline-flex items-center gap-2 text-gold text-[14px] font-semibold hover:text-gold/80 transition-colors"
               >
                 <Mail className="w-4 h-4" />
-                Contact Us →
+                Contact Us {"\u2192"}
               </a>
             </div>
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            4. FOOTER
-            ═══════════════════════════════════════════════════════════ */}
-        <footer className="py-10 px-6">
-          <div className="max-w-sm mx-auto">
-            <div className="grid grid-cols-2 gap-3 mb-8 max-w-[340px] mx-auto">
-              <a
-                href="mailto:thefilmmaker.og@gmail.com"
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                <Mail className="w-4 h-4" />
-                <span>Email</span>
-              </a>
-              <a
-                href="https://www.instagram.com/filmmaker.og"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                <Instagram className="w-4 h-4" />
-                <span>Instagram</span>
-              </a>
-              <button
-                onClick={handleShare}
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                <Share2 className="w-4 h-4" />
-                <span>Share</span>
-              </button>
-              <button
-                onClick={handleCopyLink}
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                {linkCopied ? (
-                  <>
-                    <Check className="w-4 h-4 text-gold" />
-                    <span className="text-gold">Copied!</span>
-                  </>
-                ) : (
-                  <>
-                    <Link2 className="w-4 h-4" />
-                    <span>Copy Link</span>
-                  </>
-                )}
-              </button>
-            </div>
 
-            <div className="flex items-center justify-center mb-2">
-              <span className="font-bebas text-3xl tracking-[0.2em] text-gold">
-                FILMMAKER<span className="text-white">.OG</span>
-              </span>
-            </div>
-            <p className="text-ink-secondary/60 text-[12px] tracking-wide text-center mb-4">
-              Democratizing the business of film.
-            </p>
-            <p className="text-ink-secondary/60 text-[12px] tracking-wide leading-relaxed text-center">
-              For educational and informational purposes only. Not legal, tax, or
-              investment advice. Consult a qualified entertainment attorney before
-              making financing decisions.
-            </p>
-          </div>
+        {/* ──────────────────────────────────────────────────────────
+             FOOTER — legal only
+           ────────────────────────────────────────────────────────── */}
+        <footer className="py-8 px-6 max-w-md mx-auto">
+          <p className="text-ink-ghost text-[12px] tracking-wide leading-relaxed text-center">
+            For educational and informational purposes only. Not legal, tax, or
+            investment advice. Consult a qualified entertainment attorney before
+            making financing decisions.
+          </p>
         </footer>
       </main>
     </div>

--- a/src/pages/StoreCompare.tsx
+++ b/src/pages/StoreCompare.tsx
@@ -8,6 +8,7 @@ import {
   type FeatureValue,
 } from "@/lib/store-products";
 
+
 /* ═══════════════════════════════════════════════════════════════════
    FEATURE VALUE CELL
    ═══════════════════════════════════════════════════════════════════ */
@@ -22,7 +23,7 @@ const FeatureCell = ({
     return value ? (
       <Check className={cn("w-4 h-4 mx-auto", featured ? "text-gold" : "text-ink-body")} />
     ) : (
-      <XIcon className="w-3.5 h-3.5 mx-auto text-ink-secondary/30" />
+      <XIcon className="w-3.5 h-3.5 mx-auto text-ink-ghost" />
     );
   }
   return (
@@ -32,8 +33,9 @@ const FeatureCell = ({
   );
 };
 
+
 /* ═══════════════════════════════════════════════════════════════════
-   STORE COMPARE PAGE
+   STORE COMPARE PAGE — three-column comparison
    ═══════════════════════════════════════════════════════════════════ */
 const StoreCompare = () => {
   const navigate = useNavigate();
@@ -43,9 +45,9 @@ const StoreCompare = () => {
 
   return (
     <div className="min-h-screen bg-black flex flex-col grain-overlay">
-      <main className="flex-1 animate-fade-in">
+      <main className="flex-1" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
         {/* BACK NAV */}
-        <div className="px-6 pt-6 max-w-3xl mx-auto">
+        <div className="px-6 pt-6 max-w-md mx-auto">
           <button
             onClick={() => navigate("/store")}
             className="flex items-center gap-2 text-[14px] text-ink-secondary hover:text-ink-body transition-colors"
@@ -55,101 +57,102 @@ const StoreCompare = () => {
           </button>
         </div>
 
-        <section id="compare" className="px-6 py-12">
-          <div className="max-w-3xl mx-auto">
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-2 font-semibold">
-              Side by Side
-            </p>
-            <h2 className="font-bebas text-3xl tracking-[0.06em] text-gold text-center mb-8">
-              COMPARE <span className="text-white">PACKAGES</span>
-            </h2>
+        <section id="compare" className="py-14 md:py-20 px-4">
+          <div className="max-w-md mx-auto">
+            <div className="text-center mb-8">
+              <h1 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                COMPARE <span className="text-white">PACKAGES</span>
+              </h1>
+            </div>
 
-            {/* Column headers */}
-            <div className="overflow-x-auto">
-              <table className="store-compare-table w-full">
-                <thead>
-                  <tr>
-                    <th className="text-left" />
-                    <th>
-                      <div className="flex flex-col items-center gap-1">
-                        <span>{blueprint?.name}</span>
-                        <span className="font-mono text-ink-body text-[14px] font-medium">
-                          ${blueprint?.price.toLocaleString()}
-                        </span>
+            {/* Comparison table */}
+            <div
+              className="border border-gold-border bg-black overflow-hidden rounded-xl"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}
+            >
+              {/* Column headers */}
+              <div className="grid grid-cols-4 gap-0 px-3 py-4 border-b border-bg-card-rule">
+                <div /> {/* empty label col */}
+                <div className="text-center">
+                  <p className="font-bebas text-[12px] tracking-[0.06em] text-white leading-tight">
+                    {blueprint?.name.toUpperCase()}
+                  </p>
+                  <p className="font-mono text-[12px] text-ink-secondary mt-0.5">
+                    ${blueprint?.price}
+                  </p>
+                </div>
+                <div className="text-center">
+                  <p className="font-bebas text-[12px] tracking-[0.06em] text-gold leading-tight">
+                    {pitchPackage?.name.toUpperCase()}
+                  </p>
+                  <p className="font-mono text-[12px] text-gold mt-0.5">
+                    ${pitchPackage?.price}
+                  </p>
+                </div>
+                <div className="text-center">
+                  <p className="font-bebas text-[12px] tracking-[0.06em] text-white leading-tight">
+                    {marketCase?.name.toUpperCase()}
+                  </p>
+                  <p className="font-mono text-[12px] text-ink-secondary mt-0.5">
+                    ${marketCase?.price.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+
+              {/* Sections + rows */}
+              {comparisonSections.map((section) => (
+                <div key={section.title}>
+                  {/* Section label */}
+                  <div className="px-3 pt-5 pb-2">
+                    <span className="font-mono text-[12px] tracking-[0.15em] uppercase text-gold font-bold">
+                      {section.title}
+                    </span>
+                  </div>
+
+                  {/* Feature rows */}
+                  {section.features.map((feat) => (
+                    <div
+                      key={feat.label}
+                      className="grid grid-cols-4 gap-0 px-3 py-3 border-t border-bg-card-rule items-center"
+                    >
+                      <span className="text-[12px] text-ink-secondary leading-snug pr-2">
+                        {feat.label}
+                      </span>
+                      <div className="text-center">
+                        <FeatureCell value={feat.theBlueprint} />
                       </div>
-                    </th>
-                    <th className="featured-col">
-                      <div className="flex flex-col items-center gap-1">
-                        <span className="text-gold">{pitchPackage?.name}</span>
-                        <span className="font-mono text-gold text-[14px] font-medium">
-                          ${pitchPackage?.price.toLocaleString()}
-                        </span>
+                      <div className="text-center">
+                        <FeatureCell value={feat.thePitchPackage} featured />
                       </div>
-                    </th>
-                    <th>
-                      <div className="flex flex-col items-center gap-1">
-                        <span>{marketCase?.name}</span>
-                        <span className="font-mono text-ink-body text-[14px] font-medium">
-                          ${marketCase?.price.toLocaleString()}
-                        </span>
+                      <div className="text-center">
+                        <FeatureCell value={feat.theMarketCase} />
                       </div>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {comparisonSections.map((section) => (
-                    <>
-                      <tr key={`section-${section.title}`}>
-                        <td
-                          colSpan={4}
-                          className="!text-left !text-gold !text-[11px] !tracking-[0.15em] !uppercase !font-bold !pt-6 !pb-2 !border-b-0"
-                        >
-                          {section.title}
-                        </td>
-                      </tr>
-                      {section.features.map((feat) => (
-                        <tr key={feat.label}>
-                          <td>{feat.label}</td>
-                          <td>
-                            <FeatureCell value={feat.theBlueprint} />
-                          </td>
-                          <td className="featured-col">
-                            <FeatureCell value={feat.thePitchPackage} featured />
-                          </td>
-                          <td>
-                            <FeatureCell value={feat.theMarketCase} />
-                          </td>
-                        </tr>
-                      ))}
-                    </>
+                    </div>
                   ))}
-                </tbody>
-              </table>
+                </div>
+              ))}
             </div>
 
             {/* CTAs */}
-            <div className="grid grid-cols-3 gap-4 mt-8">
+            <div className="space-y-3 mt-8">
               <button
                 onClick={() => navigate("/store#products")}
-                className="h-12 text-[14px] btn-cta-secondary"
+                className="w-full h-14 btn-cta-primary animate-cta-glow-pulse"
               >
-                START WITH THE BLUEPRINT
-              </button>
-              <button
-                onClick={() => navigate("/store#products")}
-                className="h-12 text-[14px] btn-cta-primary"
-              >
-                GET THE PITCH PACKAGE
-              </button>
-              <button
-                onClick={() => navigate("/store#products")}
-                className="h-12 text-[14px] btn-cta-secondary"
-              >
-                GET THE FULL PACKAGE
+                CHOOSE YOUR PACKAGE
               </button>
             </div>
           </div>
         </section>
+
+        {/* Footer */}
+        <footer className="py-8 px-6 max-w-md mx-auto">
+          <p className="text-ink-ghost text-[12px] tracking-wide leading-relaxed text-center">
+            For educational and informational purposes only. Not legal, tax, or
+            investment advice. Consult a qualified entertainment attorney before
+            making financing decisions.
+          </p>
+        </footer>
       </main>
     </div>
   );

--- a/src/pages/StorePackage.tsx
+++ b/src/pages/StorePackage.tsx
@@ -1,16 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import {
-  ArrowLeft,
-  Check,
-  Mail,
-  Instagram,
-} from "lucide-react";
+import { ArrowLeft, Check, Mail, Instagram } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { getProduct, mainProducts } from "@/lib/store-products";
+import { getProduct } from "@/lib/store-products";
 import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
-import { useState, useCallback } from "react";
+
 
 const StorePackage = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -43,7 +38,7 @@ const StorePackage = () => {
       <div className="min-h-screen bg-black flex flex-col">
         <main className="flex-1 flex items-center justify-center">
           <div className="text-center">
-            <p className="text-ink-body mb-4">Package not found.</p>
+            <p className="text-ink-body text-[16px] mb-4">Package not found.</p>
             <button
               onClick={() => navigate("/store")}
               className="text-ink-secondary text-[14px] hover:text-ink-body transition-colors"
@@ -57,13 +52,15 @@ const StorePackage = () => {
   }
 
   const isFeatured = product.featured;
+  const isPremium = product.tier === 3;
   const descParagraphs = product.fullDescription.split("\n\n");
 
   return (
     <div className="min-h-screen bg-black flex flex-col grain-overlay">
-      <main className="flex-1 animate-fade-in pb-24">
+      <main className="flex-1 pb-24" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
+
         {/* BACK NAV */}
-        <div className="px-6 pt-6 max-w-2xl mx-auto">
+        <div className="px-6 pt-6 max-w-md mx-auto">
           <button
             onClick={() => navigate("/store")}
             className="flex items-center gap-2 text-[14px] text-ink-secondary hover:text-ink-body transition-colors"
@@ -73,66 +70,80 @@ const StorePackage = () => {
           </button>
         </div>
 
-        {/* ═══════════════════════════════════════════════════════════
-            HERO
-            ═══════════════════════════════════════════════════════════ */}
-        <section className="px-6 pt-8 pb-2 max-w-2xl mx-auto">
+        {/* ──────────────────────────────────────────────────────────
+             PRODUCT HEADER
+           ────────────────────────────────────────────────────────── */}
+        <section className="px-6 pt-8 pb-6 max-w-md mx-auto">
           {product.badge && (
             <div className="mb-4">
-              <span className="inline-block px-3 py-1.5 rounded-full bg-gold/[0.15] border border-gold/30 text-gold text-[12px] tracking-[0.15em] uppercase font-bold">
+              <span className={cn(
+                "inline-block px-3 py-1.5 text-[12px] tracking-[0.15em] uppercase font-bold rounded",
+                isFeatured
+                  ? "bg-gold/20 border border-gold/40 text-gold"
+                  : isPremium
+                  ? "bg-gold/10 border border-gold/25 text-gold"
+                  : "border border-gold-border text-ink-secondary"
+              )}>
                 {product.badge}
               </span>
             </div>
           )}
 
-          <h1 className="font-bebas text-3xl md:text-4xl text-white leading-tight mb-3">
+          <h1 className="font-bebas text-[40px] tracking-[0.06em] text-white leading-tight mb-3">
             {product.name.toUpperCase()}
           </h1>
 
           <div className="mb-6">
             {product.originalPrice && (
-              <span className="font-mono text-lg text-ink-secondary line-through mr-2">
-                ${product.originalPrice.toLocaleString()}
+              <span className="font-mono text-[16px] text-ink-secondary line-through mr-2">
+                ${product.originalPrice}
               </span>
             )}
-            <span className="font-mono text-4xl font-medium text-white">
+            <span className="font-mono text-[40px] font-bold text-white">
               ${product.price.toLocaleString()}
             </span>
           </div>
 
-          <div className="space-y-4 mb-2">
+          <div className="space-y-4">
             {descParagraphs.map((p, i) => (
-              <p key={i} className="text-ink-body text-[14px] leading-relaxed">
+              <p key={i} className="text-ink-body text-[16px] leading-relaxed">
                 {p}
               </p>
             ))}
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            WHAT'S INCLUDED
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="whats-included" className="px-6 py-12">
-          <div className="max-w-2xl mx-auto">
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-2 font-semibold">
-              Deliverables
-            </p>
-            <h2 className="font-bebas text-3xl tracking-[0.06em] text-gold text-center mb-8">
-              WHAT'S <span className="text-white">INCLUDED</span>
-            </h2>
-            <div className="space-y-4">
-              {product.whatsIncluded.map((item) => (
+
+        {/* ──────────────────────────────────────────────────────────
+             WHAT'S INCLUDED — ledger-style cards
+           ────────────────────────────────────────────────────────── */}
+        <section className="py-14 md:py-20 px-6">
+          <div className="max-w-md mx-auto">
+            <div className="text-center mb-8">
+              <h2 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                WHAT{"\u2019"}S <span className="text-white">INCLUDED</span>
+              </h2>
+            </div>
+
+            <div
+              className="border border-gold-border bg-black overflow-hidden rounded-xl"
+              style={{ boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)' }}
+            >
+              {product.whatsIncluded.map((item, i) => (
                 <div
                   key={item.title}
-                  className="rounded-xl border border-gold-border bg-transparent p-5"
+                  className={cn(
+                    "px-6 py-5",
+                    i > 0 && "border-t border-bg-card-rule",
+                  )}
                 >
                   <div className="flex items-start gap-3 mb-2">
                     <Check className="w-4 h-4 text-gold flex-shrink-0 mt-0.5" />
-                    <h3 className="font-bebas text-lg tracking-[0.06em] text-white">
+                    <h3 className="font-bebas text-[16px] tracking-[0.06em] text-white">
                       {item.title.toUpperCase()}
                     </h3>
                   </div>
-                  <p className="text-ink-body text-[14px] leading-relaxed pl-7">
+                  <p className="text-ink-secondary text-[16px] leading-relaxed pl-7">
                     {item.body}
                   </p>
                 </div>
@@ -141,45 +152,52 @@ const StorePackage = () => {
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            WHO THIS IS FOR
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="who-its-for" className="px-6 py-12">
-          <div className="max-w-2xl mx-auto">
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-2 font-semibold">
-              Ideal For
-            </p>
-            <h2 className="font-bebas text-3xl tracking-[0.06em] text-gold text-center mb-8">
-              WHO THIS IS <span className="text-white">FOR</span>
-            </h2>
-            <p className="text-ink-body text-[14px] leading-relaxed">
+
+        {/* ──────────────────────────────────────────────────────────
+             WHO THIS IS FOR
+           ────────────────────────────────────────────────────────── */}
+        <section className="py-14 md:py-20 px-6">
+          <div className="max-w-md mx-auto">
+            <div className="text-center mb-8">
+              <h2 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                WHO THIS IS <span className="text-white">FOR</span>
+              </h2>
+            </div>
+            <p className="text-ink-body text-[16px] leading-relaxed">
               {product.whoItsFor}
             </p>
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            WHAT YOU'LL BUILD
-            ═══════════════════════════════════════════════════════════ */}
-        <section id="what-youll-build" className="px-6 py-12">
-          <div className="max-w-2xl mx-auto">
-            <p className="text-ink-secondary text-[12px] tracking-[0.2em] uppercase text-center mb-2 font-semibold">
-              The Result
-            </p>
-            <h2 className="font-bebas text-3xl tracking-[0.06em] text-gold text-center mb-8">
-              WHAT YOU'LL <span className="text-white">BUILD</span>
-            </h2>
-            <p className="text-ink-body text-[14px] leading-relaxed">
+
+        {/* ──────────────────────────────────────────────────────────
+             WHAT YOU'LL BUILD
+           ────────────────────────────────────────────────────────── */}
+        <section className="py-14 md:py-20 px-6">
+          <div className="max-w-md mx-auto">
+            <div className="text-center mb-8">
+              <h2 className="font-bebas text-[40px] tracking-[0.08em] text-gold">
+                WHAT YOU{"\u2019"}LL <span className="text-white">BUILD</span>
+              </h2>
+            </div>
+            <p className="text-ink-body text-[16px] leading-relaxed">
               {product.whatYoullBuild}
             </p>
 
-            {/* Upgrade prompt (Blueprint only) */}
+            {/* Upgrade prompt */}
             {product.upgradePrompt && (
-              <div className="mt-6 rounded-xl border border-gold/20 bg-gold/[0.04] p-5">
-                <h3 className="font-bebas text-lg tracking-[0.08em] text-gold mb-2">
+              <div
+                className="mt-8 p-6 rounded-xl"
+                style={{
+                  border: '1px solid rgba(212,175,55,0.15)',
+                  background: 'rgba(212,175,55,0.03)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
+                }}
+              >
+                <h3 className="font-bebas text-[16px] tracking-[0.08em] text-gold mb-2">
                   {product.upgradePrompt.title}
                 </h3>
-                <p className="text-ink-body text-[14px] leading-relaxed mb-4">
+                <p className="text-ink-secondary text-[16px] leading-relaxed mb-4">
                   {product.upgradePrompt.body}
                 </p>
                 <button
@@ -193,64 +211,45 @@ const StorePackage = () => {
           </div>
         </section>
 
-        {/* ═══════════════════════════════════════════════════════════
-            FOOTER
-            ═══════════════════════════════════════════════════════════ */}
-        <footer className="py-10 px-6">
-          <div className="max-w-sm mx-auto">
-            <div className="grid grid-cols-2 gap-3 mb-8 max-w-[340px] mx-auto">
-              <a
-                href="mailto:thefilmmaker.og@gmail.com"
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                <Mail className="w-4 h-4" />
-                <span>Email</span>
-              </a>
-              <a
-                href="https://www.instagram.com/filmmaker.og"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 text-[14px] tracking-wider text-gold/70 hover:text-gold transition-colors active:scale-[0.97] py-3.5 rounded-lg border border-gold-border hover:border-gold/30"
-              >
-                <Instagram className="w-4 h-4" />
-                <span>Instagram</span>
-              </a>
-            </div>
 
-            <div className="flex items-center justify-center mb-2">
-              <span className="font-bebas text-3xl tracking-[0.2em] text-gold">
-                FILMMAKER<span className="text-white">.OG</span>
-              </span>
-            </div>
-            <p className="text-ink-secondary/60 text-[12px] tracking-wide text-center mb-4">
-              Democratizing the business of film.
-            </p>
-            <p className="text-ink-secondary/60 text-[12px] tracking-wide leading-relaxed text-center">
-              For educational and informational purposes only. Not legal, tax, or
-              investment advice. Consult a qualified entertainment attorney before
-              making financing decisions.
-            </p>
-          </div>
+        {/* ──────────────────────────────────────────────────────────
+             FOOTER
+           ────────────────────────────────────────────────────────── */}
+        <footer className="py-8 px-6 max-w-md mx-auto">
+          <p className="text-ink-secondary text-[14px] tracking-[0.04em] text-center mb-3">
+            Democratizing the business of film.
+          </p>
+          <p className="text-ink-ghost text-[12px] tracking-wide leading-relaxed text-center">
+            For educational and informational purposes only. Not legal, tax, or
+            investment advice. Consult a qualified entertainment attorney before
+            making financing decisions.
+          </p>
         </footer>
       </main>
 
-      {/* ═══════════════════════════════════════════════════════════
-          STICKY BOTTOM CTA BAR
-          ═══════════════════════════════════════════════════════════ */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-black/95 backdrop-blur-md border-t border-gold-border">
-        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between gap-4">
+      {/* ──────────────────────────────────────────────────────────
+           STICKY BOTTOM CTA BAR
+         ────────────────────────────────────────────────────────── */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-50 backdrop-blur-md"
+        style={{
+          background: 'rgba(0,0,0,0.92)',
+          borderTop: '1px solid rgba(212,175,55,0.15)',
+        }}
+      >
+        <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between gap-4">
           <div className="flex items-baseline gap-2 min-w-0">
-            <span className="font-bebas text-base text-white truncate">
+            <span className="font-bebas text-[16px] text-white truncate">
               {product.name.toUpperCase()}
             </span>
-            <span className="font-mono text-lg font-medium text-white">
+            <span className="font-mono text-[16px] font-bold text-white">
               ${product.price.toLocaleString()}
             </span>
           </div>
           <button
             onClick={() => navigate("/store#products")}
             className={cn(
-              "h-12 px-6 flex-shrink-0 text-[14px]",
+              "h-12 px-6 flex-shrink-0 uppercase tracking-[0.06em]",
               isFeatured ? "btn-cta-primary" : "btn-cta-secondary"
             )}
           >


### PR DESCRIPTION
Store:
- Remove trust anchor section and hero — products are now the first thing visitors see
- Add inline comparison table (§2) so users see tier differences without navigating away
- Simplify FAQ with design-system-compliant accordion and section headers
- Strip footer to legal-only — remove social links, branding, share buttons
- Update all tokens to design system (explicit px sizes, ink-* colors, gold-border)
- Add CompareCell component for inline comparison table
- Remove unused imports (useCallback, Instagram, Share2, Link2, getShareUrl, etc.)

StoreCompare:
- Replace HTML table with CSS grid layout matching design system
- Use div-based rows with border-bg-card-rule dividers
- Single "CHOOSE YOUR PACKAGE" CTA instead of three buttons
- Add footer with legal disclaimer
- Narrow to max-w-md, add safe-area-inset-bottom

StorePackage:
- Migrate all sections from eyebrow+heading pattern to centered 40px Bebas headings
- Convert What's Included from individual cards to ledger-style card with row dividers
- Update upgrade prompt styling to match design system callout treatment
- Simplify footer to tagline + legal
- Update sticky CTA bar with subtle gold border instead of solid border class
- Narrow to max-w-md

https://claude.ai/code/session_0187y5kGLY12RSrb4vqv3uuE