### PR TITLE
Remove mid-page CTA, tighten dead space, sharpen subhero copy

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -78,11 +78,11 @@ const Index = () => {
                   SEE WHERE EVERY DOLLAR <span className="text-white">GOES</span>
                 </h1>
                 <p className="text-white/60 text-[15px] leading-[1.7] tracking-[0.04em] font-medium">
-                  Model every fee, split, and return — before you take the meeting.
+                  See every fee, split, and return — before your investor asks.
                 </p>
               </div>
 
-              <div className="mb-9 text-center px-2">
+              <div className="mb-6 text-center px-2">
                 <div className="w-full max-w-[300px] mx-auto">
                   <button
                     onClick={handleStartClick}
@@ -107,7 +107,7 @@ const Index = () => {
             </div>
           </section>
 
-          <section id="value" className="relative py-16 md:py-20 px-6">
+          <section id="value" className="relative pt-16 pb-10 md:pt-20 md:pb-12 px-6">
             <div
               ref={valueRef}
               className="relative max-w-md mx-auto flex flex-col gap-5"
@@ -204,20 +204,11 @@ const Index = () => {
               </div>
             </div>
 
-            {/* Mid-page escape CTA */}
-            <div className="text-center mt-8 max-w-md mx-auto">
-              <button
-                onClick={handleStartClick}
-                className="text-gold text-[14px] font-medium tracking-wide hover:text-white transition-colors py-3"
-              >
-                See how it works →
-              </button>
-            </div>
           </section>
 
           <div className="gold-section-divider" />
 
-          <section className="px-6 pt-12 pb-10">
+          <section className="px-6 pt-10 pb-6">
             <div className="max-w-md mx-auto">
               <div
                 ref={credRef}


### PR DESCRIPTION
- Kill "See how it works →" (duplicate CTA, different promise, same destination)
- Value section: py-16 → pt-16 pb-10 (remove gap left by deleted CTA)
- Social proof section: pt-12 pb-10 → pt-10 pb-6 (closer to final CTA)
- Hero button → demo gap: mb-9 → mb-6 (hero reads as one unit)
- Subhero: "Model every fee…before you take the meeting" → "See every fee…before your investor asks" (filmmaker language, names the pressure, through-line to final CTA)

https://claude.ai/code/session_019mjRfvfAuhDgZ6i5HQEEkR