### PR TITLE
Align landing page to filmmaker.og brand system

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -6,7 +6,7 @@ import { useHaptics } from "@/hooks/use-haptics";
    AppHeader — floating pill
    Left:  FILMMAKER.OG → home
    Right: ⋮ kebab → MobileMenu
-   320px centered pill, 16px radius, solid black, gold border 0.50
+   320px centered pill, 8px radius, solid black, gold border
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
   onMoreOpen?: () => void;
@@ -30,10 +30,10 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
             maxWidth: "320px",
             height: "54px",
             marginTop: "max(12px, env(safe-area-inset-top, 12px))",
-            borderRadius: "16px",
+            borderRadius: "8px",
             background: "#000000",
-            border: "1.5px solid rgba(212,175,55,0.50)",
-            boxShadow: "0 8px 32px rgba(0,0,0,0.95), 0 0 0 1px rgba(212,175,55,0.10)",
+            border: "1px solid rgba(212,175,55,0.25)",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.95)",
             paddingLeft: "16px",
             paddingRight: "10px",
           }}

--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -100,27 +100,37 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[calc(100%-2rem)] max-w-sm mx-auto bg-bg-void border-border-subtle p-0 gap-0">
+      <DialogContent
+        className="w-[calc(100%-2rem)] max-w-sm mx-auto p-0 gap-0"
+        style={{
+          background: "#000000",
+          border: "1px solid rgba(255,255,255,0.15)",
+          borderRadius: "6px",
+        }}
+      >
         <DialogTitle className="sr-only">Sign in to access the calculator</DialogTitle>
         {/* Gold accent */}
-        <div className="h-[2px] w-full" style={{ background: "linear-gradient(90deg, transparent, #D4AF37, transparent)" }} />
+        <div className="h-[1px] w-full" style={{ background: "linear-gradient(90deg, transparent, #D4AF37, transparent)" }} />
 
         {sent ? (
           // Magic link sent — check your email
           <div className="p-6 text-center">
-            <div className="w-12 h-12 border border-gold/50 flex items-center justify-center mx-auto mb-4">
+            <div
+              className="w-12 h-12 flex items-center justify-center mx-auto mb-4"
+              style={{ border: "1px solid rgba(212,175,55,0.25)", borderRadius: "6px" }}
+            >
               <Mail className="w-6 h-6 text-gold" />
             </div>
-            <p className="font-bebas text-xl tracking-wider text-text-primary mb-2">
+            <p className="font-bebas text-xl tracking-wider text-white mb-2">
               CHECK YOUR EMAIL
             </p>
-            <p className="text-text-dim text-sm mb-2">
+            <p className="text-sm mb-2" style={{ color: "rgba(255,255,255,0.40)" }}>
               We sent a sign-in link to
             </p>
             <p className="font-mono text-gold text-sm mb-6">
               {email}
             </p>
-            <p className="text-text-dim text-xs mb-6">
+            <p className="text-xs mb-6" style={{ color: "rgba(255,255,255,0.40)" }}>
               Click the link in your email to access the calculator.
             </p>
 
@@ -128,14 +138,16 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
               <button
                 onClick={handleResend}
                 disabled={loading}
-                className="text-text-dim hover:text-text-mid text-xs tracking-wider transition-colors"
+                className="text-xs tracking-wider transition-colors"
+                style={{ color: "rgba(255,255,255,0.40)" }}
               >
                 {loading ? "Sending..." : "Didn't get it? Resend"}
               </button>
               <div>
                 <button
                   onClick={() => setSent(false)}
-                  className="text-text-dim hover:text-text-mid text-xs transition-colors"
+                  className="text-xs transition-colors"
+                  style={{ color: "rgba(255,255,255,0.40)" }}
                 >
                   Use different email
                 </button>
@@ -145,10 +157,10 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
         ) : (
           // Name + email form
           <form onSubmit={handleSubmit} className="p-6">
-            <p className="font-bebas text-xl tracking-wider text-text-primary text-center mb-1">
+            <p className="font-bebas text-xl tracking-wider text-white text-center mb-1">
               BUILD YOUR WATERFALL
             </p>
-            <p className="text-text-dim text-xs text-center mb-6">
+            <p className="text-xs text-center mb-6" style={{ color: "rgba(255,255,255,0.40)" }}>
               Enter your name and email to start building your waterfall.
             </p>
 
@@ -167,7 +179,20 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
                     (e.currentTarget.nextElementSibling as HTMLInputElement)?.focus();
                   }
                 }}
-                className="w-full h-12 px-4 bg-bg-surface border border-border-subtle rounded-lg text-text-primary placeholder:text-text-dim text-sm focus:border-gold focus:shadow-[0_0_0_3px_rgba(212,175,55,0.10)] focus:outline-none transition-all"
+                className="w-full h-12 px-4 text-white text-sm focus:outline-none transition-all"
+                style={{
+                  background: "#1A1A1A",
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  borderRadius: "4px",
+                }}
+                onFocus={e => {
+                  e.currentTarget.style.borderColor = "#D4AF37";
+                  e.currentTarget.style.boxShadow = "0 0 0 3px rgba(212,175,55,0.08)";
+                }}
+                onBlur={e => {
+                  e.currentTarget.style.borderColor = "rgba(255,255,255,0.15)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
               />
 
               <input
@@ -186,7 +211,20 @@ const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps)
                     handleSubmit(e as unknown as React.FormEvent);
                   }
                 }}
-                className="w-full h-12 px-4 bg-bg-surface border border-border-subtle rounded-lg text-text-primary placeholder:text-text-dim font-mono text-sm focus:border-gold focus:shadow-[0_0_0_3px_rgba(212,175,55,0.10)] focus:outline-none transition-all"
+                className="w-full h-12 px-4 font-mono text-white text-sm focus:outline-none transition-all"
+                style={{
+                  background: "#1A1A1A",
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  borderRadius: "4px",
+                }}
+                onFocus={e => {
+                  e.currentTarget.style.borderColor = "#D4AF37";
+                  e.currentTarget.style.boxShadow = "0 0 0 3px rgba(212,175,55,0.08)";
+                }}
+                onBlur={e => {
+                  e.currentTarget.style.borderColor = "rgba(255,255,255,0.15)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
               />
 
               <button

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -61,7 +61,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
 
   /* ─── Section label ─────────────────────────────────────────── */
   const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-    <p className="font-bebas text-[16px] text-white/70 uppercase tracking-[0.20em] mb-3 pl-1">{children}</p>
+    <p className="font-sans text-[11px] uppercase tracking-[0.2em] mb-3 pl-1" style={{ color: "rgba(255,255,255,0.40)" }}>{children}</p>
   );
 
   return (
@@ -76,14 +76,15 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
       {/* Bottom Sheet */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-[201] rounded-t-2xl max-h-[85vh] overflow-y-auto",
+          "fixed bottom-0 left-0 right-0 z-[201] max-h-[85vh] overflow-y-auto",
           "transition-transform duration-300 ease-out",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}
         style={{
           paddingBottom: "env(safe-area-inset-bottom)",
-          background: "#0A0A0A",
-          boxShadow: "0 -4px 60px rgba(212,175,55,0.12), 0 -2px 20px rgba(0,0,0,0.80)",
+          background: "#111111",
+          borderRadius: "8px 8px 0 0",
+          boxShadow: "0 -4px 60px rgba(212,175,55,0.08), 0 -2px 20px rgba(0,0,0,0.80)",
         }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
@@ -92,16 +93,17 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
         <div
           className="h-[1px] w-full"
           style={{
-            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.65) 30%, rgba(212,175,55,0.65) 70%, transparent 100%)",
+            background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.25) 30%, rgba(212,175,55,0.25) 70%, transparent 100%)",
           }}
         />
 
         {/* Drag handle + X close button */}
         <div className="relative flex justify-center pt-4 pb-6">
-          <div className="w-8 h-1 bg-white/15 rounded-full" />
+          <div className="w-8 h-1 rounded-full" style={{ background: "rgba(255,255,255,0.15)" }} />
           <button
             onClick={() => { haptics.light(); setIsOpen(false); }}
-            className="absolute top-3 right-4 w-9 h-9 flex items-center justify-center text-gold/60 hover:text-gold transition-colors"
+            className="absolute top-3 right-4 w-9 h-9 flex items-center justify-center transition-colors"
+            style={{ color: "rgba(255,255,255,0.40)" }}
             aria-label="Close menu"
           >
             <CloseIcon className="w-5 h-5" />
@@ -126,18 +128,17 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                     onClick={() => handleNavigate(item.path)}
                     className="relative flex flex-col items-center justify-center gap-2 py-5 border text-center group transition-all overflow-hidden"
                     style={{
-                      borderRadius: 12,
-                      borderColor: "rgba(255,255,255,0.10)",
-                      background: "rgba(255,255,255,0.03)",
+                      borderRadius: "6px",
+                      borderColor: "rgba(255,255,255,0.15)",
+                      background: "rgba(255,255,255,0.06)",
                     }}
                   >
                     <Icon
-                      className="w-5 h-5 transition-colors"
-                      style={{ color: "rgba(212,175,55,1)" }}
+                      className="w-5 h-5 transition-colors text-gold"
                     />
                     <span
                       className="font-bebas text-[18px] tracking-[0.12em] leading-none transition-colors"
-                      style={{ color: "rgba(255,255,255,0.85)" }}
+                      style={{ color: "rgba(255,255,255,0.70)" }}
                     >
                       {item.label}
                     </span>
@@ -148,17 +149,21 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           </div>
 
           {/* Contact + Share */}
-          <div className="pt-2 border-t border-white/[0.08] space-y-3">
+          <div className="pt-2 space-y-3" style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
             <SectionLabel>Contact & Share</SectionLabel>
             <div className="grid grid-cols-3 gap-2">
               <a
                 href="mailto:thefilmmaker.og@gmail.com"
                 onClick={() => haptics.light()}
-                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.03] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 12 }}
+                className="relative flex flex-col items-center gap-2 p-4 border text-center group transition-all overflow-hidden hover:bg-gold-subtle"
+                style={{
+                  borderRadius: "6px",
+                  borderColor: "rgba(255,255,255,0.15)",
+                  background: "rgba(255,255,255,0.06)",
+                }}
               >
-                <Mail className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-[15px] tracking-[0.08em] text-white/75 group-hover:text-white leading-none transition-colors">Email</span>
+                <Mail className="w-5 h-5 text-gold group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[15px] tracking-[0.08em] leading-none transition-colors" style={{ color: "rgba(255,255,255,0.70)" }}>Email</span>
               </a>
 
               <a
@@ -166,27 +171,35 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => haptics.light()}
-                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.03] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 12 }}
+                className="relative flex flex-col items-center gap-2 p-4 border text-center group transition-all overflow-hidden hover:bg-gold-subtle"
+                style={{
+                  borderRadius: "6px",
+                  borderColor: "rgba(255,255,255,0.15)",
+                  background: "rgba(255,255,255,0.06)",
+                }}
               >
-                <Instagram className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-[15px] tracking-[0.08em] text-white/75 group-hover:text-white leading-none transition-colors">Instagram</span>
+                <Instagram className="w-5 h-5 text-gold group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[15px] tracking-[0.08em] leading-none transition-colors" style={{ color: "rgba(255,255,255,0.70)" }}>Instagram</span>
               </a>
 
               <button
                 onClick={handleShare}
-                className="relative flex flex-col items-center gap-2 p-4 border border-white/[0.10] bg-white/[0.03] text-center group hover:border-gold/40 hover:bg-gold/[0.06] transition-all overflow-hidden"
-                style={{ borderRadius: 12 }}
+                className="relative flex flex-col items-center gap-2 p-4 border text-center group transition-all overflow-hidden hover:bg-gold-subtle"
+                style={{
+                  borderRadius: "6px",
+                  borderColor: "rgba(255,255,255,0.15)",
+                  background: "rgba(255,255,255,0.06)",
+                }}
               >
-                <Share2 className="w-5 h-5 text-gold/70 group-hover:text-gold transition-colors" />
-                <span className="font-bebas text-[15px] tracking-[0.08em] text-white/75 group-hover:text-white leading-none transition-colors">Share</span>
+                <Share2 className="w-5 h-5 text-gold group-hover:text-gold transition-colors" />
+                <span className="font-bebas text-[15px] tracking-[0.08em] leading-none transition-colors" style={{ color: "rgba(255,255,255,0.70)" }}>Share</span>
               </button>
             </div>
           </div>
 
-          {/* Legal disclaimer — replaces the old FILMMAKER.OG brand footer */}
-          <div className="pt-3 border-t border-white/[0.06]">
-            <p className="text-white/30 text-[11px] tracking-wide leading-relaxed text-center px-2">
+          {/* Legal disclaimer */}
+          <div className="pt-3" style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+            <p className="text-[11px] tracking-wide leading-relaxed" style={{ color: "rgba(255,255,255,0.40)" }}>
               For educational and informational purposes only. Not legal, tax, or investment advice.
               Consult a qualified entertainment attorney before making financing decisions.
             </p>

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -22,9 +22,9 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
         right: "20px",
         width: "44px",
         height: "44px",
-        borderRadius: "50%",
+        borderRadius: "8px",
         background: "#000000",
-        border: "1.5px solid rgba(255,255,255,0.12)",
+        border: "1px solid rgba(212,175,55,0.15)",
         boxShadow: "0 4px 20px rgba(0,0,0,0.80)",
       }}
       aria-label="Open OG assistant"
@@ -34,7 +34,7 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
         style={{
           width: "22px",
           height: "22px",
-          filter: "drop-shadow(0 0 4px rgba(212,175,55,0.30))",
+          filter: "drop-shadow(0 0 4px rgba(212,175,55,0.25))",
         }}
       />
     </button>

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -208,7 +208,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       {/* ── Bottom Sheet ── */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-[180] transition-transform duration-300 ease-out rounded-t-2xl",
+          "fixed bottom-0 left-0 right-0 z-[180] transition-transform duration-300 ease-out",
           "flex flex-col",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}
@@ -216,7 +216,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           height: "min(72vh, 580px)",
           paddingBottom: "calc(var(--bottom-bar-h) + env(safe-area-inset-bottom))",
           background: "#000000",
-          boxShadow: "0 -20px 60px rgba(212,175,55,0.18), 0 -40px 80px rgba(0,0,0,0.95)",
+          borderRadius: "8px 8px 0 0",
+          boxShadow: "0 -20px 60px rgba(212,175,55,0.08), 0 -40px 80px rgba(0,0,0,0.95)",
         }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
@@ -225,12 +226,12 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         <div
           className="absolute top-0 left-0 right-0 h-[1px] pointer-events-none z-10"
           style={{
-            background: "linear-gradient(to right, transparent 0%, rgba(212,175,55,0.60) 30%, rgba(212,175,55,0.80) 50%, rgba(212,175,55,0.60) 70%, transparent 100%)",
-            borderRadius: "16px 16px 0 0",
+            background: "linear-gradient(to right, transparent 0%, rgba(212,175,55,0.25) 30%, rgba(212,175,55,0.25) 70%, transparent 100%)",
+            borderRadius: "8px 8px 0 0",
           }}
         />
 
-        {/* Drag handle — neutral white, standard iOS affordance */}
+        {/* Drag handle */}
         <div className="flex justify-center pt-3 pb-1 flex-shrink-0">
           <div className="w-10 h-[3px] rounded-full" style={{ background: "rgba(255,255,255,0.15)" }} />
         </div>
@@ -238,10 +239,10 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* ── Sheet header ── */}
         <div
           className="px-5 pt-3 pb-4 flex-shrink-0 border-b"
-          style={{ borderColor: "rgba(212,175,55,0.18)" }}
+          style={{ borderColor: "rgba(212,175,55,0.15)" }}
         >
           <div className="flex items-end justify-between">
-            <h2 className="font-bebas text-[28px] tracking-[0.15em] leading-none" style={{ color: "rgba(212,175,55,1)" }}>
+            <h2 className="font-bebas text-[28px] tracking-[0.15em] leading-none text-gold">
               ASK THE OG
             </h2>
             <div className="flex items-center gap-3 pb-0.5">
@@ -249,9 +250,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 <button
                   onClick={handleReset}
                   className="flex items-center gap-1.5 font-bebas text-[11px] uppercase tracking-[0.15em] transition-colors tabular-nums"
-                  style={{ color: "rgba(255,255,255,0.30)" }}
-                  onMouseEnter={e => (e.currentTarget.style.color = "rgba(212,175,55,0.70)")}
-                  onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.30)")}
+                  style={{ color: "rgba(255,255,255,0.40)" }}
+                  onMouseEnter={e => (e.currentTarget.style.color = "rgba(212,175,55,0.25)")}
+                  onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.40)")}
                 >
                   <RotateCcw className="w-3 h-3" />
                   Reset
@@ -260,9 +261,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
               <button
                 onClick={() => setIsOpen(false)}
                 className="transition-colors p-1"
-                style={{ color: "rgba(255,255,255,0.35)" }}
+                style={{ color: "rgba(255,255,255,0.40)" }}
                 onMouseEnter={e => (e.currentTarget.style.color = "rgba(255,255,255,0.70)")}
-                onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.35)")}
+                onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.40)")}
               >
                 <X className="w-4 h-4" />
               </button>
@@ -275,7 +276,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           {/* Empty state — example chips with eyebrow */}
           {ogMessages.length === 0 && (
             <div className="flex flex-col items-center gap-5 pt-3">
-              <span className="font-bebas text-[20px] tracking-[0.16em] uppercase" style={{ color: "rgba(212,175,55,0.60)" }}>
+              <span className="font-bebas text-[20px] tracking-[0.16em] uppercase" style={{ color: "rgba(255,255,255,0.40)" }}>
                 What do you want to know
               </span>
 
@@ -288,28 +289,28 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     disabled={ogLoading}
                     className="font-bebas text-[15px] tracking-[0.10em] px-5 py-3 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
                     onMouseEnter={e => {
-                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
-                      e.currentTarget.style.background = "rgba(212,175,55,0.14)";
-                      e.currentTarget.style.color = "rgba(255,255,255,1)";
+                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.25)";
+                      e.currentTarget.style.background = "rgba(212,175,55,0.08)";
+                      e.currentTarget.style.color = "#FFFFFF";
                     }}
                     onMouseLeave={e => {
-                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)";
-                      e.currentTarget.style.background = "rgba(212,175,55,0.08)";
-                      e.currentTarget.style.color = "rgba(255,255,255,0.80)";
+                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.15)";
+                      e.currentTarget.style.background = "rgba(212,175,55,0.03)";
+                      e.currentTarget.style.color = "rgba(255,255,255,0.70)";
                     }}
                     onTouchStart={e => {
-                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)";
-                      e.currentTarget.style.background = "rgba(212,175,55,0.14)";
-                    }}
-                    onTouchEnd={e => {
-                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)";
+                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.25)";
                       e.currentTarget.style.background = "rgba(212,175,55,0.08)";
                     }}
+                    onTouchEnd={e => {
+                      e.currentTarget.style.borderColor = "rgba(212,175,55,0.15)";
+                      e.currentTarget.style.background = "rgba(212,175,55,0.03)";
+                    }}
                     style={{
-                      borderRadius: "10px",
-                      borderColor: "rgba(212,175,55,0.30)",
-                      background: "rgba(212,175,55,0.08)",
-                      color: "rgba(255,255,255,0.80)",
+                      borderRadius: "4px",
+                      borderColor: "rgba(212,175,55,0.15)",
+                      background: "rgba(212,175,55,0.03)",
+                      color: "rgba(255,255,255,0.70)",
                     }}
                   >
                     {chip}
@@ -327,9 +328,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 <div
                   className="relative max-w-[85%] px-4 py-3 border overflow-hidden"
                   style={{
-                    borderRadius: "12px",
-                    background: "rgba(255,255,255,0.04)",
-                    borderColor: "rgba(212,175,55,0.20)",
+                    borderRadius: "6px",
+                    background: "rgba(255,255,255,0.06)",
+                    borderColor: "rgba(212,175,55,0.15)",
                   }}
                 >
                   <p className="text-base text-white leading-relaxed">{msg.question}</p>
@@ -341,7 +342,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 <div
                   className="max-w-[95%] border overflow-hidden"
                   style={{
-                    borderRadius: "12px",
+                    borderRadius: "6px",
                     background: "#000000",
                     borderColor: "rgba(212,175,55,0.15)",
                     boxShadow: "0 0 30px rgba(212,175,55,0.08)",
@@ -352,17 +353,17 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     {/* Inline attribution header */}
                     <div className="flex items-center gap-2 mb-3">
                       <img src={filmmakerFIcon} alt="OG" className="w-4 h-4 object-contain" />
-                      <span className="font-bebas text-[14px] tracking-[0.14em] leading-none" style={{ color: "rgba(212,175,55,1)" }}>OG</span>
+                      <span className="font-bebas text-[14px] tracking-[0.14em] leading-none text-gold">OG</span>
                       {msg.streaming && (
                         <div className="flex gap-1 ml-1">
-                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "0ms" }} />
-                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "150ms" }} />
-                          <div className="w-1.5 h-1.5 rounded-full bg-gold/50 animate-bounce" style={{ animationDelay: "300ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(212,175,55,0.25)", animationDelay: "0ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(212,175,55,0.25)", animationDelay: "150ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(212,175,55,0.25)", animationDelay: "300ms" }} />
                         </div>
                       )}
                     </div>
                     {msg.error ? (
-                      <p className="text-[15px] leading-relaxed" style={{ color: "rgba(212,175,55,0.60)" }}>{msg.error}</p>
+                      <p className="text-[15px] leading-relaxed" style={{ color: "rgba(255,255,255,0.40)" }}>{msg.error}</p>
                     ) : (
                       <p className="text-base text-white leading-[1.8] whitespace-pre-wrap">
                         {msg.answer}
@@ -382,17 +383,17 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* Input area */}
         <div
           className="px-4 pb-3 pt-3 flex-shrink-0 border-t"
-          style={{ borderColor: "rgba(212,175,55,0.20)", background: "#000000" }}
+          style={{ borderColor: "rgba(212,175,55,0.15)", background: "#000000" }}
         >
           <form onSubmit={handleOgSubmit}>
             <div
-              className="flex gap-0 border transition-colors"
+              className="flex gap-0 transition-colors"
               style={{
-                borderRadius: "12px",
-                border: "1px solid rgba(212,175,55,0.30)",
+                borderRadius: "6px",
+                border: "1px solid rgba(212,175,55,0.15)",
               }}
-              onFocus={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.60)")}
-              onBlur={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.30)")}
+              onFocus={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.25)")}
+              onBlur={e => (e.currentTarget.style.borderColor = "rgba(212,175,55,0.15)")}
             >
               <textarea
                 ref={inputRef}
@@ -406,7 +407,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 disabled={ogLoading}
                 className="flex-1 px-4 py-3 focus:outline-none text-base text-white resize-none disabled:opacity-50 min-h-[52px]"
                 style={{
-                  borderRadius: "12px 0 0 12px",
+                  borderRadius: "6px 0 0 6px",
                   background: "transparent",
                   color: "#FFFFFF",
                 }}
@@ -415,11 +416,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   type="submit"
                   disabled={!ogInput.trim() || ogLoading}
                   className="px-5 font-bebas tracking-wider transition-all flex items-center gap-2 flex-shrink-0 disabled:opacity-30 disabled:cursor-not-allowed"
-                  onMouseEnter={e => !e.currentTarget.disabled && (e.currentTarget.style.background = "rgba(212,175,55,0.80)")}
-                  onMouseLeave={e => (e.currentTarget.style.background = "rgba(212,175,55,1)")}
-                  onTouchStart={e => !e.currentTarget.disabled && (e.currentTarget.style.background = "rgba(212,175,55,0.80)")}
-                  onTouchEnd={e => (e.currentTarget.style.background = "rgba(212,175,55,1)")}
-                  style={{ background: "rgba(212,175,55,1)", color: "#000", borderRadius: "0 11px 11px 0" }}
+                  onMouseEnter={e => !e.currentTarget.disabled && (e.currentTarget.style.opacity = "0.8")}
+                  onMouseLeave={e => (e.currentTarget.style.opacity = "1")}
+                  style={{ background: "#D4AF37", color: "#000", borderRadius: "0 5px 5px 0" }}
                 >
                 <SendHorizonal className="w-4 h-4" />
               </button>
@@ -427,7 +426,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
             <div className="flex items-center justify-end mt-1.5 px-1">
               <span className={cn(
                 "text-[10px] tabular-nums",
-                ogInput.length > 1350 ? "text-gold/60" : "text-white/25"
+                ogInput.length > 1350 ? "text-gold" : "text-ink-secondary"
               )}>
                 {ogInput.length}/1500
               </span>

--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -63,10 +63,17 @@ const WaterfallCascade = () => {
   return (
     <div ref={containerRef} className="pt-4 pb-5">
       {/* Ledger card */}
-      <div className="border border-gold/[0.12] bg-black overflow-hidden rounded-xl">
+      <div
+        className="overflow-hidden"
+        style={{
+          border: "1px solid rgba(212,175,55,0.15)",
+          borderRadius: "6px",
+          background: "#000000",
+        }}
+      >
         {/* Source row */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
-          <span className="font-bebas text-[22px] tracking-[0.06em] text-gold-label">
+          <span className="font-bebas text-[22px] tracking-[0.06em]" style={{ color: "rgba(255,255,255,0.70)" }}>
             Acquisition Price
           </span>
           <span className="font-mono text-[17px] font-semibold text-gold tabular-nums">
@@ -79,7 +86,7 @@ const WaterfallCascade = () => {
           className="mx-5 h-[1px]"
           style={{
             background:
-              "linear-gradient(90deg, rgba(212,175,55,0.30), rgba(212,175,55,0.08))",
+              "linear-gradient(90deg, rgba(212,175,55,0.25), rgba(212,175,55,0.08))",
             opacity: revealed ? 1 : 0,
             transition: "opacity 600ms ease-out",
           }}
@@ -93,10 +100,11 @@ const WaterfallCascade = () => {
             return (
               <div
                 key={d.name}
-                className="flex justify-between items-baseline rounded-md"
+                className="flex justify-between items-baseline"
                 style={{
                   padding: "9px 8px",
                   margin: "0 -8px",
+                  borderRadius: "4px",
                   background: isEven ? "rgba(212,175,55,0.03)" : "transparent",
                   opacity: revealed ? 1 : 0,
                   transform: revealed ? "translateY(0)" : "translateY(6px)",
@@ -119,17 +127,18 @@ const WaterfallCascade = () => {
 
       {/* Profit box */}
       <div
-        className="mt-2 rounded-[10px] py-5 bg-black text-center"
+        className="mt-2 py-5 bg-black text-center"
         style={{
-          border: "2px solid rgba(212,175,55,0.60)",
-          boxShadow: "0 0 16px 0px rgba(212,175,55,0.10), inset 0 1px 0 rgba(212,175,55,0.08)",
+          border: "1px solid rgba(212,175,55,0.25)",
+          borderRadius: "6px",
+          boxShadow: "0 0 16px rgba(212,175,55,0.08)",
           opacity: revealed ? 1 : 0,
           transform: revealed ? "translateY(0)" : "translateY(8px)",
           transition: "opacity 600ms ease-out, transform 600ms ease-out",
           transitionDelay: "1400ms",
         }}
       >
-        <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
+        <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold mb-1" style={{ color: "rgba(255,255,255,0.70)" }}>
           Net Profits
         </p>
         <span className="font-mono text-[32px] font-bold text-gold tracking-tight tabular-nums">
@@ -145,8 +154,10 @@ const WaterfallCascade = () => {
         ].map((c) => (
           <div
             key={c.label}
-            className="border border-gold/[0.15] px-3.5 py-3.5 text-center rounded-lg"
+            className="px-3.5 py-3.5 text-center"
             style={{
+              border: "1px solid rgba(212,175,55,0.15)",
+              borderRadius: "6px",
               background: "rgba(212,175,55,0.03)",
               opacity: corridorVisible ? 1 : 0,
               transform: corridorVisible
@@ -156,7 +167,7 @@ const WaterfallCascade = () => {
               transitionDelay: `${c.extraDelay}ms`,
             }}
           >
-            <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold text-gold-label mb-1">
+            <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold mb-1" style={{ color: "rgba(255,255,255,0.70)" }}>
               {c.label}
             </p>
             <span className="font-mono text-[24px] font-bold text-gold tabular-nums">
@@ -166,7 +177,7 @@ const WaterfallCascade = () => {
         ))}
       </div>
 
-      <p className="font-mono text-[12px] text-ink-ghost text-center mt-3.5">
+      <p className="font-mono text-[12px] text-ink-secondary text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Sans:wght@400;500;600&family=Roboto+Mono:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;600&family=Roboto+Mono:wght@500&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -57,43 +57,59 @@
 @layer base {
   :root {
     /* ═══════════════════════════════════════════════════════════════════
-       BACKGROUND LAYERS
-       Rule: Content always lives on --bg-card, never directly on --bg-void
+       BACKGROUND LAYERS — Brand spec: #000, #111, #1A1A1A only
        ═══════════════════════════════════════════════════════════════════ */
     --bg-void: #000000;
-    --bg-card: #141414;
-    --bg-surface: #111111;
-    --bg-elevated: #0D0D0D;
-    --bg-header: #0A0A0A;
+    --bg-elevated: #111111;
+    --bg-surface: #1A1A1A;
 
     /* ═══════════════════════════════════════════════════════════════════
        TWO-GOLD SYSTEM
        Rule: If it's not clickable, it's NOT --gold-cta.
+
+       Gold opacities — ONLY these 4:
+         strong  0.25  — active borders, hover states
+         medium  0.15  — card borders, section dividers
+         subtle  0.08  — background tints, hover fills
+         ghost   0.03  — ambient glow, large area tints
        ═══════════════════════════════════════════════════════════════════ */
 
-    /* Metallic Gold — non-interactive brand elements (8 tiers, no drift) */
+    /* Metallic Gold — non-interactive brand elements */
     --gold: #D4AF37;
-    --gold-label: rgba(212, 175, 55, 0.72);
-    --gold-muted: rgba(212, 175, 55, 0.45);
-    --gold-glow: rgba(212, 175, 55, 0.25);
-    --gold-ghost: rgba(212, 175, 55, 0.15);
-    --gold-subtle: rgba(212, 175, 55, 0.10);
-    --gold-ambient: rgba(212, 175, 55, 0.06);
+    --gold-strong: rgba(212, 175, 55, 0.25);
+    --gold-medium: rgba(212, 175, 55, 0.15);
+    --gold-subtle: rgba(212, 175, 55, 0.08);
+    --gold-ghost: rgba(212, 175, 55, 0.03);
+    --gold-deep: #7A5C12;
 
     /* CTA Gold — buttons, links, interactive CTAs ONLY */
     --gold-cta: #F9E076;
-    --gold-cta-muted: rgba(249, 224, 118, 0.45);
-    --gold-cta-subtle: rgba(249, 224, 118, 0.12);
 
-    /* TEXT HIERARCHY */
+    /* Legacy aliases — map old tokens to new spec for non-landing pages */
+    --bg-card: #111111;
+    --bg-header: #000000;
+    --gold-label: rgba(212, 175, 55, 0.25);
+    --gold-muted: rgba(212, 175, 55, 0.15);
+    --gold-glow: rgba(212, 175, 55, 0.25);
+    --gold-ambient: rgba(212, 175, 55, 0.03);
+    --text-mid: rgba(255, 255, 255, 0.70);
+    --text-dim: rgba(255, 255, 255, 0.40);
+
+    /* ═══════════════════════════════════════════════════════════════════
+       TEXT / WHITE HIERARCHY — ONLY these 4:
+         strong  0.70  — secondary text
+         medium  0.40  — tertiary text, borders
+         subtle  0.15  — dividers, faint borders
+         ghost   0.06  — hover backgrounds, surface tints
+       ═══════════════════════════════════════════════════════════════════ */
     --text-primary: #FFFFFF;
-    --text-mid: #D4D4D4;  /* INCREASED FROM #CFCFCF for legibility */
-    --text-dim: #999999;  /* INCREASED FROM #8A8A8A for legibility */
+    --text-secondary: rgba(255, 255, 255, 0.70);
+    --text-tertiary: rgba(255, 255, 255, 0.40);
 
     /* BORDERS */
-    --border-default: rgba(212, 175, 55, 0.20);
-    --border-subtle: #2A2A2A; /* INCREASED FROM #1A1A1A for visibility */
-    --border-active: rgba(212, 175, 55, 0.50);
+    --border-default: rgba(212, 175, 55, 0.15);
+    --border-subtle: rgba(255, 255, 255, 0.15);
+    --border-active: rgba(212, 175, 55, 0.25);
 
     /* SPACING (Base unit: 4px) */
     --space-xs: 4px;
@@ -103,19 +119,18 @@
     --space-xl: 24px;
     --space-2xl: 32px;
 
-    /* BORDER RADIUS */
+    /* BORDER RADIUS — 8px absolute max, 4-6px typical */
     --radius-none: 0px;
-    --radius-sm: 8px;
-    --radius-md: 12px;
-    --radius-lg: 14px;
-    --radius-xl: 18px;
+    --radius-sm: 4px;
+    --radius-md: 6px;
+    --radius-lg: 8px;
     --radius-full: 999px;
 
     /* SHADOWS & ELEVATION */
     --shadow-none: none;
-    --shadow-focus: 0 0 0 1px rgba(212, 175, 55, 0.16);
-    --shadow-card-active: 0 0 20px rgba(212, 175, 55, 0.08);
-    --shadow-button: 0 10px 26px rgba(249, 224, 118, 0.15);
+    --shadow-focus: 0 0 0 1px var(--gold-medium);
+    --shadow-card-active: 0 0 20px var(--gold-subtle);
+    --shadow-button: 0 10px 26px var(--gold-medium);
     --shadow-modal: 0 20px 50px rgba(0, 0, 0, 0.8);
 
     /* LAYOUT */
@@ -143,23 +158,23 @@
     --primary-foreground: 0 0% 0%;
     --secondary: 0 0% 7%;
     --secondary-foreground: 0 0% 100%;
-    --muted: 0 0% 8%;
-    --muted-foreground: 0 0% 54%;
+    --muted: 0 0% 7%;
+    --muted-foreground: 0 0% 40%;
     --accent: 45 74% 41%;
     --accent-foreground: 0 0% 0%;
-    --destructive: 0 0% 54%;            /* Gold-only: dim for destructive */
+    --destructive: 0 0% 40%;
     --destructive-foreground: 0 0% 100%;
-    --border: 0 0% 10%;
-    --input: 0 0% 7%;
+    --border: 0 0% 15%;
+    --input: 0 0% 10%;
     --ring: 45 74% 41%;
-    --radius: 14px;
+    --radius: 6px;
   }
 
   /* Force true black + base font */
   html, body {
     background-color: #000000;
     color: #FFFFFF;
-    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
     /* Suppress iOS pull-to-refresh and bounce scroll */
     overscroll-behavior: none;
   }
@@ -242,16 +257,16 @@
      Matches Wiki Style: bg-elevated, border-gold-muted, shadow-gold-glow
      ═══════════════════════════════════════════════════════════════════ */
   .chapter-card {
-    background: var(--bg-card);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
+    border: 1px solid var(--gold-medium);
+    border-radius: var(--radius-md);
     overflow: hidden;
     min-height: auto;
     position: relative;
   }
 
   .chapter-card.is-active {
-    border-color: rgba(255, 255, 255, 0.06);
+    border-color: var(--gold-strong);
   }
 
   .chapter-card-header {
@@ -259,7 +274,7 @@
     grid-template-columns: 3px 52px 1fr auto;
     align-items: center;
     height: 52px;
-    background: var(--bg-elevated);
+    background: var(--bg-void);
     border-bottom: 1px solid var(--border-subtle);
   }
 
@@ -267,8 +282,8 @@
   .chapter-card-gold-bar {
     width: 3px;
     height: 100%;
-    background: linear-gradient(180deg, var(--gold) 0%, var(--gold-label) 60%, var(--border-default) 100%);
-    box-shadow: 0 0 16px rgba(212, 175, 55, 0.30);
+    background: linear-gradient(180deg, var(--gold) 0%, var(--gold-strong) 100%);
+    box-shadow: 0 0 16px var(--gold-subtle);
   }
 
   .chapter-card-number {
@@ -295,22 +310,22 @@
 
   .chapter-card-body {
     padding: var(--space-lg);
-    background: var(--bg-elevated);
+    background: var(--bg-void);
   }
 
   /* ═══════════════════════════════════════════════════════════════════
      GLASS CARDS
      ═══════════════════════════════════════════════════════════════════ */
   .glass-card {
-    background: var(--bg-card);
+    background: var(--bg-elevated);
     border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-md);
   }
 
   .glass-card-gold {
-    background: linear-gradient(180deg, var(--gold-subtle) 0%, rgba(212, 175, 55, 0.02) 100%);
-    border: 1px solid var(--gold-muted);
-    border-radius: var(--radius-lg);
+    background: linear-gradient(180deg, var(--gold-subtle) 0%, var(--gold-ghost) 100%);
+    border: 1px solid var(--gold-medium);
+    border-radius: var(--radius-md);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
   }
@@ -324,27 +339,27 @@
      STORE-SPECIFIC STYLES
      ═══════════════════════════════════════════════════════════════════ */
   .store-card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg);
+    background: var(--bg-elevated);
+    border: 1px solid var(--gold-medium);
+    border-radius: var(--radius-md);
     padding: var(--space-xl) var(--space-lg);
     position: relative;
     transition: border-color var(--timing-medium) ease, box-shadow var(--timing-medium) ease;
   }
 
   .store-card:hover {
-    border-color: var(--gold-ghost);
+    border-color: var(--gold-strong);
   }
 
   .store-card-featured {
-    background: linear-gradient(180deg, var(--gold-ambient) 0%, var(--bg-card) 40%);
-    border: 1.5px solid var(--gold-muted);
-    box-shadow: 0 0 40px rgba(212, 175, 55, 0.08), inset 0 1px 0 var(--gold-subtle);
+    background: linear-gradient(180deg, var(--gold-ghost) 0%, var(--bg-elevated) 40%);
+    border: 1px solid var(--gold-strong);
+    box-shadow: 0 0 40px var(--gold-subtle), inset 0 1px 0 var(--gold-subtle);
   }
 
   .store-card-featured:hover {
     border-color: var(--gold);
-    box-shadow: 0 0 50px rgba(212, 175, 55, 0.12), inset 0 1px 0 var(--gold-ghost);
+    box-shadow: 0 0 50px var(--gold-subtle), inset 0 1px 0 var(--gold-medium);
   }
 
   .store-compare-table {
@@ -366,28 +381,28 @@
   }
 
   .store-compare-table th.featured-col {
-    background: var(--gold-ambient);
-    border-bottom: 1px solid rgba(212, 175, 55, 0.3);
+    background: var(--gold-ghost);
+    border-bottom: 1px solid var(--gold-strong);
   }
 
   .store-compare-table td {
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 12px;
-    color: var(--text-mid);
+    color: var(--text-secondary);
     padding: 10px;
     text-align: center;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   }
 
   .store-compare-table td:first-child {
     text-align: left;
-    color: var(--text-dim);
+    color: var(--text-tertiary);
     font-size: 11px;
     min-width: 160px;
   }
 
   .store-compare-table td.featured-col {
-    background: rgba(212, 175, 55, 0.03);
+    background: var(--gold-ghost);
   }
 
   .store-compare-table tr:last-child td {
@@ -399,16 +414,14 @@
      ═══════════════════════════════════════════════════════════════════ */
   .premium-divider {
     height: 1px;
-    background: linear-gradient(90deg, transparent 0%, var(--gold) 50%, transparent 100%);
-    opacity: 0.3;
+    background: linear-gradient(90deg, transparent 0%, var(--gold-medium) 50%, transparent 100%);
   }
 
   .gold-section-divider {
     height: 1px;
     max-width: 120px;
     margin: 0 auto;
-    background: linear-gradient(90deg, transparent 0%, var(--gold) 50%, transparent 100%);
-    opacity: 0.35;
+    background: linear-gradient(90deg, transparent 0%, var(--gold-medium) 50%, transparent 100%);
   }
 
   /* ═══════════════════════════════════════════════════════════════════
@@ -422,7 +435,7 @@
     height: var(--tabbar-h);
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    background: var(--bg-header);
+    background: var(--bg-void);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
     border-top: 1px solid var(--border-subtle);
@@ -437,12 +450,12 @@
     justify-content: center;
     gap: var(--space-xs);
     padding: var(--space-sm) 0;
-    font-family: 'DM Sans', sans-serif;
-    font-size: 10px;
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: var(--text-dim);
+    color: var(--text-tertiary);
     transition: all var(--timing-fast) ease;
     cursor: pointer;
     border-radius: var(--radius-sm);
@@ -454,7 +467,7 @@
 
   .tab-bar-item.is-active {
     color: var(--gold-cta);
-    background: var(--gold-cta-subtle);
+    background: var(--gold-subtle);
   }
 
   .tab-bar-item .tab-icon {
@@ -476,13 +489,13 @@
     justify-content: center;
     width: 28px;
     height: 28px;
-    border: 1.5px solid rgba(212, 175, 55, 0.3);
+    border: 1px solid var(--gold-medium);
     border-radius: var(--radius-full);
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 11px;
     font-weight: 600;
-    color: rgba(212, 175, 55, 0.7);
-    background: var(--gold-ambient);
+    color: var(--text-secondary);
+    background: var(--gold-ghost);
     cursor: pointer;
     transition: all var(--timing-fast) ease;
   }
@@ -490,7 +503,7 @@
   .glossary-trigger:hover,
   .glossary-trigger:active {
     background: var(--gold-subtle);
-    border-color: var(--gold);
+    border-color: var(--gold-strong);
     color: var(--gold);
   }
 
@@ -506,7 +519,7 @@
   .input-field {
     background: var(--bg-surface);
     border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     padding: var(--space-md);
     font-family: 'Roboto Mono', monospace;
     font-size: 22px;
@@ -519,13 +532,13 @@
 
   .input-field:focus {
     outline: none;
-    border-color: var(--border-active);
-    background: rgba(212, 175, 55, 0.04);
+    border-color: var(--gold);
+    background: var(--gold-ghost);
     box-shadow: var(--shadow-focus);
   }
 
   .input-field::placeholder {
-    color: var(--text-dim);
+    color: var(--text-tertiary);
   }
 
   /* ═══════════════════════════════════════════════════════════════════
@@ -536,12 +549,12 @@
     align-items: center;
     justify-content: space-between;
     margin-bottom: var(--space-sm);
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: var(--text-dim);
+    color: var(--text-tertiary);
   }
 
   /* ═══════════════════════════════════════════════════════════════════
@@ -603,8 +616,8 @@
   }
 
   @keyframes borderGlow {
-    0%, 100% { border-color: rgba(212, 175, 55, 0.3); }
-    50% { border-color: rgba(212, 175, 55, 0.7); }
+    0%, 100% { border-color: var(--gold-strong); }
+    50% { border-color: var(--gold); }
   }
 
   .animate-shimmer {
@@ -686,51 +699,29 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(165deg, #FFE8A0 0%, #F9E076 25%, #D4AF37 80%, #B8962E 100%);
-    border: 1px solid rgba(255, 232, 160, 0.40);
+    background: var(--gold-cta);
+    border: none;
     color: #000000;
     font-family: 'Bebas Neue', sans-serif;
     font-size: 22px;
     font-weight: 400;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     transition: all 180ms cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow:
-      0 4px 20px rgba(212, 175, 55, 0.35),
-      0 8px 40px rgba(212, 175, 55, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    box-shadow: 0 4px 20px var(--gold-strong);
     position: relative;
     overflow: hidden;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.10);
   }
   @media (hover: hover) {
-    .btn-cta-primary::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -100%;
-      width: 60%;
-      height: 100%;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.20), transparent);
-      transition: left 0.6s ease;
-    }
-    .btn-cta-primary:hover::before {
-      left: 120%;
-    }
     .btn-cta-primary:hover {
-      background: linear-gradient(165deg, #FFF0C0 0%, #FFE8A0 25%, #D4AF37 80%, #C4A030 100%);
-      box-shadow:
-        0 6px 28px rgba(212, 175, 55, 0.45),
-        0 12px 48px rgba(212, 175, 55, 0.20),
-        inset 0 1px 0 rgba(255, 255, 255, 0.30);
+      opacity: 0.9;
+      box-shadow: 0 6px 28px var(--gold-strong);
     }
   }
   .btn-cta-primary:active {
     transform: translateY(1px) scale(0.98);
-    box-shadow:
-      0 2px 12px rgba(212, 175, 55, 0.30),
-      inset 0 1px 0 rgba(255, 255, 255, 0.20);
+    box-shadow: 0 2px 12px var(--gold-medium);
   }
   .btn-cta-primary:disabled {
     opacity: 0.3;
@@ -742,18 +733,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--gold-ambient);
-    border: 1px solid rgba(212, 175, 55, 0.30);
+    background: transparent;
+    border: 1px solid var(--gold-medium);
     color: var(--gold);
     font-family: 'Bebas Neue', sans-serif;
     font-weight: 400;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     transition: all 180ms cubic-bezier(0.22, 1, 0.36, 1);
   }
   .btn-cta-secondary:hover {
-    border-color: var(--border-active);
+    border-color: var(--gold-strong);
     background: var(--gold-subtle);
   }
   .btn-cta-secondary:active {
@@ -810,9 +801,9 @@
 
 
   @keyframes glow-pulse {
-    0%   { box-shadow: 0 0 0 rgba(212,175,55,0); }
-    40%  { box-shadow: 0 0 16px rgba(212,175,55,0.15); }
-    100% { box-shadow: 0 0 0 rgba(212,175,55,0); }
+    0%   { box-shadow: 0 0 0 transparent; }
+    40%  { box-shadow: 0 0 16px var(--gold-medium); }
+    100% { box-shadow: 0 0 0 transparent; }
   }
   .animate-glow-pulse {
     animation: glow-pulse 600ms ease-out forwards;
@@ -841,7 +832,7 @@
      TAP RIPPLE — gold radial pulse for BottomTabBar
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes tap-ripple {
-    0%   { transform: translate(-50%, -50%) scale(0); opacity: 0.4; }
+    0%   { transform: translate(-50%, -50%) scale(0); opacity: 0.25; }
     100% { transform: translate(-50%, -50%) scale(1); opacity: 0; }
   }
   .animate-tap-ripple {
@@ -863,8 +854,8 @@
      PULSE GOLD — subtle active glow breathing
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes pulse-gold {
-    0%, 100% { box-shadow: 0 0 20px rgba(212,175,55,0.15); }
-    50%      { box-shadow: 0 0 30px rgba(212,175,55,0.30); }
+    0%, 100% { box-shadow: 0 0 20px var(--gold-medium); }
+    50%      { box-shadow: 0 0 30px var(--gold-strong); }
   }
   .animate-pulse-gold {
     animation: pulse-gold 3s ease-in-out infinite;
@@ -875,16 +866,10 @@
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes cta-glow-pulse {
     0%, 100% {
-      box-shadow:
-        0 4px 20px rgba(212,175,55,0.35),
-        0 8px 40px rgba(212,175,55,0.15),
-        inset 0 1px 0 rgba(255,255,255,0.25);
+      box-shadow: 0 4px 20px var(--gold-strong);
     }
     50% {
-      box-shadow:
-        0 4px 24px rgba(212,175,55,0.50),
-        0 8px 48px rgba(212,175,55,0.25),
-        inset 0 1px 0 rgba(255,255,255,0.25);
+      box-shadow: 0 4px 24px var(--gold-strong), 0 8px 48px var(--gold-medium);
     }
   }
   .animate-cta-glow-pulse {

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -8,77 +8,87 @@
  * TWO-GOLD SYSTEM:
  *   Metallic Gold #D4AF37 — borders, icons, dividers, brand elements (non-interactive)
  *   CTA Gold #F9E076 — EXCLUSIVELY for clickable elements (buttons, links, CTAs)
+ *
+ * GOLD OPACITIES — ONLY THESE 4:
+ *   strong  rgba(212,175,55,0.25) — active borders, hover states
+ *   medium  rgba(212,175,55,0.15) — card borders, section dividers
+ *   subtle  rgba(212,175,55,0.08) — background tints, hover fills
+ *   ghost   rgba(212,175,55,0.03) — ambient glow, large area tints
+ *
+ * WHITE OPACITIES — ONLY THESE 4:
+ *   strong  rgba(255,255,255,0.70) — secondary text
+ *   medium  rgba(255,255,255,0.40) — tertiary text, borders
+ *   subtle  rgba(255,255,255,0.15) — dividers, faint borders
+ *   ghost   rgba(255,255,255,0.06) — hover backgrounds, surface tints
  */
 
-// ===== COLOR PALETTE (matches index.css exactly) =====
+// ===== COLOR PALETTE =====
 export const colors = {
-  // Backgrounds (layered system)
-  void: '#000000',           // --bg-void
-  card: '#141414',           // --bg-card
-  surface: '#111111',        // --bg-surface
-  elevated: '#0D0D0D',       // --bg-elevated
-  header: '#0A0A0A',         // --bg-header
+  // Backgrounds — #000, #111, #1A1A1A only
+  void: '#000000',
+  elevated: '#111111',
+  surface: '#1A1A1A',
 
   // Borders
-  borderDefault: 'rgba(212, 175, 55, 0.20)',  // --border-default (metallic gold 20%)
-  borderSubtle: '#2A2A2A',                     // --border-subtle
-  borderActive: 'rgba(212, 175, 55, 0.50)',    // --border-active
+  borderDefault: 'rgba(212, 175, 55, 0.15)',   // gold-medium
+  borderSubtle: 'rgba(255, 255, 255, 0.15)',    // white-subtle
+  borderActive: 'rgba(212, 175, 55, 0.25)',     // gold-strong
 
-  // Gold palette — Metallic (non-interactive brand elements, 8 tiers)
-  gold: '#D4AF37',                             // --gold (metallic)
-  goldLabel: 'rgba(212, 175, 55, 0.60)',       // --gold-label
-  goldMuted: 'rgba(212, 175, 55, 0.45)',       // --gold-muted
-  goldGlow: 'rgba(212, 175, 55, 0.25)',        // --gold-glow
-  goldGhost: 'rgba(212, 175, 55, 0.15)',       // --gold-ghost
-  goldSubtle: 'rgba(212, 175, 55, 0.10)',      // --gold-subtle
-  goldAmbient: 'rgba(212, 175, 55, 0.06)',     // --gold-ambient
+  // Gold palette — 4 opacity tiers only
+  gold: '#D4AF37',
+  goldStrong: 'rgba(212, 175, 55, 0.25)',
+  goldMedium: 'rgba(212, 175, 55, 0.15)',
+  goldSubtle: 'rgba(212, 175, 55, 0.08)',
+  goldGhost: 'rgba(212, 175, 55, 0.03)',
+  goldDeep: '#7A5C12',
 
   // CTA Gold — EXCLUSIVELY for clickable elements
-  goldCta: '#F9E076',                          // --gold-cta (bright, warm)
-  goldCtaMuted: 'rgba(249, 224, 118, 0.45)',   // --gold-cta-muted
-  goldCtaSubtle: 'rgba(249, 224, 118, 0.12)',  // --gold-cta-subtle
+  goldCta: '#F9E076',
 
-  // Text hierarchy
-  textPrimary: '#FFFFFF',    // --text-primary
-  textMid: '#D4D4D4',        // --text-mid
-  textDim: '#999999',        // --text-dim
+  // Text hierarchy — 4 tiers only
+  textPrimary: '#FFFFFF',
+  textSecondary: 'rgba(255, 255, 255, 0.70)',
+  textTertiary: 'rgba(255, 255, 255, 0.40)',
+  textGhost: 'rgba(255, 255, 255, 0.06)',
+
+  // White opacity helpers
+  whiteStrong: 'rgba(255, 255, 255, 0.70)',
+  whiteMedium: 'rgba(255, 255, 255, 0.40)',
+  whiteSubtle: 'rgba(255, 255, 255, 0.15)',
+  whiteGhost: 'rgba(255, 255, 255, 0.06)',
 } as const;
 
-// ===== SPACING (matches index.css) =====
+// ===== SPACING =====
 export const spacing = {
-  xs: '4px',     // --space-xs
-  sm: '8px',     // --space-sm
-  md: '12px',    // --space-md
-  lg: '16px',    // --space-lg
-  xl: '24px',    // --space-xl
-  '2xl': '32px', // --space-2xl
+  xs: '4px',
+  sm: '8px',
+  md: '12px',
+  lg: '16px',
+  xl: '24px',
+  '2xl': '32px',
 } as const;
 
-// ===== BORDER RADIUS (matches index.css) =====
+// ===== BORDER RADIUS — 8px max, 4-6px typical =====
 export const radius = {
-  none: '0px',    // --radius-none
-  sm: '8px',      // --radius-sm
-  md: '12px',     // --radius-md
-  lg: '14px',     // --radius-lg
-  xl: '18px',     // --radius-xl
-  full: '999px',  // --radius-full
+  none: '0px',
+  sm: '4px',    // CTAs, small elements
+  md: '6px',    // cards, typical
+  lg: '8px',    // absolute maximum
+  full: '999px',
 } as const;
 
-// ===== SHADOWS (matches index.css) =====
+// ===== SHADOWS =====
 export const shadows = {
-  none: 'none',                                      // --shadow-none
-  focus: '0 0 0 1px rgba(212, 175, 55, 0.16)',      // --shadow-focus
-  cardActive: '0 0 20px rgba(212, 175, 55, 0.08)',  // --shadow-card-active
-  button: '0 10px 26px rgba(249, 224, 118, 0.15)',  // --shadow-button (CTA glow)
-  modal: '0 20px 50px rgba(0, 0, 0, 0.8)',          // --shadow-modal
+  none: 'none',
+  focus: `0 0 0 1px ${colors.goldMedium}`,
+  cardActive: `0 0 20px ${colors.goldSubtle}`,
+  button: `0 10px 26px ${colors.goldMedium}`,
+  modal: '0 20px 50px rgba(0, 0, 0, 0.8)',
 } as const;
 
 // ===== GRADIENTS =====
 export const gradients = {
-  gold: 'linear-gradient(135deg, #D4AF37 0%, #E6C84A 100%)',
-  goldCta: 'linear-gradient(135deg, #F9E076 0%, #F5D55A 100%)',
-  goldSubtle: 'linear-gradient(135deg, rgba(212, 175, 55, 0.08) 0%, rgba(212, 175, 55, 0.02) 100%)',
-  dividerGold: 'linear-gradient(90deg, transparent 0%, rgba(212, 175, 55, 0.4) 20%, rgba(212, 175, 55, 0.4) 80%, transparent 100%)',
+  dividerGold: `linear-gradient(90deg, transparent 0%, ${colors.goldMedium} 20%, ${colors.goldMedium} 80%, transparent 100%)`,
   fadeBottom: 'linear-gradient(to top, #000000 0%, #000000 85%, transparent 100%)',
 } as const;
 
@@ -91,11 +101,11 @@ export const typography = {
     textTransform: 'uppercase' as const,
   },
   body: {
-    fontFamily: "'DM Sans', sans-serif",
+    fontFamily: "'Inter', sans-serif",
     fontWeight: 400,
   },
   bodyBold: {
-    fontFamily: "'DM Sans', sans-serif",
+    fontFamily: "'Inter', sans-serif",
     fontWeight: 600,
   },
   mono: {
@@ -104,10 +114,10 @@ export const typography = {
     fontVariantNumeric: 'tabular-nums',
   },
   label: {
-    fontSize: '10px',
+    fontSize: '11px',
     letterSpacing: '0.2em',
     textTransform: 'uppercase' as const,
-    color: colors.textDim,
+    color: colors.textTertiary,
   },
 } as const;
 
@@ -135,7 +145,7 @@ export const verdictStatus = {
   excellent: {
     label: 'EXCELLENT DEAL',
     color: colors.gold,
-    bgColor: colors.goldGhost,
+    bgColor: colors.goldMedium,
     description: 'This return profile will attract institutional capital.',
   },
   good: {
@@ -146,14 +156,14 @@ export const verdictStatus = {
   },
   marginal: {
     label: 'MARGINAL',
-    color: colors.goldMuted,
-    bgColor: colors.goldAmbient,
+    color: colors.textSecondary,
+    bgColor: colors.goldGhost,
     description: 'Consider renegotiating terms for better returns.',
   },
   underwater: {
     label: 'UNDERWATER',
-    color: colors.textDim,
-    bgColor: 'rgba(255, 255, 255, 0.04)',
+    color: colors.textTertiary,
+    bgColor: colors.whiteGhost,
     description: 'The acquisition price doesn\'t cover all costs.',
   },
 } as const;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -52,14 +52,14 @@ const Index = () => {
   const { ref: bridgeRef, inView: bridgeVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
   const withItems = [
-    { title: "Returns Mapped", desc: "Every investor sees exactly what they get back — and when" },
-    { title: "Nothing Hidden", desc: "Fees, splits, and repayment — all visible before you commit" },
-    { title: "Real Math, No Guessing", desc: "Know your margins before you shoot a single frame" },
+    { title: "Returns Mapped", desc: "Every investor sees exactly what they get back — and when." },
+    { title: "Nothing Hidden", desc: "Fees, splits, and repayment order — all visible before you commit." },
+    { title: "Your Margins, Confirmed", desc: "Run the numbers on your backend points before you shoot a single frame. No more guessing at what's left after the waterfall." },
   ];
   const withoutItems = [
-    { title: "The Question You Can't Answer", desc: "'How do I get my money back?' — and you're improvising" },
-    { title: "Surprises After Signatures", desc: "Fees and splits you didn't account for surface after the deal closes" },
-    { title: "First-Deal Math", desc: "Your backend points were worth nothing after the sales agent commission you forgot to model" },
+    { title: "The Question You Can't Answer", desc: "'How do I get my money back?' — and you're improvising." },
+    { title: "Surprises After Signatures", desc: "Fees and splits you didn't model surface after the deal closes." },
+    { title: "First-Deal Math", desc: "Your backend points were worth nothing after the sales agent commission you forgot to model." },
   ];
 
   return (
@@ -76,20 +76,28 @@ const Index = () => {
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
         <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-          <section id="hero" className="relative pt-12 pb-6" style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.04) 0%, transparent 60%)" }}>
-            <div className="relative px-8 max-w-md mx-auto">
+          {/* ═══ HERO — HEAVY ═══ */}
+          <section
+            id="hero"
+            className="relative py-20 md:py-28"
+            style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.03) 0%, transparent 60%)" }}
+          >
+            <div className="relative px-8 max-w-md mx-auto md:max-w-2xl">
 
-              <div className="text-center mb-8">
-                <h1 className="font-bebas text-[clamp(3rem,10vw,4.2rem)] leading-[0.95] tracking-[0.02em] text-gold mb-4">
-                  SEE WHERE EVERY DOLLAR <span className="text-ink">GOES</span>
+              <div className="mb-10">
+                <p className="font-sans text-[11px] uppercase tracking-[0.2em] text-ink-secondary mb-4">
+                  FILM FINANCE SIMULATOR
+                </p>
+                <h1 className="font-bebas text-[clamp(3rem,10vw,4.5rem)] leading-[0.95] tracking-[0.02em] text-ink mb-5">
+                  SEE WHERE EVERY DOLLAR GOES
                 </h1>
-                <p className="text-ink-body text-[16px] leading-[1.7] tracking-[0.04em] font-medium">
+                <p className="text-ink-body text-[16px] leading-[1.7] tracking-[0.01em] max-w-sm">
                   Know every fee, split, and return — before your investor asks.
                 </p>
               </div>
 
-              <div className="mb-6 text-center">
-                <div className="w-full max-w-[300px] mx-auto">
+              <div className="mb-10">
+                <div className="w-full max-w-[300px]">
                   <button
                     onClick={handleStartClick}
                     className={`w-full h-[52px] btn-cta-primary${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
@@ -106,39 +114,66 @@ const Index = () => {
             </div>
           </section>
 
-          {/* What This Is — education + mission */}
-          <section id="what-this-is" className="relative pt-12 pb-10 md:pt-16 md:pb-12 px-6">
-            <div className="max-w-md mx-auto flex flex-col gap-5">
+          {/* ═══ STATS DIVIDER — LIGHT ═══ */}
+          <section
+            className="py-6 md:py-8"
+            style={{
+              background: "#111111",
+              borderTop: "1px solid rgba(255,255,255,0.15)",
+              borderBottom: "1px solid rgba(255,255,255,0.15)",
+            }}
+          >
+            <div className="max-w-md mx-auto md:max-w-2xl px-8 flex justify-between">
+              <div>
+                <p className="font-mono text-[14px] text-gold tabular-nums">5</p>
+                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Deduction tiers</p>
+              </div>
+              <div>
+                <p className="font-mono text-[14px] text-gold tabular-nums">50/50</p>
+                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Profit split</p>
+              </div>
+              <div>
+                <p className="font-mono text-[14px] text-gold tabular-nums">PDF</p>
+                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Export ready</p>
+              </div>
+            </div>
+          </section>
+
+          {/* ═══ EDUCATION — MEDIUM ═══ */}
+          <section id="what-this-is" className="relative py-20 md:py-28 px-8">
+            <div className="max-w-md mx-auto md:max-w-2xl flex flex-col gap-8">
 
               {/* Card 1 — The problem */}
               <div
-                className="rounded-xl overflow-hidden"
                 style={{
-                  border: "1px solid rgba(212,175,55,0.25)",
-                  background: "rgba(212,175,55,0.02)",
-                  boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
+                  border: "1px solid rgba(212,175,55,0.15)",
+                  background: "#111111",
+                  borderRadius: "6px",
                 }}
               >
-                <div className="px-6 pt-7 pb-7 flex flex-col gap-5">
-                  <h2 className="font-bebas text-[clamp(1.6rem,6vw,2rem)] leading-[1.1] tracking-[0.04em] text-gold">
+                <div className="px-8 py-10 md:px-10 md:py-12 flex flex-col gap-5">
+                  <p className="font-sans text-[11px] uppercase tracking-[0.2em] text-ink-secondary">
+                    THE TOOL
+                  </p>
+                  <h2 className="font-bebas text-[clamp(1.6rem,6vw,2.2rem)] leading-[1.1] tracking-[0.04em] text-ink">
                     KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
                   </h2>
 
-                  <p className="text-[16px] text-ink-body leading-[1.75] tracking-[0.01em]">
+                  <p className="text-[16px] text-ink-body leading-[1.7]">
                     Every film deal has a pecking order&nbsp;— distributors, agents, lenders, and investors all get paid before you&nbsp;do.
                   </p>
 
-                  <p className="text-[16px] text-ink-body leading-[1.75] tracking-[0.01em]">
+                  <p className="text-[16px] text-ink-body leading-[1.7]">
                     That's called a <span className="text-gold font-semibold">waterfall</span>. This tool lets you model yours before you sign&nbsp;anything.
                   </p>
 
                   <a
                     href="/resources?tab=waterfall"
-                    className="inline-flex items-center gap-2 text-gold/70 hover:text-gold transition-colors text-[14px] font-medium"
+                    className="inline-flex items-center gap-2 text-gold-cta hover:opacity-80 transition-opacity text-[14px] font-medium"
                   >
                     <span
-                      className="inline-flex items-center justify-center w-[20px] h-[20px] rounded-full text-[12px] font-bold leading-none"
-                      style={{ border: "1px solid rgba(212,175,55,0.40)", color: "rgba(212,175,55,0.70)" }}
+                      className="inline-flex items-center justify-center w-[20px] h-[20px] text-[12px] font-bold leading-none"
+                      style={{ border: "1px solid rgba(212,175,55,0.25)", borderRadius: "4px", color: "rgba(255,255,255,0.70)" }}
                       aria-hidden="true"
                     >
                       i
@@ -148,22 +183,21 @@ const Index = () => {
                 </div>
               </div>
 
-              {/* Card 2 — The tool + mission */}
+              {/* Card 2 — Mission */}
               <div
-                className="rounded-xl overflow-hidden"
                 style={{
-                  border: "1px solid rgba(212,175,55,0.25)",
-                  background: "rgba(212,175,55,0.02)",
-                  boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
+                  border: "1px solid rgba(212,175,55,0.15)",
+                  background: "#111111",
+                  borderRadius: "6px",
                 }}
               >
-                <div className="px-6 pt-7 pb-7 flex flex-col gap-5">
-                  <p className="text-[16px] text-ink-body leading-[1.75] tracking-[0.01em]">
+                <div className="px-8 py-10 md:px-10 md:py-12 flex flex-col gap-5">
+                  <p className="text-[16px] text-ink-body leading-[1.7]">
                     Run it as many times as you want. Premium unlocks extended scenarios, financial modeling, and PDF&nbsp;exports.
                   </p>
 
-                  <p className="text-[15px] text-gold/60 italic tracking-[0.02em]">
-                    We're democratizing the business of film.
+                  <p className="text-[14px] text-ink-secondary italic tracking-[0.02em]">
+                    Institutional-grade tools shouldn't cost institutional-grade fees.
                   </p>
                 </div>
               </div>
@@ -171,21 +205,31 @@ const Index = () => {
             </div>
           </section>
 
-          <section id="value" className="relative pb-10 md:pb-12 px-6">
+          {/* ═══ LIGHT DIVIDER ═══ */}
+          <div
+            className="h-[1px] max-w-md mx-auto md:max-w-2xl w-full"
+            style={{ background: "linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.15) 50%, transparent 100%)" }}
+          />
+
+          {/* ═══ VALUE PROP — MEDIUM ═══ */}
+          <section id="value" className="relative py-20 md:py-28 px-8">
             <div
               ref={valueRef}
-              className="relative max-w-md mx-auto flex flex-col gap-5"
+              className="relative max-w-md mx-auto md:max-w-2xl flex flex-col gap-8"
             >
               {/* WITH card */}
               <div
-                className="rounded-xl overflow-hidden"
-                style={{ border: "1px solid rgba(212,175,55,0.25)", background: "rgba(212,175,55,0.02)", boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)" }}
+                style={{
+                  border: "1px solid rgba(212,175,55,0.15)",
+                  background: "#111111",
+                  borderRadius: "6px",
+                }}
               >
-                <div className="px-5 pt-6 pb-6">
-                  <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-6">
+                <div className="px-8 py-10 md:px-10 md:py-12">
+                  <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-8">
                     With your waterfall
                   </h2>
-                  <ul className="flex flex-col gap-5" aria-label="Benefits of using a waterfall">
+                  <ul className="flex flex-col gap-6" aria-label="Benefits of using a waterfall">
                     {withItems.map((item, i) => (
                       <li
                         key={item.title}
@@ -197,17 +241,15 @@ const Index = () => {
                           transitionDelay: prefersReducedMotion ? "0ms" : `${i * 80}ms`,
                         }}
                       >
-                        <div
-                          className="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
-                          style={{
-                            background: "linear-gradient(135deg, #D4AF37 0%, #B8962E 100%)",
-                          }}
+                        <span
+                          className="flex-shrink-0 text-gold text-[16px] font-bold leading-none mt-1"
+                          aria-hidden="true"
                         >
-                          <span className="text-black text-[18px] font-bold leading-none" aria-hidden="true">{"\u2713"}</span>
-                        </div>
+                          {"\u2713"}
+                        </span>
                         <div>
                           <p className="text-[15px] font-semibold text-ink leading-snug">{item.title}</p>
-                          <p className="text-[13px] text-ink-body leading-snug mt-1">{item.desc}</p>
+                          <p className="text-[13px] text-ink-body leading-relaxed mt-1">{item.desc}</p>
                         </div>
                       </li>
                     ))}
@@ -215,19 +257,19 @@ const Index = () => {
                 </div>
               </div>
 
-              {/* WITHOUT card */}
+              {/* WITHOUT card — gold system only, no red */}
               <div
-                className="rounded-xl overflow-hidden"
                 style={{
-                  border: "1px solid rgba(180,60,60,0.28)",
-                  background: "rgba(180,60,60,0.07)",
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  background: "#000000",
+                  borderRadius: "6px",
                 }}
               >
-                <div className="px-5 pt-6 pb-6">
+                <div className="px-8 py-10 md:px-10 md:py-12">
                   <h2
-                    className="font-mono text-[13px] tracking-[0.14em] uppercase mb-6"
+                    className="font-mono text-[13px] tracking-[0.14em] uppercase mb-8"
                     style={{
-                      color: "rgba(220,120,120,0.70)",
+                      color: "rgba(255,255,255,0.40)",
                       opacity: prefersReducedMotion || valueVisible ? 1 : 0,
                       transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out",
                       transitionDelay: prefersReducedMotion ? "0ms" : `${withItems.length * 80 + 60}ms`,
@@ -235,7 +277,7 @@ const Index = () => {
                   >
                     Without a waterfall
                   </h2>
-                  <ul className="flex flex-col gap-5" aria-label="Risks without a waterfall">
+                  <ul className="flex flex-col gap-6" aria-label="Risks without a waterfall">
                     {withoutItems.map((item, i) => (
                       <li
                         key={item.title}
@@ -247,18 +289,16 @@ const Index = () => {
                           transitionDelay: prefersReducedMotion ? "0ms" : `${(withItems.length + i + 1) * 80}ms`,
                         }}
                       >
-                        <div
-                          className="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
-                          style={{
-                            background: "rgba(180,60,60,0.20)",
-                            border: "1px solid rgba(180,60,60,0.30)",
-                          }}
+                        <span
+                          className="flex-shrink-0 text-[16px] font-bold leading-none mt-1"
+                          style={{ color: "rgba(255,255,255,0.40)" }}
+                          aria-hidden="true"
                         >
-                          <span className="text-[16px] font-bold leading-none" aria-hidden="true" style={{ color: "rgba(220,100,100,0.90)" }}>{"\u2717"}</span>
-                        </div>
+                          {"\u2717"}
+                        </span>
                         <div>
                           <p className="text-[15px] font-semibold leading-snug text-ink">{item.title}</p>
-                          <p className="text-[13px] leading-snug mt-1 text-ink-secondary">{item.desc}</p>
+                          <p className="text-[13px] leading-relaxed mt-1 text-ink-secondary">{item.desc}</p>
                         </div>
                       </li>
                     ))}
@@ -269,35 +309,39 @@ const Index = () => {
 
           </section>
 
-          <section id="final-cta" className="py-12 md:py-16 px-6">
-            <div className="max-w-md mx-auto">
+          {/* ═══ FINAL CTA — HEAVY ═══ */}
+          <section id="final-cta" className="py-20 md:py-28 px-8" style={{ background: "#111111" }}>
+            <div className="max-w-md mx-auto md:max-w-lg">
               <div
                 ref={bridgeRef}
-                className="rounded-2xl px-6 py-10 md:py-14 text-center"
+                className="px-8 py-12 md:px-10 md:py-16"
                 style={{
-                  border: "2px solid rgba(212,175,55,0.40)",
-                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.04) 0%, rgba(212,175,55,0.02) 60%, transparent 100%)",
-                  boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
+                  border: "1px solid rgba(212,175,55,0.15)",
+                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.03) 0%, transparent 100%)",
+                  borderRadius: "6px",
                   opacity: prefersReducedMotion || bridgeVisible ? 1 : 0,
                   transform: prefersReducedMotion || bridgeVisible ? "translateY(0)" : "translateY(16px)",
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.1] tracking-[0.06em] text-gold mb-6">
-                  YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS <span className="text-ink">BACK.</span>
+                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.1] tracking-[0.06em] text-ink mb-8">
+                  YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
                 </h2>
-                <button
-                  onClick={handleStartClick}
-                  className="w-full max-w-[300px] h-[52px] btn-cta-primary mx-auto"
-                >
-                  BUILD YOUR WATERFALL
-                </button>
+                <div className="max-w-[300px]">
+                  <button
+                    onClick={handleStartClick}
+                    className="w-full h-[52px] btn-cta-primary"
+                  >
+                    BUILD YOUR WATERFALL
+                  </button>
+                </div>
               </div>
             </div>
           </section>
 
-          <footer className="py-8 px-6 max-w-md mx-auto">
-            <p className="text-ink-ghost text-[13px] tracking-wide leading-relaxed text-center">
+          {/* ═══ FOOTER — LIGHT ═══ */}
+          <footer className="py-12 md:py-16 px-8 max-w-md mx-auto md:max-w-2xl">
+            <p className="text-ink-secondary text-[13px] tracking-wide leading-relaxed">
               For educational and informational purposes only. Not legal, tax, or investment advice.
               Consult a qualified entertainment attorney before making financing decisions.
             </p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,7 @@ export default {
     extend: {
       fontFamily: {
         bebas: ["Bebas Neue", "sans-serif"],
-        sans: ["DM Sans", "sans-serif"],
+        sans: ["Inter", "sans-serif"],
         mono: ["Roboto Mono", "monospace"],
       },
       colors: {
@@ -33,63 +33,68 @@ export default {
 
         // ── CHROME: header, tab bar, navigation fixtures ──
         chrome: {
-          bg:        "rgba(10, 10, 10, 0.88)",       // pill background
-          "bg-solid": "rgba(0, 0, 0, 0.85)",         // tab bar (slightly darker)
-          border:    "rgba(212, 175, 55, 0.50)",      // confident gold border
-          glow:      "rgba(212, 175, 55, 0.30)",      // edge gradient peaks
-          "glow-faint": "rgba(212, 175, 55, 0.10)",   // outer shadow rings
-          active:    "rgba(212, 175, 55, 0.06)",       // active tab bg tint
-          ripple:    "rgba(212, 175, 55, 0.30)",       // tap ripple
+          bg:        "#000000",
+          "bg-solid": "#000000",
+          border:    "rgba(212, 175, 55, 0.25)",
+          glow:      "rgba(212, 175, 55, 0.25)",
+          "glow-faint": "rgba(212, 175, 55, 0.08)",
+          active:    "rgba(212, 175, 55, 0.03)",
+          ripple:    "rgba(212, 175, 55, 0.25)",
         },
 
-        // ── GOLD: content hierarchy (6 tiers, no drift) ──
+        // ── GOLD: 4-tier opacity system, no drift ──
         gold: {
-          DEFAULT:   "#D4AF37",                        // headlines, wordmarks, icons — FULL
-          label:     "rgba(212, 175, 55, 0.72)",       // micro-labels, category text
-          accent:    "rgba(212, 175, 55, 0.40)",       // dividers, connectors, accent stripes
-          border:    "rgba(212, 175, 55, 0.25)",       // card/section borders
-          ghost:     "rgba(212, 175, 55, 0.15)",       // watermarks, ghost text
-          glow:      "rgba(212, 175, 55, 0.06)",       // ambient radial backgrounds
-          cta:       "#F9E076",                        // CTA buttons ONLY
-          "cta-muted": "rgba(249, 224, 118, 0.45)",
-          "cta-subtle": "rgba(249, 224, 118, 0.12)",
+          DEFAULT:   "#D4AF37",                          // brand mark, icons — FULL
+          strong:    "rgba(212, 175, 55, 0.25)",         // active borders, hover states
+          medium:    "rgba(212, 175, 55, 0.15)",         // card borders, section dividers
+          subtle:    "rgba(212, 175, 55, 0.08)",         // background tints, hover fills
+          ghost:     "rgba(212, 175, 55, 0.03)",         // ambient glow, large area tints
+          deep:      "#7A5C12",                          // gradient depth, shadows
+          cta:       "#F9E076",                          // CTA buttons ONLY
+          // Legacy aliases for non-landing pages
+          label:     "rgba(212, 175, 55, 0.25)",
+          accent:    "rgba(212, 175, 55, 0.15)",
+          border:    "rgba(212, 175, 55, 0.15)",
+          glow:      "rgba(212, 175, 55, 0.03)",
+          "cta-muted": "rgba(212, 175, 55, 0.25)",
+          "cta-subtle": "rgba(212, 175, 55, 0.08)",
         },
 
         // ── WHITE TEXT: 4 tiers, no drift ──
         ink: {
-          DEFAULT:   "#FFFFFF",                        // headlines, key numbers — FULL
-          body:      "rgba(255, 255, 255, 0.80)",      // paragraph text, descriptions
-          secondary: "rgba(255, 255, 255, 0.62)",      // supporting info, metadata
-          ghost:     "rgba(255, 255, 255, 0.30)",      // disclaimers, fine print
+          DEFAULT:   "#FFFFFF",                          // headlines, key numbers — FULL
+          body:      "rgba(255, 255, 255, 0.70)",        // secondary / paragraph text
+          secondary: "rgba(255, 255, 255, 0.40)",        // tertiary, metadata
+          ghost:     "rgba(255, 255, 255, 0.06)",        // hover bg, surface tints
         },
 
-        // ── BACKGROUNDS ──
+        // ── BACKGROUNDS — #000, #111, #1A1A1A only ──
         bg: {
           void:      "#000000",
-          surface:   "#111111",
-          elevated:  "#0C0C0C",                        // quote cards, featured
-          card:      "rgba(255, 255, 255, 0.04)",      // content card fill
-          "card-border": "rgba(255, 255, 255, 0.10)",  // content card stroke
-          "card-rule":   "rgba(255, 255, 255, 0.06)",  // inner divider lines
+          elevated:  "#111111",
+          surface:   "#1A1A1A",
+          card:      "#111111",                          // legacy alias
+          "card-border": "rgba(255, 255, 255, 0.15)",   // legacy alias
+          "card-rule":   "rgba(255, 255, 255, 0.06)",   // legacy alias
           overlay:   "rgba(0, 0, 0, 0.85)",
         },
 
         // ── WATERFALL BARS ──
         bar: {
-          DEFAULT:   "rgba(212, 175, 55, 0.65)",       // standard tier bar
-          final:     "rgba(212, 175, 55, 0.85)",       // net profits bar
+          DEFAULT:   "rgba(212, 175, 55, 0.25)",         // standard tier bar
+          final:     "#D4AF37",                          // net profits bar
         },
 
-        // ── LEGACY COMPAT (other pages still using old tokens) ──
+        // ── COMPAT ALIASES ──
         border: {
-          default: "rgba(212, 175, 55, 0.25)",
-          active:  "rgba(212, 175, 55, 0.50)",
-          subtle:  "#2A2A2A",
+          default: "rgba(212, 175, 55, 0.15)",
+          active:  "rgba(212, 175, 55, 0.25)",
+          subtle:  "rgba(255, 255, 255, 0.15)",
         },
         text: {
           primary: "#FFFFFF",
-          mid:     "#D4D4D4",
-          dim:     "#999999",
+          mid:     "rgba(255, 255, 255, 0.70)",
+          dim:     "rgba(255, 255, 255, 0.40)",
         },
       },
       borderRadius: {


### PR DESCRIPTION
Design token overhaul:
- Swap DM Sans to Inter for body/label typography
- Collapse gold opacities to 4 spec tiers (0.25/0.15/0.08/0.03)
- Collapse white opacities to 4 spec tiers (0.70/0.40/0.15/0.06)
- Fix backgrounds to #000/#111/#1A1A1A only
- Cap border-radius at 8px max (4px on CTAs, 6px typical)

Landing page:
- White headlines instead of gold (gold reserved for surgical use)
- Left-align all body text, remove center-aligned paragraphs
- Section spacing increased to 80px+ desktop, 48px+ mobile
- Background alternation (#000/#111) for scroll rhythm
- Add LIGHT stats bar between hero and education sections
- Remove red from Without card (white/gold hierarchy only)
- Flatten CTA button to solid #F9E076, remove gradient/shine
- Fix section weight: HEAVY > LIGHT > MEDIUM > MEDIUM > HEAVY > LIGHT
- Rewrite "democratizing" copy to brand voice
- Vary benefit list items to break parallel structure

Components:
- AppHeader: 8px radius, gold-strong border
- MobileMenu: 6px radius, spec opacity tokens
- OgBotFab: 8px radius (was circle), spec tokens
- OgBotSheet: 6px radius on bubbles/inputs, spec tokens
- LeadCaptureModal: 4-6px radius, #1A1A1A input bg
- WaterfallCascade: 6px cards, spec opacity tokens

Legacy aliases preserved in CSS/Tailwind for non-landing pages.

https://claude.ai/code/session_01FeEDjheyertyEv9W555feV