### PR TITLE
Move founder quote between WITH/WITHOUT, improve cascade readability

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -114,10 +114,10 @@ const WaterfallCascade = () => {
                   transitionDelay: `${delay}ms`,
                 }}
               >
-                <span className="text-[14px] font-medium text-white/60">
+                <span className="text-[14px] font-medium text-white/70">
                   {d.name}
                 </span>
-                <span className="font-mono text-[14px] font-medium text-white/60 tabular-nums">
+                <span className="font-mono text-[15px] font-medium text-white/70 tabular-nums">
                   {"\u2212"}{fmtFull(d.amount)}
                 </span>
               </div>
@@ -175,7 +175,7 @@ const WaterfallCascade = () => {
         ))}
       </div>
 
-      <p className="font-mono text-[11px] text-white/35 text-center mt-3.5">
+      <p className="font-mono text-[12px] text-white/45 text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
       </p>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -150,6 +150,10 @@ const Index = () => {
                 </div>
               </div>
 
+              <p className="text-[14px] text-white/45 italic leading-relaxed tracking-[0.01em] text-center py-4">
+                My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math.
+              </p>
+
               {/* WITHOUT card */}
               <div
                 className="rounded-xl overflow-hidden"
@@ -219,9 +223,6 @@ const Index = () => {
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <p className="text-[15px] text-white/55 italic leading-relaxed tracking-[0.01em] mb-6">
-                  My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math. These are the tools I built so you don't have to.
-                </p>
                 <h2 className="font-bebas text-[32px] leading-[1.1] tracking-[0.06em] text-gold mb-6">
                   YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-white">BACK.</span>
                 </h2>


### PR DESCRIPTION
1. Moved founder quote out of the CTA box (too text-heavy) and placed it as a breathing line between the WITH and WITHOUT sections — sets up the pain points naturally. CTA box is now tight: headline + button.
2. Cascade deductions: bumped name+amount opacity from white/60 → white/70 and amount font from 14px → 15px for better scanability.
3. Assumptions line: 11px white/35 → 12px white/45 for legibility.

https://claude.ai/code/session_019mjRfvfAuhDgZ6i5HQEEkR