### PR TITLE
Landing page visual overhaul: gold narrative, token enforcement, stru…

### DIFF
--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -103,7 +103,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
       <DialogContent className="w-[calc(100%-2rem)] max-w-sm mx-auto bg-bg-void border-border-subtle p-0 gap-0">
         <DialogTitle className="sr-only">Sign in to access the calculator</DialogTitle>
         {/* Gold accent */}
-        <div className="h-[2px] w-full bg-gold" />
+        <div className="h-[2px] w-full" style={{ background: "linear-gradient(90deg, transparent, #D4AF37, transparent)" }} />
 
         {sent ? (
           // Magic link sent — check your email
@@ -167,7 +167,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
                     (e.currentTarget.nextElementSibling as HTMLInputElement)?.focus();
                   }
                 }}
-                className="w-full h-12 px-4 bg-bg-header border border-border-subtle text-text-primary placeholder:text-text-dim text-sm focus:border-gold focus:outline-none transition-colors"
+                className="w-full h-12 px-4 bg-bg-surface border border-border-subtle rounded-lg text-text-primary placeholder:text-text-dim text-sm focus:border-gold focus:shadow-[0_0_0_3px_rgba(212,175,55,0.10)] focus:outline-none transition-all"
               />
 
               <input
@@ -186,7 +186,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
                     handleSubmit(e as unknown as React.FormEvent);
                   }
                 }}
-                className="w-full h-12 px-4 bg-bg-header border border-border-subtle text-text-primary placeholder:text-text-dim font-mono text-sm focus:border-gold focus:outline-none transition-colors"
+                className="w-full h-12 px-4 bg-bg-surface border border-border-subtle rounded-lg text-text-primary placeholder:text-text-dim font-mono text-sm focus:border-gold focus:shadow-[0_0_0_3px_rgba(212,175,55,0.10)] focus:outline-none transition-all"
               />
 
               <button

--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -70,15 +70,15 @@ const WaterfallCascade = () => {
   }, [revealed]);
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} className="pt-4 pb-5">
       {/* Ledger card */}
-      <div className="border border-white/[0.08] bg-black overflow-hidden rounded-xl" style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)" }}>
+      <div className="border border-gold/[0.12] bg-black overflow-hidden rounded-xl">
         {/* Source row */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
-          <span className="font-bebas text-[22px] tracking-[0.06em] text-white/90">
+          <span className="font-bebas text-[22px] tracking-[0.06em] text-gold-label">
             Acquisition Price
           </span>
-          <span className="font-mono text-[17px] font-semibold text-white/90 tabular-nums">
+          <span className="font-mono text-[17px] font-semibold text-gold tabular-nums">
             {fmtFull(TOTAL)}
           </span>
         </div>
@@ -106,7 +106,7 @@ const WaterfallCascade = () => {
                 style={{
                   padding: "9px 8px",
                   margin: "0 -8px",
-                  background: isEven ? "rgba(255,255,255,0.03)" : "transparent",
+                  background: isEven ? "rgba(212,175,55,0.03)" : "transparent",
                   opacity: revealed ? 1 : 0,
                   transform: revealed ? "translateY(0)" : "translateY(6px)",
                   transition:
@@ -114,11 +114,11 @@ const WaterfallCascade = () => {
                   transitionDelay: `${delay}ms`,
                 }}
               >
-                <span className="text-[14px] font-medium text-white/70">
+                <span className="text-[14px] font-medium text-ink-secondary">
                   {d.name}
                 </span>
-                <span className="font-mono text-[15px] font-medium text-white/70 tabular-nums">
-                  {"\u2212"}{fmtFull(d.amount)}
+                <span className="font-mono text-[15px] font-medium text-ink-body tabular-nums">
+                  <span className="text-ink-secondary">{"\u2212"}</span>{fmtFull(d.amount)}
                 </span>
               </div>
             );
@@ -131,17 +131,17 @@ const WaterfallCascade = () => {
         className="mt-2 rounded-[10px] py-5 bg-black text-center"
         style={{
           border: "2px solid rgba(212,175,55,0.60)",
-          boxShadow: "0 0 40px 4px rgba(212,175,55,0.12), inset 0 1px 0 rgba(255,255,255,0.06)",
+          boxShadow: "0 0 40px 4px rgba(212,175,55,0.18), inset 0 1px 0 rgba(212,175,55,0.08)",
           opacity: revealed ? 1 : 0,
           transform: revealed ? "translateY(0)" : "translateY(8px)",
           transition: "opacity 600ms ease-out, transform 600ms ease-out",
           transitionDelay: "1400ms",
         }}
       >
-        <p className="font-mono text-[10px] tracking-[0.22em] uppercase font-semibold text-gold mb-1">
+        <p className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold text-gold mb-1">
           Net Profits
         </p>
-        <span className="font-mono text-[32px] font-bold text-white tracking-tight tabular-nums">
+        <span className="font-mono text-[32px] font-bold text-gold tracking-tight tabular-nums">
           ${profitCount.toLocaleString()}
         </span>
       </div>
@@ -154,9 +154,9 @@ const WaterfallCascade = () => {
         ].map((c) => (
           <div
             key={c.label}
-            className="border border-white/[0.08] bg-black px-3.5 py-3.5 text-center rounded-lg"
+            className="border border-gold/[0.15] px-3.5 py-3.5 text-center rounded-lg"
             style={{
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+              background: "rgba(212,175,55,0.03)",
               opacity: corridorVisible ? 1 : 0,
               transform: corridorVisible
                 ? "translateY(0)"
@@ -165,17 +165,17 @@ const WaterfallCascade = () => {
               transitionDelay: `${c.extraDelay}ms`,
             }}
           >
-            <p className="font-mono text-[10px] tracking-[0.18em] uppercase font-semibold text-gold-label mb-1">
+            <p className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
               {c.label}
             </p>
-            <span className="font-mono text-[20px] font-bold text-white/90 tabular-nums">
+            <span className="font-mono text-[20px] font-bold text-gold-label tabular-nums">
               {c.amount}
             </span>
           </div>
         ))}
       </div>
 
-      <p className="font-mono text-[12px] text-white/45 text-center mt-3.5">
+      <p className="font-mono text-[12px] text-ink-ghost text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -43,7 +43,7 @@
   height: 100%;
   pointer-events: none;
   z-index: 50;
-  opacity: 0.07;
+  opacity: 0.04;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   background-size: 256px 256px;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ const Index = () => {
   const [showLeadCapture, setShowLeadCapture] = useState(false);
   const [pendingDestination, setPendingDestination] = useState<string | null>(null);
   const [hasSession, setHasSession] = useState(false);
+  const [ctaGlow, setCtaGlow] = useState(false);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -40,6 +41,12 @@ const Index = () => {
 
   const prefersReducedMotion = typeof window !== "undefined"
     && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+    const timeout = setTimeout(() => setCtaGlow(true), 3500);
+    return () => clearTimeout(timeout);
+  }, [prefersReducedMotion]);
 
   const { ref: valueRef, inView: valueVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: bridgeRef, inView: bridgeVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
@@ -69,14 +76,14 @@ const Index = () => {
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
         <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-          <section id="hero" className="relative pt-8 pb-6">
+          <section id="hero" className="relative pt-8 pb-6" style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.04) 0%, transparent 60%)" }}>
             <div className="relative px-6 max-w-md mx-auto">
 
               <div className="text-center mb-8 px-2">
-                <h1 className="font-bebas text-[clamp(3rem,10vw,4.2rem)] leading-[0.95] tracking-[0.02em] text-gold mb-2.5">
-                  SEE WHERE EVERY DOLLAR <span className="text-white">GOES</span>
+                <h1 className="font-bebas text-[clamp(3rem,10vw,4.2rem)] leading-[0.95] tracking-[0.02em] text-gold mb-4">
+                  SEE WHERE EVERY DOLLAR <span className="text-ink">GOES</span>
                 </h1>
-                <p className="text-white/60 text-[15px] leading-[1.7] tracking-[0.04em] font-medium">
+                <p className="text-ink-body text-[16px] leading-[1.7] tracking-[0.04em] font-medium">
                   Know every fee, split, and return — before your investor asks.
                 </p>
               </div>
@@ -85,36 +92,36 @@ const Index = () => {
                 <div className="w-full max-w-[300px] mx-auto">
                   <button
                     onClick={handleStartClick}
-                    className="w-full h-[52px] btn-cta-primary"
+                    className={`w-full h-[52px] btn-cta-primary${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
                   >
                     BUILD YOUR WATERFALL
                   </button>
                 </div>
               </div>
 
-              <div
-                className="rounded-2xl pt-4 pb-5"
-                style={{
-                  border: "1px solid rgba(255,255,255,0.06)",
-                  background: "rgba(255,255,255,0.02)",
-                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                }}
-              >
-                <WaterfallCascade />
-              </div>
+              <WaterfallCascade />
 
             </div>
           </section>
 
-          <section id="value" className="relative pt-16 pb-10 md:pt-20 md:pb-12 px-6">
+          {/* Section divider — breath mark between demo and argument */}
+          <div className="flex justify-center py-2">
+            <div className="w-[60px] h-[1px]" style={{ background: "linear-gradient(90deg, rgba(212,175,55,0.30), rgba(212,175,55,0.08))" }} />
+          </div>
+
+          <section id="value" className="relative pt-12 pb-10 md:pt-16 md:pb-12 px-6">
             <div
               ref={valueRef}
               className="relative max-w-md mx-auto flex flex-col gap-5"
             >
+              <p className="text-[14px] text-ink-secondary italic leading-relaxed tracking-[0.01em] text-center pb-1">
+                My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math.
+              </p>
+
               {/* WITH card */}
               <div
-                className="bg-black rounded-xl overflow-hidden"
-                style={{ border: "1px solid rgba(212,175,55,0.25)", boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)" }}
+                className="rounded-xl overflow-hidden"
+                style={{ border: "1px solid rgba(212,175,55,0.25)", background: "rgba(212,175,55,0.02)", boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)" }}
               >
                 <div className="px-5 pt-6 pb-6">
                   <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-6">
@@ -141,8 +148,8 @@ const Index = () => {
                           <span className="text-black text-[18px] font-bold leading-none" aria-hidden="true">{"\u2713"}</span>
                         </div>
                         <div>
-                          <p className="text-[15px] font-semibold text-white leading-snug">{item.title}</p>
-                          <p className="text-[13px] text-white/65 leading-snug mt-1">{item.desc}</p>
+                          <p className="text-[15px] font-semibold text-ink leading-snug">{item.title}</p>
+                          <p className="text-[13px] text-ink-body leading-snug mt-1">{item.desc}</p>
                         </div>
                       </li>
                     ))}
@@ -150,17 +157,12 @@ const Index = () => {
                 </div>
               </div>
 
-              <p className="text-[14px] text-white/45 italic leading-relaxed tracking-[0.01em] text-center py-4">
-                My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math.
-              </p>
-
               {/* WITHOUT card */}
               <div
                 className="rounded-xl overflow-hidden"
                 style={{
                   border: "1px solid rgba(180,60,60,0.28)",
                   background: "rgba(180,60,60,0.07)",
-                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                 }}
               >
                 <div className="px-5 pt-6 pb-6">
@@ -173,7 +175,7 @@ const Index = () => {
                       transitionDelay: prefersReducedMotion ? "0ms" : `${withItems.length * 80 + 60}ms`,
                     }}
                   >
-                    Without it
+                    Without a waterfall
                   </h2>
                   <ul className="flex flex-col gap-5" aria-label="Risks without a waterfall">
                     {withoutItems.map((item, i) => (
@@ -197,8 +199,8 @@ const Index = () => {
                           <span className="text-[16px] font-bold leading-none" aria-hidden="true" style={{ color: "rgba(220,100,100,0.90)" }}>{"\u2717"}</span>
                         </div>
                         <div>
-                          <p className="text-[15px] font-semibold leading-snug text-white">{item.title}</p>
-                          <p className="text-[13px] leading-snug mt-1 text-white/65">{item.desc}</p>
+                          <p className="text-[15px] font-semibold leading-snug text-ink">{item.title}</p>
+                          <p className="text-[13px] leading-snug mt-1 text-ink-secondary">{item.desc}</p>
                         </div>
                       </li>
                     ))}
@@ -209,26 +211,31 @@ const Index = () => {
 
           </section>
 
-          <section id="final-cta" className="py-16 md:py-20 px-6">
+          {/* Section divider — breath mark between argument and close */}
+          <div className="flex justify-center py-2">
+            <div className="w-[60px] h-[1px]" style={{ background: "linear-gradient(90deg, rgba(212,175,55,0.30), rgba(212,175,55,0.08))" }} />
+          </div>
+
+          <section id="final-cta" className="py-12 md:py-16 px-6">
             <div className="max-w-md mx-auto">
               <div
                 ref={bridgeRef}
                 className="rounded-2xl px-6 py-10 md:py-14 text-center"
                 style={{
                   border: "2px solid rgba(212,175,55,0.40)",
-                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.04) 0%, rgba(255,255,255,0.02) 60%, transparent 100%)",
-                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.04) 0%, rgba(212,175,55,0.02) 60%, transparent 100%)",
+                  boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
                   opacity: prefersReducedMotion || bridgeVisible ? 1 : 0,
                   transform: prefersReducedMotion || bridgeVisible ? "translateY(0)" : "translateY(16px)",
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <h2 className="font-bebas text-[32px] leading-[1.1] tracking-[0.06em] text-gold mb-6">
-                  YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-white">BACK.</span>
+                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.1] tracking-[0.06em] text-gold mb-6">
+                  YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-ink">BACK.</span>
                 </h2>
                 <button
                   onClick={handleStartClick}
-                  className="w-full max-w-[300px] h-[52px] btn-cta-primary mx-auto"
+                  className="w-full max-w-[300px] h-[52px] btn-cta-primary animate-cta-glow-pulse mx-auto"
                 >
                   BUILD YOUR WATERFALL
                 </button>
@@ -237,7 +244,7 @@ const Index = () => {
           </section>
 
           <footer className="py-8 px-6 max-w-md mx-auto">
-            <p className="text-white/30 text-[12px] tracking-wide leading-relaxed text-center">
+            <p className="text-ink-ghost text-[13px] tracking-wide leading-relaxed text-center">
               For educational and informational purposes only. Not legal, tax, or investment advice.
               Consult a qualified entertainment attorney before making financing decisions.
             </p>


### PR DESCRIPTION
…ctural polish

Cascade: gold traces the path of money — acquisition price in gold, deductions in ink-secondary/ink-body, profit number in gold, corridor splits in gold-label with warm backgrounds and gold borders. Minus signs dimmed relative to amounts. Zebra stripes gold-tinted. Profit box glow increased with gold inset highlight. Ledger card border swapped white→gold.

Index: enforce 4-tier ink token system across all text (hero subhead to ink-body, WITH descriptions to ink-body, WITHOUT descriptions to ink-secondary for temperature differentiation, footer to ink-ghost). Kill ghost wrapper around cascade. Add warm radial glow behind hero. Section dividers between acts. Quote moved above WITH/WITHOUT pair. WITHOUT card white inset highlight removed. WITH card gets gold bg tint. Final CTA headline responsive with clamp(). Radial gradient all-gold. CTA buttons get delayed breathing glow (hero after 3.5s, final always).

Modal: gradient accent bar, visible input fields (bg-surface), rounded corners, gold focus glow on inputs.

CSS: grain opacity 0.07→0.04 for deeper OLED blacks. Micro-label tracking consolidated to 0.16em.

https://claude.ai/code/session_01MoA2N3QGu8jCHBA7rxQGyg