### PR TITLE
Strip cards, go editorial: Carta-meets-black redesign

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -11,12 +11,12 @@ const deductions = [
   { name: "Equity Recoupment", amount: 1_440_000 },
 ];
 
-const fmtFull = (n: number) => `$${n.toLocaleString()}`;
+const fmt = (n: number) => `$${n.toLocaleString()}`;
 
 const WaterfallCascade = () => {
   const [revealed, setRevealed] = useState(false);
   const [profitCount, setProfitCount] = useState(0);
-  const [corridorVisible, setCorridorVisible] = useState(false);
+  const [splitVisible, setSplitVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -26,11 +26,11 @@ const WaterfallCascade = () => {
     const obs = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          delay = setTimeout(() => setRevealed(true), 400);
+          delay = setTimeout(() => setRevealed(true), 300);
           obs.disconnect();
         }
       },
-      { threshold: 0.25 }
+      { threshold: 0.2 }
     );
     obs.observe(el);
     return () => { obs.disconnect(); clearTimeout(delay); };
@@ -40,146 +40,122 @@ const WaterfallCascade = () => {
     if (!revealed) return;
     let rafId: number;
     const timeout = setTimeout(() => {
-      const target = PROFIT;
-      const dur = 1400;
+      const dur = 1200;
       const start = performance.now();
       const step = (now: number) => {
         const t = Math.min((now - start) / dur, 1);
         const eased = 1 - Math.pow(1 - t, 3);
-        setProfitCount(Math.round(eased * target));
+        setProfitCount(Math.round(eased * PROFIT));
         if (t < 1) rafId = requestAnimationFrame(step);
       };
       rafId = requestAnimationFrame(step);
-    }, 1400);
+    }, deductions.length * 140 + 400);
     return () => { clearTimeout(timeout); cancelAnimationFrame(rafId); };
   }, [revealed]);
 
   useEffect(() => {
     if (!revealed) return;
-    const timeout = setTimeout(() => setCorridorVisible(true), 2000);
+    const timeout = setTimeout(() => setSplitVisible(true), deductions.length * 140 + 1800);
     return () => clearTimeout(timeout);
   }, [revealed]);
 
   return (
-    <div ref={containerRef} className="pt-4 pb-5">
-      {/* Ledger card */}
-      <div
-        className="overflow-hidden"
-        style={{
-          border: "1px solid rgba(212,175,55,0.15)",
-          borderRadius: "6px",
-          background: "#000000",
-        }}
-      >
-        {/* Source row */}
-        <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
-          <span className="font-bebas text-[22px] tracking-[0.06em]" style={{ color: "rgba(255,255,255,0.70)" }}>
-            Acquisition Price
-          </span>
-          <span className="font-mono text-[17px] font-semibold text-gold tabular-nums">
-            {fmtFull(TOTAL)}
-          </span>
-        </div>
-
-        {/* Gold divider */}
-        <div
-          className="mx-5 h-[1px]"
-          style={{
-            background:
-              "linear-gradient(90deg, rgba(212,175,55,0.25), rgba(212,175,55,0.08))",
-            opacity: revealed ? 1 : 0,
-            transition: "opacity 600ms ease-out",
-          }}
-        />
-
-        {/* Deduction line items */}
-        <div className="px-5 pt-2 pb-4">
-          {deductions.map((d, i) => {
-            const delay = (i + 1) * 180;
-            const isEven = i % 2 === 0;
-            return (
-              <div
-                key={d.name}
-                className="flex justify-between items-baseline"
-                style={{
-                  padding: "9px 8px",
-                  margin: "0 -8px",
-                  borderRadius: "4px",
-                  background: isEven ? "rgba(212,175,55,0.03)" : "transparent",
-                  opacity: revealed ? 1 : 0,
-                  transform: revealed ? "translateY(0)" : "translateY(6px)",
-                  transition:
-                    "opacity 500ms ease-out, transform 500ms ease-out",
-                  transitionDelay: `${delay}ms`,
-                }}
-              >
-                <span className="text-[14px] font-medium text-ink-secondary">
-                  {d.name}
-                </span>
-                <span className="font-mono text-[15px] font-medium text-ink-body tabular-nums">
-                  <span className="text-ink-secondary">{"\u2212"}</span>{fmtFull(d.amount)}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Profit box */}
-      <div
-        className="mt-2 py-5 bg-black text-center"
-        style={{
-          border: "1px solid rgba(212,175,55,0.25)",
-          borderRadius: "6px",
-          boxShadow: "0 0 16px rgba(212,175,55,0.08)",
-          opacity: revealed ? 1 : 0,
-          transform: revealed ? "translateY(0)" : "translateY(8px)",
-          transition: "opacity 600ms ease-out, transform 600ms ease-out",
-          transitionDelay: "1400ms",
-        }}
-      >
-        <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold mb-1" style={{ color: "rgba(255,255,255,0.70)" }}>
-          Net Profits
-        </p>
-        <span className="font-mono text-[32px] font-bold text-gold tracking-tight tabular-nums">
-          ${profitCount.toLocaleString()}
+    <div ref={containerRef}>
+      {/* Source */}
+      <div className="flex justify-between items-baseline mb-8">
+        <span
+          className="font-mono text-[11px] uppercase tracking-[0.2em]"
+          style={{ color: "rgba(255,255,255,0.30)" }}
+        >
+          Acquisition
+        </span>
+        <span className="font-mono text-[20px] font-medium text-white tabular-nums">
+          {fmt(TOTAL)}
         </span>
       </div>
 
-      {/* Producer / Investor split */}
-      <div className="grid grid-cols-2 gap-2 mt-2">
-        {[
-          { label: "Producer", amount: "$208,750", extraDelay: 0 },
-          { label: "Investor", amount: "$208,750", extraDelay: 150 },
-        ].map((c) => (
+      {/* Deductions — no cards, just rows with a faint bottom rule */}
+      <div className="space-y-0">
+        {deductions.map((d, i) => (
           <div
-            key={c.label}
-            className="px-3.5 py-3.5 text-center"
+            key={d.name}
+            className="flex justify-between items-baseline py-3"
             style={{
-              border: "1px solid rgba(212,175,55,0.15)",
-              borderRadius: "6px",
-              background: "rgba(212,175,55,0.03)",
-              opacity: corridorVisible ? 1 : 0,
-              transform: corridorVisible
-                ? "translateY(0)"
-                : "translateY(10px)",
+              borderBottom: "1px solid rgba(255,255,255,0.04)",
+              opacity: revealed ? 1 : 0,
+              transform: revealed ? "translateY(0)" : "translateY(4px)",
               transition: "opacity 500ms ease-out, transform 500ms ease-out",
-              transitionDelay: `${c.extraDelay}ms`,
+              transitionDelay: `${(i + 1) * 140}ms`,
             }}
           >
-            <p className="font-mono text-[12px] tracking-[0.16em] uppercase font-semibold mb-1" style={{ color: "rgba(255,255,255,0.70)" }}>
-              {c.label}
-            </p>
-            <span className="font-mono text-[24px] font-bold text-gold tabular-nums">
-              {c.amount}
+            <span
+              className="text-[14px]"
+              style={{ color: "rgba(255,255,255,0.35)" }}
+            >
+              {d.name}
+            </span>
+            <span
+              className="font-mono text-[14px] tabular-nums"
+              style={{ color: "rgba(255,255,255,0.50)" }}
+            >
+              {"\u2212"}{fmt(d.amount)}
             </span>
           </div>
         ))}
       </div>
 
-      <p className="font-mono text-[12px] text-ink-secondary text-center mt-3.5">
-        Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
-        acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
+      {/* Net Profits — big number, no box */}
+      <div
+        className="mt-10 mb-2"
+        style={{
+          opacity: revealed ? 1 : 0,
+          transition: "opacity 800ms ease-out",
+          transitionDelay: `${deductions.length * 140 + 300}ms`,
+        }}
+      >
+        <p
+          className="font-mono text-[11px] uppercase tracking-[0.2em] mb-2"
+          style={{ color: "rgba(212,175,55,0.40)" }}
+        >
+          Net Profits
+        </p>
+        <span className="font-mono text-[36px] font-bold text-gold tracking-tight tabular-nums">
+          ${profitCount.toLocaleString()}
+        </span>
+      </div>
+
+      {/* 50/50 split — inline, not boxed */}
+      <div
+        className="flex gap-12 mt-6"
+        style={{
+          opacity: splitVisible ? 1 : 0,
+          transition: "opacity 600ms ease-out",
+        }}
+      >
+        {([
+          { label: "Producer", amount: "$208,750" },
+          { label: "Investor", amount: "$208,750" },
+        ]).map((s) => (
+          <div key={s.label}>
+            <p
+              className="font-mono text-[11px] uppercase tracking-[0.2em] mb-1"
+              style={{ color: "rgba(255,255,255,0.20)" }}
+            >
+              {s.label}
+            </p>
+            <span className="font-mono text-[20px] font-medium text-white tabular-nums">
+              {s.amount}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Footnote */}
+      <p
+        className="mt-10 text-[12px] leading-[1.7]"
+        style={{ color: "rgba(255,255,255,0.15)" }}
+      >
+        Hypothetical $1.8M budget · $3M acquisition · 50/50 net profit split
       </p>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -703,30 +703,27 @@
     border: none;
     color: #000000;
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 22px;
+    font-size: 20px;
     font-weight: 400;
     letter-spacing: 0.18em;
     text-transform: uppercase;
     border-radius: var(--radius-sm);
-    transition: all 180ms cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow: 0 4px 20px var(--gold-strong);
+    transition: all 200ms ease;
+    box-shadow: none;
     position: relative;
     overflow: hidden;
   }
   @media (hover: hover) {
     .btn-cta-primary:hover {
-      opacity: 0.9;
-      box-shadow: 0 6px 28px var(--gold-strong);
+      opacity: 0.85;
     }
   }
   .btn-cta-primary:active {
-    transform: translateY(1px) scale(0.98);
-    box-shadow: 0 2px 12px var(--gold-medium);
+    transform: scale(0.97);
   }
   .btn-cta-primary:disabled {
     opacity: 0.3;
     cursor: not-allowed;
-    box-shadow: none;
   }
 
   .btn-cta-secondary {
@@ -866,13 +863,13 @@
      ═══════════════════════════════════════════════════════════════════ */
   @keyframes cta-glow-pulse {
     0%, 100% {
-      box-shadow: 0 4px 20px var(--gold-strong);
+      box-shadow: none;
     }
     50% {
-      box-shadow: 0 4px 24px var(--gold-strong), 0 8px 48px var(--gold-medium);
+      box-shadow: 0 0 24px var(--gold-subtle);
     }
   }
   .animate-cta-glow-pulse {
-    animation: cta-glow-pulse 3s ease-in-out infinite;
+    animation: cta-glow-pulse 4s ease-in-out infinite;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -48,19 +48,8 @@ const Index = () => {
     return () => clearTimeout(timeout);
   }, [prefersReducedMotion]);
 
-  const { ref: valueRef, inView: valueVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
-  const { ref: bridgeRef, inView: bridgeVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
-
-  const withItems = [
-    { title: "Returns Mapped", desc: "Every investor sees exactly what they get back — and when." },
-    { title: "Nothing Hidden", desc: "Fees, splits, and repayment order — all visible before you commit." },
-    { title: "Your Margins, Confirmed", desc: "Run the numbers on your backend points before you shoot a single frame. No more guessing at what's left after the waterfall." },
-  ];
-  const withoutItems = [
-    { title: "The Question You Can't Answer", desc: "'How do I get my money back?' — and you're improvising." },
-    { title: "Surprises After Signatures", desc: "Fees and splits you didn't model surface after the deal closes." },
-    { title: "First-Deal Math", desc: "Your backend points were worth nothing after the sales agent commission you forgot to model." },
-  ];
+  const { ref: valueRef, inView: valueVisible } = useInView<HTMLDivElement>({ threshold: 0.15 });
+  const { ref: closerRef, inView: closerVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
   return (
     <>
@@ -76,274 +65,219 @@ const Index = () => {
       <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
         <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-          {/* ═══ HERO — HEAVY ═══ */}
-          <section
-            id="hero"
-            className="relative py-20 md:py-28"
-            style={{ background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.03) 0%, transparent 60%)" }}
-          >
-            <div className="relative px-8 max-w-md mx-auto md:max-w-2xl">
-
-              <div className="mb-10">
-                <p className="font-sans text-[11px] uppercase tracking-[0.2em] text-ink-secondary mb-4">
-                  FILM FINANCE SIMULATOR
-                </p>
-                <h1 className="font-bebas text-[clamp(3rem,10vw,4.5rem)] leading-[0.95] tracking-[0.02em] text-ink mb-5">
-                  SEE WHERE EVERY DOLLAR GOES
-                </h1>
-                <p className="text-ink-body text-[16px] leading-[1.7] tracking-[0.01em] max-w-sm">
-                  Know every fee, split, and return — before your investor asks.
-                </p>
-              </div>
-
-              <div className="mb-10">
-                <div className="w-full max-w-[300px]">
-                  <button
-                    onClick={handleStartClick}
-                    className={`w-full h-[52px] btn-cta-primary${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
-                  >
-                    BUILD YOUR WATERFALL
-                  </button>
-                </div>
-              </div>
-
-              <div className="-mx-2">
-                <WaterfallCascade />
-              </div>
-
-            </div>
-          </section>
-
-          {/* ═══ STATS DIVIDER — LIGHT ═══ */}
-          <section
-            className="py-6 md:py-8"
-            style={{
-              background: "#111111",
-              borderTop: "1px solid rgba(255,255,255,0.15)",
-              borderBottom: "1px solid rgba(255,255,255,0.15)",
-            }}
-          >
-            <div className="max-w-md mx-auto md:max-w-2xl px-8 flex justify-between">
-              <div>
-                <p className="font-mono text-[14px] text-gold tabular-nums">5</p>
-                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Deduction tiers</p>
-              </div>
-              <div>
-                <p className="font-mono text-[14px] text-gold tabular-nums">50/50</p>
-                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Profit split</p>
-              </div>
-              <div>
-                <p className="font-mono text-[14px] text-gold tabular-nums">PDF</p>
-                <p className="font-sans text-[11px] uppercase tracking-[0.15em] text-ink-secondary">Export ready</p>
-              </div>
-            </div>
-          </section>
-
-          {/* ═══ EDUCATION — MEDIUM ═══ */}
-          <section id="what-this-is" className="relative py-20 md:py-28 px-8">
-            <div className="max-w-md mx-auto md:max-w-2xl flex flex-col gap-8">
-
-              {/* Card 1 — The problem */}
-              <div
-                style={{
-                  border: "1px solid rgba(212,175,55,0.15)",
-                  background: "#111111",
-                  borderRadius: "6px",
-                }}
+          {/* ════════════════════════════════════════════════════════
+              HERO — Big type, CTA, nothing else
+              ════════════════════════════════════════════════════════ */}
+          <section className="relative pt-16 pb-24 md:pt-24 md:pb-36">
+            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
+              <p
+                className="font-mono text-[11px] uppercase tracking-[0.25em] mb-6"
+                style={{ color: "rgba(255,255,255,0.30)" }}
               >
-                <div className="px-8 py-10 md:px-10 md:py-12 flex flex-col gap-5">
-                  <p className="font-sans text-[11px] uppercase tracking-[0.2em] text-ink-secondary">
-                    THE TOOL
-                  </p>
-                  <h2 className="font-bebas text-[clamp(1.6rem,6vw,2.2rem)] leading-[1.1] tracking-[0.04em] text-ink">
-                    KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
-                  </h2>
-
-                  <p className="text-[16px] text-ink-body leading-[1.7]">
-                    Every film deal has a pecking order&nbsp;— distributors, agents, lenders, and investors all get paid before you&nbsp;do.
-                  </p>
-
-                  <p className="text-[16px] text-ink-body leading-[1.7]">
-                    That's called a <span className="text-gold font-semibold">waterfall</span>. This tool lets you model yours before you sign&nbsp;anything.
-                  </p>
-
-                  <a
-                    href="/resources?tab=waterfall"
-                    className="inline-flex items-center gap-2 text-gold-cta hover:opacity-80 transition-opacity text-[14px] font-medium"
-                  >
-                    <span
-                      className="inline-flex items-center justify-center w-[20px] h-[20px] text-[12px] font-bold leading-none"
-                      style={{ border: "1px solid rgba(212,175,55,0.25)", borderRadius: "4px", color: "rgba(255,255,255,0.70)" }}
-                      aria-hidden="true"
-                    >
-                      i
-                    </span>
-                    What's a waterfall?
-                  </a>
-                </div>
-              </div>
-
-              {/* Card 2 — Mission */}
-              <div
-                style={{
-                  border: "1px solid rgba(212,175,55,0.15)",
-                  background: "#111111",
-                  borderRadius: "6px",
-                }}
+                Film Finance Simulator
+              </p>
+              <h1 className="font-bebas text-[clamp(3.2rem,12vw,5.5rem)] leading-[0.92] tracking-[0.01em] text-white mb-8">
+                SEE WHERE<br />
+                EVERY DOLLAR<br />
+                GOES
+              </h1>
+              <p
+                className="text-[17px] leading-[1.75] max-w-sm mb-12"
+                style={{ color: "rgba(255,255,255,0.50)" }}
               >
-                <div className="px-8 py-10 md:px-10 md:py-12 flex flex-col gap-5">
-                  <p className="text-[16px] text-ink-body leading-[1.7]">
-                    Run it as many times as you want. Premium unlocks extended scenarios, financial modeling, and PDF&nbsp;exports.
-                  </p>
-
-                  <p className="text-[14px] text-ink-secondary italic tracking-[0.02em]">
-                    Institutional-grade tools shouldn't cost institutional-grade fees.
-                  </p>
-                </div>
-              </div>
-
+                Model your waterfall. Know every fee, split, and&nbsp;return
+                — before your investor asks.
+              </p>
+              <button
+                onClick={handleStartClick}
+                className={`h-[52px] px-10 btn-cta-primary${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
+              >
+                BUILD YOUR WATERFALL
+              </button>
             </div>
           </section>
 
-          {/* ═══ LIGHT DIVIDER ═══ */}
+          {/* ════════════════════════════════════════════════════════
+              THE WATERFALL — full bleed, no card wrapper
+              Thin gold rule separates it from hero
+              ════════════════════════════════════════════════════════ */}
           <div
-            className="h-[1px] max-w-md mx-auto md:max-w-2xl w-full"
-            style={{ background: "linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.15) 50%, transparent 100%)" }}
+            className="w-full h-[1px]"
+            style={{ background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.12) 30%, rgba(212,175,55,0.12) 70%, transparent)" }}
           />
 
-          {/* ═══ VALUE PROP — MEDIUM ═══ */}
-          <section id="value" className="relative py-20 md:py-28 px-8">
+          <section className="py-20 md:py-28">
+            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
+              <p
+                className="font-mono text-[11px] uppercase tracking-[0.25em] mb-10"
+                style={{ color: "rgba(255,255,255,0.30)" }}
+              >
+                Example Waterfall
+              </p>
+              <WaterfallCascade />
+            </div>
+          </section>
+
+          {/* ════════════════════════════════════════════════════════
+              WHAT THIS IS — editorial text, no cards
+              ════════════════════════════════════════════════════════ */}
+          <section className="py-24 md:py-36">
+            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
+              <h2 className="font-bebas text-[clamp(2rem,8vw,3.2rem)] leading-[0.95] tracking-[0.02em] text-white mb-8">
+                KNOW YOUR DEAL<br />
+                BEFORE YOU SIGN&nbsp;IT
+              </h2>
+
+              <div className="space-y-6">
+                <p
+                  className="text-[17px] leading-[1.8]"
+                  style={{ color: "rgba(255,255,255,0.50)" }}
+                >
+                  Every film deal has a pecking order — distributors, sales agents,
+                  lenders, and investors all get paid before you do.
+                  That's called a <span className="text-gold">waterfall</span>.
+                </p>
+                <p
+                  className="text-[17px] leading-[1.8]"
+                  style={{ color: "rgba(255,255,255,0.50)" }}
+                >
+                  This tool lets you model yours before you sign anything.
+                  Run it as many times as you want. Premium unlocks extended
+                  scenarios, financial modeling, and PDF exports.
+                </p>
+              </div>
+
+              <a
+                href="/resources?tab=waterfall"
+                className="inline-block mt-8 font-mono text-[13px] tracking-[0.08em] text-gold-cta hover:opacity-70 transition-opacity"
+              >
+                What's a waterfall? {"\u2192"}
+              </a>
+            </div>
+          </section>
+
+          {/* ════════════════════════════════════════════════════════
+              WITH / WITHOUT — two text columns, no boxes
+              Left-aligned, separated by a single gold rule
+              ════════════════════════════════════════════════════════ */}
+          <div
+            className="w-full h-[1px]"
+            style={{ background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.06) 30%, rgba(255,255,255,0.06) 70%, transparent)" }}
+          />
+
+          <section className="py-24 md:py-36">
             <div
               ref={valueRef}
-              className="relative max-w-md mx-auto md:max-w-2xl flex flex-col gap-8"
+              className="px-8 max-w-lg mx-auto md:max-w-xl"
             >
-              {/* WITH card */}
-              <div
-                style={{
-                  border: "1px solid rgba(212,175,55,0.15)",
-                  background: "#111111",
-                  borderRadius: "6px",
-                }}
-              >
-                <div className="px-8 py-10 md:px-10 md:py-12">
-                  <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-8">
-                    With your waterfall
-                  </h2>
-                  <ul className="flex flex-col gap-6" aria-label="Benefits of using a waterfall">
-                    {withItems.map((item, i) => (
-                      <li
-                        key={item.title}
-                        className="flex items-start gap-4"
-                        style={{
-                          opacity: prefersReducedMotion || valueVisible ? 1 : 0,
-                          transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(12px)",
-                          transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
-                          transitionDelay: prefersReducedMotion ? "0ms" : `${i * 80}ms`,
-                        }}
-                      >
-                        <span
-                          className="flex-shrink-0 text-gold text-[16px] font-bold leading-none mt-1"
-                          aria-hidden="true"
-                        >
-                          {"\u2713"}
-                        </span>
-                        <div>
-                          <p className="text-[15px] font-semibold text-ink leading-snug">{item.title}</p>
-                          <p className="text-[13px] text-ink-body leading-relaxed mt-1">{item.desc}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+              {/* WITH */}
+              <div className="mb-20">
+                <p
+                  className="font-mono text-[11px] uppercase tracking-[0.25em] text-gold mb-8"
+                >
+                  With your waterfall
+                </p>
+                <ul className="space-y-8">
+                  {([
+                    { title: "Returns mapped", desc: "Every investor sees exactly what they get back — and when." },
+                    { title: "Nothing hidden", desc: "Fees, splits, and repayment order — all visible before you commit." },
+                    { title: "Your margins, confirmed", desc: "Run the numbers on your backend points before you shoot a single frame." },
+                  ]).map((item, i) => (
+                    <li
+                      key={item.title}
+                      style={{
+                        opacity: prefersReducedMotion || valueVisible ? 1 : 0,
+                        transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(8px)",
+                        transition: prefersReducedMotion ? "none" : "opacity 600ms ease-out, transform 600ms ease-out",
+                        transitionDelay: prefersReducedMotion ? "0ms" : `${i * 120}ms`,
+                      }}
+                    >
+                      <p className="text-[15px] font-medium text-white leading-snug mb-1">{item.title}</p>
+                      <p className="text-[15px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.40)" }}>{item.desc}</p>
+                    </li>
+                  ))}
+                </ul>
               </div>
 
-              {/* WITHOUT card — gold system only, no red */}
+              {/* Thin separator */}
               <div
-                style={{
-                  border: "1px solid rgba(255,255,255,0.15)",
-                  background: "#000000",
-                  borderRadius: "6px",
-                }}
-              >
-                <div className="px-8 py-10 md:px-10 md:py-12">
-                  <h2
-                    className="font-mono text-[13px] tracking-[0.14em] uppercase mb-8"
-                    style={{
-                      color: "rgba(255,255,255,0.40)",
-                      opacity: prefersReducedMotion || valueVisible ? 1 : 0,
-                      transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out",
-                      transitionDelay: prefersReducedMotion ? "0ms" : `${withItems.length * 80 + 60}ms`,
-                    }}
-                  >
-                    Without a waterfall
-                  </h2>
-                  <ul className="flex flex-col gap-6" aria-label="Risks without a waterfall">
-                    {withoutItems.map((item, i) => (
-                      <li
-                        key={item.title}
-                        className="flex items-start gap-4"
-                        style={{
-                          opacity: prefersReducedMotion || valueVisible ? 1 : 0,
-                          transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(12px)",
-                          transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
-                          transitionDelay: prefersReducedMotion ? "0ms" : `${(withItems.length + i + 1) * 80}ms`,
-                        }}
-                      >
-                        <span
-                          className="flex-shrink-0 text-[16px] font-bold leading-none mt-1"
-                          style={{ color: "rgba(255,255,255,0.40)" }}
-                          aria-hidden="true"
-                        >
-                          {"\u2717"}
-                        </span>
-                        <div>
-                          <p className="text-[15px] font-semibold leading-snug text-ink">{item.title}</p>
-                          <p className="text-[13px] leading-relaxed mt-1 text-ink-secondary">{item.desc}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </div>
+                className="h-[1px] w-16 mb-20"
+                style={{ background: "rgba(255,255,255,0.10)" }}
+              />
 
-          </section>
-
-          {/* ═══ FINAL CTA — HEAVY ═══ */}
-          <section id="final-cta" className="py-20 md:py-28 px-8" style={{ background: "#111111" }}>
-            <div className="max-w-md mx-auto md:max-w-lg">
-              <div
-                ref={bridgeRef}
-                className="px-8 py-12 md:px-10 md:py-16"
-                style={{
-                  border: "1px solid rgba(212,175,55,0.15)",
-                  background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.03) 0%, transparent 100%)",
-                  borderRadius: "6px",
-                  opacity: prefersReducedMotion || bridgeVisible ? 1 : 0,
-                  transform: prefersReducedMotion || bridgeVisible ? "translateY(0)" : "translateY(16px)",
-                  transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-                }}
-              >
-                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.1] tracking-[0.06em] text-ink mb-8">
-                  YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
-                </h2>
-                <div className="max-w-[300px]">
-                  <button
-                    onClick={handleStartClick}
-                    className="w-full h-[52px] btn-cta-primary"
-                  >
-                    BUILD YOUR WATERFALL
-                  </button>
-                </div>
+              {/* WITHOUT */}
+              <div>
+                <p
+                  className="font-mono text-[11px] uppercase tracking-[0.25em] mb-8"
+                  style={{ color: "rgba(255,255,255,0.20)" }}
+                >
+                  Without one
+                </p>
+                <ul className="space-y-8">
+                  {([
+                    { title: "The question you can't answer", desc: "'How do I get my money back?' — and you're improvising." },
+                    { title: "Surprises after signatures", desc: "Fees and splits you didn't model surface after the deal closes." },
+                    { title: "First-deal math", desc: "Your backend points were worth nothing after the sales agent commission you forgot to model." },
+                  ]).map((item, i) => (
+                    <li
+                      key={item.title}
+                      style={{
+                        opacity: prefersReducedMotion || valueVisible ? 1 : 0,
+                        transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(8px)",
+                        transition: prefersReducedMotion ? "none" : "opacity 600ms ease-out, transform 600ms ease-out",
+                        transitionDelay: prefersReducedMotion ? "0ms" : `${(3 + i) * 120 + 200}ms`,
+                      }}
+                    >
+                      <p className="text-[15px] font-medium leading-snug mb-1" style={{ color: "rgba(255,255,255,0.50)" }}>{item.title}</p>
+                      <p className="text-[15px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.25)" }}>{item.desc}</p>
+                    </li>
+                  ))}
+                </ul>
               </div>
             </div>
           </section>
 
-          {/* ═══ FOOTER — LIGHT ═══ */}
-          <footer className="py-12 md:py-16 px-8 max-w-md mx-auto md:max-w-2xl">
-            <p className="text-ink-secondary text-[13px] tracking-wide leading-relaxed">
-              For educational and informational purposes only. Not legal, tax, or investment advice.
-              Consult a qualified entertainment attorney before making financing decisions.
+          {/* ════════════════════════════════════════════════════════
+              CLOSER — one line + CTA, maximum breathing room
+              ════════════════════════════════════════════════════════ */}
+          <section className="py-28 md:py-40">
+            <div
+              ref={closerRef}
+              className="px-8 max-w-lg mx-auto md:max-w-xl"
+              style={{
+                opacity: prefersReducedMotion || closerVisible ? 1 : 0,
+                transform: prefersReducedMotion || closerVisible ? "translateY(0)" : "translateY(12px)",
+                transition: prefersReducedMotion ? "none" : "opacity 800ms ease-out, transform 800ms ease-out",
+              }}
+            >
+              <h2 className="font-bebas text-[clamp(2rem,8vw,3rem)] leading-[0.95] tracking-[0.02em] text-white mb-10">
+                YOUR INVESTORS WILL ASK<br />
+                HOW THE MONEY FLOWS&nbsp;BACK.
+              </h2>
+              <button
+                onClick={handleStartClick}
+                className="h-[52px] px-10 btn-cta-primary"
+              >
+                BUILD YOUR WATERFALL
+              </button>
+            </div>
+          </section>
+
+          {/* ════════════════════════════════════════════════════════
+              FOOTER
+              ════════════════════════════════════════════════════════ */}
+          <footer className="pb-16 pt-8 px-8 max-w-lg mx-auto md:max-w-xl">
+            <div
+              className="h-[1px] w-full mb-8"
+              style={{ background: "rgba(255,255,255,0.06)" }}
+            />
+            <p
+              className="text-[12px] leading-[1.8] tracking-wide"
+              style={{ color: "rgba(255,255,255,0.20)" }}
+            >
+              For educational and informational purposes only. Not legal, tax,
+              or investment advice. Consult a qualified entertainment attorney
+              before making financing decisions.
             </p>
           </footer>
 


### PR DESCRIPTION
Landing page:
- Remove ALL bordered card wrappers from every section
- Content floats directly on black — hierarchy via type + spacing only
- Section padding doubled (py-24/py-36 desktop, py-20 mobile)
- With/Without now two text groups separated by a 16px rule, not boxes
- Waterfall gets its own full-bleed section with mono eyebrow label
- Closer section: massive breathing room (py-28/py-40), just type + CTA
- Stats bar removed — was adding visual clutter for low information value
- Footer stripped to quiet footnote with hairline separator

WaterfallCascade:
- Zero bordered boxes — was 6 nested rectangles, now 0
- Deductions are bare label/number rows with 4% white hairlines
- Net Profits: big gold number floating on black, no container
- 50/50 split: side-by-side labels, no boxes
- Footnote opacity dropped to 0.15 (barely there)

CTA button:
- Remove box-shadow at rest (was gold glow)
- Hover: simple opacity 0.85 instead of intensified glow
- Glow pulse animation: barely visible, 4s cycle
- Font size 20px (was 22px) — slightly quieter

Design philosophy: if Carta did a dark-mode film finance tool. Negative space is the primary design element. Typography does the work. Cards are for the calculator, not the marketing page.

https://claude.ai/code/session_01FeEDjheyertyEv9W555feV