### PR TITLE
Add 'What This Is' section, fix hero padding, bump cascade readability

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -129,7 +129,7 @@ const WaterfallCascade = () => {
           transitionDelay: "1400ms",
         }}
       >
-        <p className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
+        <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
           Net Profits
         </p>
         <span className="font-mono text-[32px] font-bold text-gold tracking-tight tabular-nums">
@@ -156,10 +156,10 @@ const WaterfallCascade = () => {
               transitionDelay: `${c.extraDelay}ms`,
             }}
           >
-            <p className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
+            <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
               {c.label}
             </p>
-            <span className="font-mono text-[20px] font-bold text-gold tabular-nums">
+            <span className="font-mono text-[24px] font-bold text-gold tabular-nums">
               {c.amount}
             </span>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -76,7 +76,7 @@ const Index = () => {
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
         <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-          <section id="hero" className="relative pt-2 pb-6" style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.04) 0%, transparent 60%)" }}>
+          <section id="hero" className="relative pt-12 pb-6" style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.04) 0%, transparent 60%)" }}>
             <div className="relative px-8 max-w-md mx-auto">
 
               <div className="text-center mb-8">
@@ -106,15 +106,60 @@ const Index = () => {
             </div>
           </section>
 
-          <section id="value" className="relative pt-12 pb-10 md:pt-16 md:pb-12 px-6">
+          {/* What This Is — education + mission */}
+          <section id="what-this-is" className="relative pt-12 pb-10 md:pt-16 md:pb-12 px-6">
+            <div className="max-w-md mx-auto">
+              <div
+                className="rounded-xl overflow-hidden"
+                style={{
+                  border: "1px solid rgba(212,175,55,0.25)",
+                  background: "rgba(212,175,55,0.02)",
+                  boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
+                }}
+              >
+                <div className="px-6 pt-7 pb-7 flex flex-col gap-5">
+                  <h2 className="font-bebas text-[clamp(1.6rem,6vw,2rem)] leading-[1.1] tracking-[0.04em] text-gold">
+                    KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
+                  </h2>
+
+                  <p className="text-[15px] text-ink-body leading-[1.7] tracking-[0.01em]">
+                    Every film deal has a pecking order&nbsp;— distributors, agents, lenders, and investors all get paid before you&nbsp;do.
+                  </p>
+
+                  <p className="text-[15px] text-ink-body leading-[1.7] tracking-[0.01em]">
+                    That's called a <span className="text-gold font-semibold">waterfall</span>. This tool lets you model yours before you sign&nbsp;anything.
+                    <a
+                      href="/resources?tab=waterfall"
+                      className="inline-flex items-center gap-1.5 ml-2 text-gold/70 hover:text-gold transition-colors text-[13px] font-medium"
+                    >
+                      <span
+                        className="inline-flex items-center justify-center w-[18px] h-[18px] rounded-full text-[11px] font-bold leading-none"
+                        style={{ border: "1px solid rgba(212,175,55,0.40)", color: "rgba(212,175,55,0.70)" }}
+                        aria-hidden="true"
+                      >
+                        i
+                      </span>
+                      What's a waterfall?
+                    </a>
+                  </p>
+
+                  <p className="text-[15px] text-ink-body leading-[1.7] tracking-[0.01em]">
+                    Run it as many times as you want. Premium unlocks extended scenarios, financial modeling, and PDF&nbsp;exports.
+                  </p>
+
+                  <p className="text-[14px] text-gold/60 italic tracking-[0.02em] pt-1">
+                    We're democratizing the business of film.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="value" className="relative pb-10 md:pb-12 px-6">
             <div
               ref={valueRef}
               className="relative max-w-md mx-auto flex flex-col gap-5"
             >
-              <p className="text-[14px] text-ink-secondary italic leading-relaxed tracking-[0.01em] text-center pb-1">
-                My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math.
-              </p>
-
               {/* WITH card */}
               <div
                 className="rounded-xl overflow-hidden"


### PR DESCRIPTION
- Hero: pt-2 → pt-12 so headline isn't jammed against viewport top
- WaterfallCascade: Net Profits/Producer/Investor labels 10px → 12px, split amounts 20px → 24px for readability
- Remove anonymous Tribeca quote — added no credibility
- New 'What This Is' section between hero and With/Without cards: explains what a waterfall is in plain language, links to resources tab with (i) icon, teases premium, closes with mission statement "We're democratizing the business of film."

https://claude.ai/code/session_01MoA2N3QGu8jCHBA7rxQGyg