### PR TITLE
Add "Pick this one if..." to product cards, remove compare link

### DIFF
--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -20,6 +20,7 @@ export interface Product {
   whatsIncluded: { title: string; body: string }[];
   whoItsFor: string;
   whatYoullBuild: string;
+  pickThisIf: string | null;
   upgradePrompt: { title: string; body: string; cta: string; link: string } | null;
 }
 
@@ -60,6 +61,7 @@ export const products: Product[] = [
         body: "Every default value, industry standard, and assumption documented with source and range — so your attorney knows exactly what to review.",
       },
     ],
+    pickThisIf: "you need the numbers documented — no meeting yet",
     whoItsFor:
       "Producers who need a clear, professional record of their project's financial structure. Use it for internal planning, co-producer alignment, or as the foundation document when investors ask for the numbers.",
     whatYoullBuild:
@@ -112,6 +114,7 @@ export const products: Product[] = [
         body: "A clean, structured summary of all deal terms — distribution model, commission rates, fee structures, and recoupment waterfall — formatted for attorney review and investor due diligence.",
       },
     ],
+    pickThisIf: "you have an investor meeting coming up",
     whoItsFor:
       "Producers preparing to sit in front of investors, equity partners, or co-financiers. You have a meeting coming up — or you want to be ready when one lands. This package gives you the complete set of materials that institutional capital expects to see.",
     whatYoullBuild:
@@ -164,6 +167,7 @@ export const products: Product[] = [
         body: "A one-page analysis of where your film sits in the current acquisition landscape — which buyers are active in your genre, what price range the market supports, and what elements of your package (cast, genre, budget) strengthen or weaken your position.",
       },
     ],
+    pickThisIf: "you need to defend a valuation to institutional money",
     whoItsFor:
       "Producers raising $1M+ who need to defend their valuation to sophisticated investors or co-financiers. You're not just presenting a plan — you're making a market case for why this specific project, at this specific budget, in this specific genre, is a sound investment at the proposed terms.",
     whatYoullBuild:
@@ -205,6 +209,7 @@ export const products: Product[] = [
         body: "Clear the inputs and start fresh with a new project. The model structure, formulas, and documentation work for any production in the $1M\u201310M budget range. Buy it once, use it forever.",
       },
     ],
+    pickThisIf: null,
     whoItsFor:
       "Producers and production companies who model multiple projects, want to stress-test deal structures before committing, or need a reusable financial tool they can bring to every negotiation.",
     whatYoullBuild:

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
 import { Check, Mail, X as XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -246,9 +245,16 @@ const ProductCard = ({
       )}
 
       {/* Name */}
-      <h3 className="font-bebas text-[28px] tracking-[0.06em] text-white mb-2">
+      <h3 className="font-bebas text-[28px] tracking-[0.06em] text-white mb-1">
         {product.name.toUpperCase()}
       </h3>
+
+      {/* Pick this if */}
+      {product.pickThisIf && (
+        <p className="text-gold/70 text-[13px] italic mb-3">
+          Pick this one if {product.pickThisIf}
+        </p>
+      )}
 
       {/* Price */}
       <div className="mb-3">
@@ -337,7 +343,6 @@ const CompareCell = ({ value, featured }: { value: FeatureValue; featured?: bool
    MAIN STORE COMPONENT
    ═══════════════════════════════════════════════════════════════════ */
 const Store = () => {
-  const navigate = useNavigate();
   const haptics = useHaptics();
   const [showPopup, setShowPopup] = useState<Product | null>(null);
   const [checkoutLoading, setCheckoutLoading] = useState(false);
@@ -462,15 +467,6 @@ const Store = () => {
               </div>
             )}
 
-            {/* Compare packages link */}
-            <div className="text-center mt-6">
-              <button
-                onClick={() => { haptics.light(); navigate("/store/compare"); }}
-                className="text-ink-secondary text-[14px] hover:text-gold transition-colors tracking-[0.04em]"
-              >
-                Compare packages side by side {"\u2192"}
-              </button>
-            </div>
           </div>
         </section>
 


### PR DESCRIPTION
Each card now tells users who it's for at a glance:
- Blueprint: "...you need the numbers documented — no meeting yet"
- Pitch Package: "...you have an investor meeting coming up"
- Market Case: "...you need to defend a valuation to institutional money"

Removed the "Compare packages side by side" link — the cards now self-select, making the link redundant. Cleaned up unused navigate import.

https://claude.ai/code/session_019MBwLhm442aNELWhVW8eQo