### PR TITLE
Visual audit: uniform ledger, readable Without section, social proof …

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -69,7 +69,7 @@ const WaterfallCascade = () => {
   return (
     <div ref={containerRef}>
       {/* Ledger card */}
-      <div className="border border-white/[0.08] bg-black overflow-hidden rounded-xl">
+      <div className="border border-white/[0.08] bg-black overflow-hidden rounded-xl" style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)" }}>
         {/* Source row */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
           <span className="font-bebas text-[22px] tracking-[0.06em] text-white/90">
@@ -94,17 +94,13 @@ const WaterfallCascade = () => {
         {/* Deduction line items */}
         <div className="px-5 pt-2 pb-4">
           {deductions.map((d, i) => {
-            const isEquity = d.name === "Equity Recoupment";
             const delay = (i + 1) * 180;
             return (
               <div
                 key={d.name}
                 className="flex justify-between items-baseline"
                 style={{
-                  padding: isEquity ? "10px 0 10px 12px" : "9px 0",
-                  borderLeft: isEquity
-                    ? "2px solid rgba(212,175,55,0.50)"
-                    : "2px solid transparent",
+                  padding: "9px 0",
                   opacity: revealed ? 1 : 0,
                   transform: revealed ? "translateY(0)" : "translateY(6px)",
                   transition:
@@ -112,22 +108,10 @@ const WaterfallCascade = () => {
                   transitionDelay: `${delay}ms`,
                 }}
               >
-                <span
-                  className={
-                    isEquity
-                      ? "text-[14px] font-semibold text-white/80"
-                      : "text-[14px] font-medium text-white/45"
-                  }
-                >
+                <span className="text-[14px] font-medium text-white/50">
                   {d.name}
                 </span>
-                <span
-                  className={
-                    isEquity
-                      ? "font-mono text-[15px] font-semibold text-white/85 tabular-nums"
-                      : "font-mono text-[14px] font-medium text-white/45 tabular-nums"
-                  }
-                >
+                <span className="font-mono text-[14px] font-medium text-white/50 tabular-nums">
                   {"\u2212"}{fmt(d.amount)}
                 </span>
               </div>
@@ -141,6 +125,7 @@ const WaterfallCascade = () => {
         className="mt-2 rounded-[10px] px-[18px] py-5 bg-black"
         style={{
           border: "2px solid rgba(212,175,55,0.60)",
+          boxShadow: "0 0 40px 4px rgba(212,175,55,0.07), inset 0 1px 0 rgba(255,255,255,0.06)",
           opacity: revealed ? 1 : 0,
           transform: revealed ? "translateY(0)" : "translateY(8px)",
           transition: "opacity 600ms ease-out, transform 600ms ease-out",
@@ -165,6 +150,7 @@ const WaterfallCascade = () => {
             key={c.label}
             className="border border-white/[0.08] bg-black px-3.5 py-3.5 text-center rounded-lg"
             style={{
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
               opacity: corridorVisible ? 1 : 0,
               transform: corridorVisible
                 ? "translateY(0)"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -87,7 +87,7 @@ const Index = () => {
                   SEE WHERE EVERY DOLLAR <span className="text-white">GOES</span>
                 </h1>
                 <p className="text-white/60 text-[15px] leading-[1.7] tracking-[0.04em] font-medium">
-                  Simulate your film's money flow before you take the meeting.
+                  Model every fee, split, and return — before you take the meeting.
                 </p>
               </div>
 
@@ -96,6 +96,7 @@ const Index = () => {
                 style={{
                   border: "1px solid rgba(255,255,255,0.06)",
                   background: "rgba(255,255,255,0.02)",
+                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                 }}
               >
                 <WaterfallCascade />
@@ -123,7 +124,7 @@ const Index = () => {
               {/* WITH card */}
               <div
                 className="bg-black rounded-xl overflow-hidden"
-                style={{ border: "1px solid rgba(212,175,55,0.15)" }}
+                style={{ border: "1px solid rgba(212,175,55,0.15)", boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)" }}
               >
                 <div className="px-5 pt-6 pb-6">
                   <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-6">
@@ -163,8 +164,9 @@ const Index = () => {
               <div
                 className="rounded-xl overflow-hidden"
                 style={{
-                  border: "1px solid rgba(180,60,60,0.22)",
-                  background: "rgba(180,60,60,0.04)",
+                  border: "1px solid rgba(180,60,60,0.28)",
+                  background: "rgba(180,60,60,0.07)",
+                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                 }}
               >
                 <div className="px-5 pt-6 pb-6">
@@ -201,8 +203,8 @@ const Index = () => {
                           <span className="text-[16px] font-bold leading-none" aria-hidden="true" style={{ color: "rgba(220,100,100,0.90)" }}>{"\u2717"}</span>
                         </div>
                         <div>
-                          <p className="text-[15px] font-semibold leading-snug" style={{ color: "rgba(255,200,200,0.80)" }}>{item.title}</p>
-                          <p className="text-[13px] leading-snug mt-1 text-white/50">{item.desc}</p>
+                          <p className="text-[15px] font-semibold leading-snug text-white/90">{item.title}</p>
+                          <p className="text-[13px] leading-snug mt-1 text-white/55">{item.desc}</p>
                         </div>
                       </li>
                     ))}
@@ -216,18 +218,49 @@ const Index = () => {
             <div className="max-w-md mx-auto">
               <div
                 ref={credRef}
-                className="rounded-xl px-8 py-10 text-center"
                 style={{
-                  border: "1px solid rgba(255,255,255,0.08)",
-                  background: "rgba(255,255,255,0.02)",
                   opacity: prefersReducedMotion || credVisible ? 1 : 0,
                   transform: prefersReducedMotion || credVisible ? "translateY(0)" : "translateY(16px)",
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <p className="text-[15px] text-white/70 leading-relaxed tracking-wide">
-                  Built by a second-generation producer. Tribeca premiere. Netflix acquisition. This is the tool I needed on my first deal.
+                <p className="font-mono text-[11px] tracking-[0.14em] uppercase text-white/40 text-center mb-3">
+                  Second-generation producer{"\u00A0"}{"\u00B7"}{"\u00A0"}Tribeca premiere{"\u00A0"}{"\u00B7"}{"\u00A0"}Netflix acquisition
                 </p>
+                <p className="text-[15px] text-white/60 leading-relaxed text-center mb-7">
+                  This is the tool I needed on my first deal.
+                </p>
+                <div className="flex flex-col gap-3">
+                  {[0, 1].map((idx) => (
+                    <div
+                      key={idx}
+                      className="rounded-xl px-6 py-5 text-left"
+                      style={{
+                        border: "1px solid rgba(255,255,255,0.08)",
+                        background: "rgba(255,255,255,0.02)",
+                        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+                        opacity: prefersReducedMotion || credVisible ? 1 : 0,
+                        transform: prefersReducedMotion || credVisible ? "translateY(0)" : "translateY(10px)",
+                        transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
+                        transitionDelay: prefersReducedMotion ? "0ms" : `${400 + idx * 150}ms`,
+                      }}
+                    >
+                      <span
+                        className="block font-bebas text-[32px] leading-none select-none"
+                        aria-hidden="true"
+                        style={{ color: "rgba(212,175,55,0.18)" }}
+                      >
+                        {"\u201C"}
+                      </span>
+                      <p className="text-[14px] text-white/30 italic leading-relaxed -mt-1">
+                        {idx === 0 ? "Producer testimonial placeholder" : "Industry testimonial placeholder"}
+                      </p>
+                      <p className="font-mono text-[11px] text-white/20 mt-3 tracking-[0.08em]">
+                        — Name, Title
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </section>
@@ -239,7 +272,8 @@ const Index = () => {
                 className="rounded-2xl px-8 py-10 md:py-14 text-center"
                 style={{
                   border: "2px solid rgba(212,175,55,0.40)",
-                  background: "rgba(255,255,255,0.02)",
+                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.04) 0%, rgba(255,255,255,0.02) 60%, transparent 100%)",
+                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                   opacity: prefersReducedMotion || bridgeVisible ? 1 : 0,
                   transform: prefersReducedMotion || bridgeVisible ? "translateY(0)" : "translateY(16px)",
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",


### PR DESCRIPTION
…+ inner-light

Waterfall ledger:
- Remove all Equity Recoupment special-casing (no gold border, no bold, no size difference) — every row uniform at white/50
- Add subtle gold radial glow (0.07 opacity) behind profit box
- Add inner-light (inset top highlight at 6%) to all card surfaces

Index landing page:
- Subtitle: "Model every fee, split, and return" replaces "Simulate"
- Without-it card: titles now white/90 (not red), descriptions white/55, card border bumped to 0.28, background to 0.07 for stronger presence
- Social proof restructured: credential line as sparse mono label, personal "tool I needed" statement, two placeholder quote cards with gold open-quote accent and staggered reveal animation
- Inner-light shadow added to all card surfaces (waterfall container, WITH card, WITHOUT card, quote cards, final CTA)
- Final CTA card gets subtle gold radial warmth gradient behind button

https://claude.ai/code/session_019mjRfvfAuhDgZ6i5HQEEkR