### PR TITLE
Gamma×Vercel redesign: cards as slides, centered CTAs, breathing room

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -61,52 +61,52 @@ const WaterfallCascade = () => {
 
   return (
     <div ref={containerRef}>
-      {/* Source */}
-      <div className="flex justify-between items-baseline mb-8">
-        <span
-          className="font-mono text-[11px] uppercase tracking-[0.2em]"
-          style={{ color: "rgba(255,255,255,0.30)" }}
-        >
-          Acquisition
+      {/* Source line */}
+      <div className="flex justify-between items-baseline pb-4 mb-1" style={{ borderBottom: "1px solid rgba(212,175,55,0.10)" }}>
+        <span className="text-[14px] font-medium text-white">
+          Acquisition Price
         </span>
-        <span className="font-mono text-[20px] font-medium text-white tabular-nums">
+        <span className="font-mono text-[18px] font-semibold text-white tabular-nums">
           {fmt(TOTAL)}
         </span>
       </div>
 
-      {/* Deductions — no cards, just rows with a faint bottom rule */}
-      <div className="space-y-0">
-        {deductions.map((d, i) => (
-          <div
-            key={d.name}
-            className="flex justify-between items-baseline py-3"
-            style={{
-              borderBottom: "1px solid rgba(255,255,255,0.04)",
-              opacity: revealed ? 1 : 0,
-              transform: revealed ? "translateY(0)" : "translateY(4px)",
-              transition: "opacity 500ms ease-out, transform 500ms ease-out",
-              transitionDelay: `${(i + 1) * 140}ms`,
-            }}
-          >
-            <span
-              className="text-[14px]"
-              style={{ color: "rgba(255,255,255,0.35)" }}
-            >
-              {d.name}
-            </span>
-            <span
-              className="font-mono text-[14px] tabular-nums"
-              style={{ color: "rgba(255,255,255,0.50)" }}
-            >
-              {"\u2212"}{fmt(d.amount)}
-            </span>
-          </div>
-        ))}
-      </div>
+      {/* Deductions */}
+      {deductions.map((d, i) => (
+        <div
+          key={d.name}
+          className="flex justify-between items-baseline py-3"
+          style={{
+            borderBottom: i < deductions.length - 1 ? "1px solid rgba(255,255,255,0.04)" : "none",
+            opacity: revealed ? 1 : 0,
+            transform: revealed ? "translateY(0)" : "translateY(4px)",
+            transition: "opacity 500ms ease-out, transform 500ms ease-out",
+            transitionDelay: `${(i + 1) * 140}ms`,
+          }}
+        >
+          <span className="text-[14px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+            {d.name}
+          </span>
+          <span className="font-mono text-[14px] tabular-nums" style={{ color: "rgba(255,255,255,0.50)" }}>
+            {"\u2212"}{fmt(d.amount)}
+          </span>
+        </div>
+      ))}
 
-      {/* Net Profits — big number, no box */}
+      {/* Gold divider before profit */}
       <div
-        className="mt-10 mb-2"
+        className="h-[1px] mt-6 mb-8"
+        style={{
+          background: "linear-gradient(90deg, rgba(212,175,55,0.20), rgba(212,175,55,0.05))",
+          opacity: revealed ? 1 : 0,
+          transition: "opacity 800ms ease-out",
+          transitionDelay: `${deductions.length * 140 + 200}ms`,
+        }}
+      />
+
+      {/* Net Profits — big number, centered */}
+      <div
+        className="text-center mb-8"
         style={{
           opacity: revealed ? 1 : 0,
           transition: "opacity 800ms ease-out",
@@ -115,18 +115,18 @@ const WaterfallCascade = () => {
       >
         <p
           className="font-mono text-[11px] uppercase tracking-[0.2em] mb-2"
-          style={{ color: "rgba(212,175,55,0.40)" }}
+          style={{ color: "rgba(212,175,55,0.50)" }}
         >
           Net Profits
         </p>
-        <span className="font-mono text-[36px] font-bold text-gold tracking-tight tabular-nums">
+        <span className="font-mono text-[38px] font-bold text-gold tracking-tight tabular-nums">
           ${profitCount.toLocaleString()}
         </span>
       </div>
 
-      {/* 50/50 split — inline, not boxed */}
+      {/* 50/50 split */}
       <div
-        className="flex gap-12 mt-6"
+        className="flex justify-center gap-16"
         style={{
           opacity: splitVisible ? 1 : 0,
           transition: "opacity 600ms ease-out",
@@ -136,9 +136,9 @@ const WaterfallCascade = () => {
           { label: "Producer", amount: "$208,750" },
           { label: "Investor", amount: "$208,750" },
         ]).map((s) => (
-          <div key={s.label}>
+          <div key={s.label} className="text-center">
             <p
-              className="font-mono text-[11px] uppercase tracking-[0.2em] mb-1"
+              className="font-mono text-[10px] uppercase tracking-[0.2em] mb-1"
               style={{ color: "rgba(255,255,255,0.20)" }}
             >
               {s.label}
@@ -152,7 +152,7 @@ const WaterfallCascade = () => {
 
       {/* Footnote */}
       <p
-        className="mt-10 text-[12px] leading-[1.7]"
+        className="text-center mt-10 text-[11px] leading-[1.7]"
         style={{ color: "rgba(255,255,255,0.15)" }}
       >
         Hypothetical $1.8M budget · $3M acquisition · 50/50 net profit split

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,33 @@ import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import WaterfallCascade from "@/components/WaterfallCascade";
 
+/* ═══════════════════════════════════════════════════════════════════
+   CARD — reusable slide-style content unit (Gamma-style)
+   bg alternation creates separation; borders are optional + subtle.
+   ═══════════════════════════════════════════════════════════════════ */
+const Card = ({
+  children,
+  bg = "#111111",
+  className = "",
+  style = {},
+}: {
+  children: React.ReactNode;
+  bg?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}) => (
+  <div
+    className={className}
+    style={{
+      background: bg,
+      borderRadius: "8px",
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
 const Index = () => {
   const navigate = useNavigate();
   const haptics = useHaptics();
@@ -51,6 +78,16 @@ const Index = () => {
   const { ref: valueRef, inView: valueVisible } = useInView<HTMLDivElement>({ threshold: 0.15 });
   const { ref: closerRef, inView: closerVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
 
+  const anim = (i: number, visible: boolean) =>
+    prefersReducedMotion
+      ? {}
+      : {
+          opacity: visible ? 1 : 0,
+          transform: visible ? "translateY(0)" : "translateY(8px)",
+          transition: "opacity 600ms ease-out, transform 600ms ease-out",
+          transitionDelay: `${i * 120}ms`,
+        };
+
   return (
     <>
       <LeadCaptureModal
@@ -62,225 +99,226 @@ const Index = () => {
           navigate(pendingDestination || "/calculator?tab=budget");
         }}
       />
-      <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
-        <main aria-label="Film Finance Simulator" className="flex-1 flex flex-col" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
 
-          {/* ════════════════════════════════════════════════════════
-              HERO — Big type, CTA, nothing else
-              ════════════════════════════════════════════════════════ */}
-          <section className="relative pt-16 pb-24 md:pt-24 md:pb-36">
-            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
+      <div className="min-h-screen flex flex-col relative overflow-hidden bg-black grain-overlay">
+        <main
+          aria-label="Film Finance Simulator"
+          className="flex-1 flex flex-col items-center"
+          style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+        >
+          {/* Container — all cards stack inside this */}
+          <div className="w-full max-w-2xl px-4 md:px-6 flex flex-col gap-2 py-4">
+
+            {/* ════════════════════════════════════════════════════════
+                HERO CARD — tall, centered, confident
+                ════════════════════════════════════════════════════════ */}
+            <Card bg="#111111" className="px-8 py-20 md:px-14 md:py-28 text-center">
               <p
-                className="font-mono text-[11px] uppercase tracking-[0.25em] mb-6"
+                className="font-mono text-[11px] uppercase tracking-[0.25em] mb-8"
                 style={{ color: "rgba(255,255,255,0.30)" }}
               >
                 Film Finance Simulator
               </p>
-              <h1 className="font-bebas text-[clamp(3.2rem,12vw,5.5rem)] leading-[0.92] tracking-[0.01em] text-white mb-8">
-                SEE WHERE<br />
-                EVERY DOLLAR<br />
-                GOES
+
+              <h1 className="font-bebas text-[clamp(3rem,11vw,5rem)] leading-[0.93] tracking-[0.015em] text-white mb-6 mx-auto max-w-md">
+                SEE WHERE EVERY DOLLAR GOES
               </h1>
+
               <p
-                className="text-[17px] leading-[1.75] max-w-sm mb-12"
-                style={{ color: "rgba(255,255,255,0.50)" }}
+                className="text-[16px] md:text-[17px] leading-[1.75] mx-auto max-w-sm mb-12"
+                style={{ color: "rgba(255,255,255,0.45)" }}
               >
                 Model your waterfall. Know every fee, split, and&nbsp;return
                 — before your investor asks.
               </p>
+
               <button
                 onClick={handleStartClick}
-                className={`h-[52px] px-10 btn-cta-primary${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
+                className={`h-[52px] px-12 btn-cta-primary mx-auto${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
               >
                 BUILD YOUR WATERFALL
               </button>
-            </div>
-          </section>
+            </Card>
 
-          {/* ════════════════════════════════════════════════════════
-              THE WATERFALL — full bleed, no card wrapper
-              Thin gold rule separates it from hero
-              ════════════════════════════════════════════════════════ */}
-          <div
-            className="w-full h-[1px]"
-            style={{ background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.12) 30%, rgba(212,175,55,0.12) 70%, transparent)" }}
-          />
+            {/* ════════════════════════════════════════════════════════
+                STATS STRIP — three data points, institutional feel
+                ════════════════════════════════════════════════════════ */}
+            <Card bg="transparent" className="px-8 py-5 md:px-14">
+              <div className="flex justify-center gap-10 md:gap-16">
+                {([
+                  { value: "5", label: "Deduction tiers" },
+                  { value: "50/50", label: "Profit split" },
+                  { value: "PDF", label: "Export ready" },
+                ]).map((stat) => (
+                  <div key={stat.label} className="text-center">
+                    <p className="font-mono text-[15px] font-medium text-gold tabular-nums">
+                      {stat.value}
+                    </p>
+                    <p
+                      className="font-mono text-[10px] uppercase tracking-[0.18em] mt-1"
+                      style={{ color: "rgba(255,255,255,0.20)" }}
+                    >
+                      {stat.label}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </Card>
 
-          <section className="py-20 md:py-28">
-            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
+            {/* ════════════════════════════════════════════════════════
+                WATERFALL CARD — the product showcase, ledger feel
+                ════════════════════════════════════════════════════════ */}
+            <Card bg="#111111" className="px-8 py-12 md:px-14 md:py-16">
               <p
                 className="font-mono text-[11px] uppercase tracking-[0.25em] mb-10"
-                style={{ color: "rgba(255,255,255,0.30)" }}
+                style={{ color: "rgba(255,255,255,0.25)" }}
               >
                 Example Waterfall
               </p>
               <WaterfallCascade />
-            </div>
-          </section>
+            </Card>
 
-          {/* ════════════════════════════════════════════════════════
-              WHAT THIS IS — editorial text, no cards
-              ════════════════════════════════════════════════════════ */}
-          <section className="py-24 md:py-36">
-            <div className="px-8 max-w-lg mx-auto md:max-w-xl">
-              <h2 className="font-bebas text-[clamp(2rem,8vw,3.2rem)] leading-[0.95] tracking-[0.02em] text-white mb-8">
-                KNOW YOUR DEAL<br />
-                BEFORE YOU SIGN&nbsp;IT
-              </h2>
+            {/* ════════════════════════════════════════════════════════
+                EDUCATION CARD — what is this tool
+                ════════════════════════════════════════════════════════ */}
+            <Card bg="#0A0A0A" className="px-8 py-14 md:px-14 md:py-20">
+              <div className="max-w-lg">
+                <h2 className="font-bebas text-[clamp(1.8rem,7vw,2.8rem)] leading-[0.96] tracking-[0.02em] text-white mb-8">
+                  KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
+                </h2>
 
-              <div className="space-y-6">
-                <p
-                  className="text-[17px] leading-[1.8]"
-                  style={{ color: "rgba(255,255,255,0.50)" }}
+                <div className="space-y-5">
+                  <p
+                    className="text-[16px] leading-[1.8]"
+                    style={{ color: "rgba(255,255,255,0.45)" }}
+                  >
+                    Every film deal has a pecking order — distributors, sales agents,
+                    lenders, and investors all get paid before you do.
+                    That's called a <span className="text-gold font-medium">waterfall</span>.
+                  </p>
+                  <p
+                    className="text-[16px] leading-[1.8]"
+                    style={{ color: "rgba(255,255,255,0.45)" }}
+                  >
+                    This tool lets you model yours before you sign anything.
+                    Run it as many times as you want. Premium unlocks extended
+                    scenarios, financial modeling, and PDF exports.
+                  </p>
+                </div>
+
+                <a
+                  href="/resources?tab=waterfall"
+                  className="inline-block mt-8 font-mono text-[13px] tracking-[0.06em] text-gold-cta hover:opacity-70 transition-opacity"
                 >
-                  Every film deal has a pecking order — distributors, sales agents,
-                  lenders, and investors all get paid before you do.
-                  That's called a <span className="text-gold">waterfall</span>.
-                </p>
-                <p
-                  className="text-[17px] leading-[1.8]"
-                  style={{ color: "rgba(255,255,255,0.50)" }}
-                >
-                  This tool lets you model yours before you sign anything.
-                  Run it as many times as you want. Premium unlocks extended
-                  scenarios, financial modeling, and PDF exports.
-                </p>
+                  What's a waterfall? {"\u2192"}
+                </a>
               </div>
+            </Card>
 
-              <a
-                href="/resources?tab=waterfall"
-                className="inline-block mt-8 font-mono text-[13px] tracking-[0.08em] text-gold-cta hover:opacity-70 transition-opacity"
-              >
-                What's a waterfall? {"\u2192"}
-              </a>
-            </div>
-          </section>
-
-          {/* ════════════════════════════════════════════════════════
-              WITH / WITHOUT — two text columns, no boxes
-              Left-aligned, separated by a single gold rule
-              ════════════════════════════════════════════════════════ */}
-          <div
-            className="w-full h-[1px]"
-            style={{ background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.06) 30%, rgba(255,255,255,0.06) 70%, transparent)" }}
-          />
-
-          <section className="py-24 md:py-36">
-            <div
-              ref={valueRef}
-              className="px-8 max-w-lg mx-auto md:max-w-xl"
-            >
-              {/* WITH */}
-              <div className="mb-20">
-                <p
-                  className="font-mono text-[11px] uppercase tracking-[0.25em] text-gold mb-8"
-                >
+            {/* ════════════════════════════════════════════════════════
+                VALUE PROP — With / Without, two cards side-by-side on md+
+                ════════════════════════════════════════════════════════ */}
+            <div ref={valueRef} className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              {/* WITH — confident, present */}
+              <Card bg="#111111" className="px-8 py-12 md:px-10 md:py-14">
+                <p className="font-mono text-[11px] uppercase tracking-[0.25em] text-gold mb-8">
                   With your waterfall
                 </p>
-                <ul className="space-y-8">
+                <ul className="space-y-7">
                   {([
                     { title: "Returns mapped", desc: "Every investor sees exactly what they get back — and when." },
                     { title: "Nothing hidden", desc: "Fees, splits, and repayment order — all visible before you commit." },
-                    { title: "Your margins, confirmed", desc: "Run the numbers on your backend points before you shoot a single frame." },
+                    { title: "Your margins, confirmed", desc: "Run the numbers on your backend points before you shoot a frame." },
                   ]).map((item, i) => (
-                    <li
-                      key={item.title}
-                      style={{
-                        opacity: prefersReducedMotion || valueVisible ? 1 : 0,
-                        transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(8px)",
-                        transition: prefersReducedMotion ? "none" : "opacity 600ms ease-out, transform 600ms ease-out",
-                        transitionDelay: prefersReducedMotion ? "0ms" : `${i * 120}ms`,
-                      }}
-                    >
-                      <p className="text-[15px] font-medium text-white leading-snug mb-1">{item.title}</p>
-                      <p className="text-[15px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.40)" }}>{item.desc}</p>
+                    <li key={item.title} style={anim(i, valueVisible)}>
+                      <p className="text-[15px] font-medium text-white leading-snug mb-1.5">{item.title}</p>
+                      <p className="text-[14px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.40)" }}>{item.desc}</p>
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
 
-              {/* Thin separator */}
-              <div
-                className="h-[1px] w-16 mb-20"
-                style={{ background: "rgba(255,255,255,0.10)" }}
-              />
-
-              {/* WITHOUT */}
-              <div>
+              {/* WITHOUT — recessive, dimmed */}
+              <Card bg="#080808" className="px-8 py-12 md:px-10 md:py-14">
                 <p
                   className="font-mono text-[11px] uppercase tracking-[0.25em] mb-8"
-                  style={{ color: "rgba(255,255,255,0.20)" }}
+                  style={{ color: "rgba(255,255,255,0.15)" }}
                 >
                   Without one
                 </p>
-                <ul className="space-y-8">
+                <ul className="space-y-7">
                   {([
                     { title: "The question you can't answer", desc: "'How do I get my money back?' — and you're improvising." },
                     { title: "Surprises after signatures", desc: "Fees and splits you didn't model surface after the deal closes." },
                     { title: "First-deal math", desc: "Your backend points were worth nothing after the sales agent commission you forgot to model." },
                   ]).map((item, i) => (
-                    <li
-                      key={item.title}
-                      style={{
-                        opacity: prefersReducedMotion || valueVisible ? 1 : 0,
-                        transform: prefersReducedMotion || valueVisible ? "translateY(0)" : "translateY(8px)",
-                        transition: prefersReducedMotion ? "none" : "opacity 600ms ease-out, transform 600ms ease-out",
-                        transitionDelay: prefersReducedMotion ? "0ms" : `${(3 + i) * 120 + 200}ms`,
-                      }}
-                    >
-                      <p className="text-[15px] font-medium leading-snug mb-1" style={{ color: "rgba(255,255,255,0.50)" }}>{item.title}</p>
-                      <p className="text-[15px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.25)" }}>{item.desc}</p>
+                    <li key={item.title} style={anim(3 + i, valueVisible)}>
+                      <p className="text-[14px] font-medium leading-snug mb-1.5" style={{ color: "rgba(255,255,255,0.40)" }}>{item.title}</p>
+                      <p className="text-[13px] leading-[1.7]" style={{ color: "rgba(255,255,255,0.22)" }}>{item.desc}</p>
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
             </div>
-          </section>
 
-          {/* ════════════════════════════════════════════════════════
-              CLOSER — one line + CTA, maximum breathing room
-              ════════════════════════════════════════════════════════ */}
-          <section className="py-28 md:py-40">
-            <div
-              ref={closerRef}
-              className="px-8 max-w-lg mx-auto md:max-w-xl"
+            {/* ════════════════════════════════════════════════════════
+                PULL QUOTE — one line, maximum confidence
+                ════════════════════════════════════════════════════════ */}
+            <Card bg="transparent" className="px-8 py-10 md:px-14 md:py-14 text-center">
+              <p
+                className="font-mono text-[13px] md:text-[14px] leading-[1.8] tracking-[0.02em] italic mx-auto max-w-md"
+                style={{ color: "rgba(255,255,255,0.30)" }}
+              >
+                "Institutional-grade tools shouldn't cost institutional-grade&nbsp;fees."
+              </p>
+            </Card>
+
+            {/* ════════════════════════════════════════════════════════
+                CLOSER CTA — the conversion moment
+                ════════════════════════════════════════════════════════ */}
+            <Card
+              bg="#111111"
+              className="px-8 py-16 md:px-14 md:py-24 text-center"
               style={{
-                opacity: prefersReducedMotion || closerVisible ? 1 : 0,
-                transform: prefersReducedMotion || closerVisible ? "translateY(0)" : "translateY(12px)",
-                transition: prefersReducedMotion ? "none" : "opacity 800ms ease-out, transform 800ms ease-out",
+                borderTop: "1px solid rgba(212,175,55,0.08)",
               }}
             >
-              <h2 className="font-bebas text-[clamp(2rem,8vw,3rem)] leading-[0.95] tracking-[0.02em] text-white mb-10">
-                YOUR INVESTORS WILL ASK<br />
-                HOW THE MONEY FLOWS&nbsp;BACK.
-              </h2>
-              <button
-                onClick={handleStartClick}
-                className="h-[52px] px-10 btn-cta-primary"
+              <div
+                ref={closerRef}
+                style={{
+                  opacity: prefersReducedMotion || closerVisible ? 1 : 0,
+                  transform: prefersReducedMotion || closerVisible ? "translateY(0)" : "translateY(12px)",
+                  transition: prefersReducedMotion ? "none" : "opacity 800ms ease-out, transform 800ms ease-out",
+                }}
               >
-                BUILD YOUR WATERFALL
-              </button>
-            </div>
-          </section>
+                <h2 className="font-bebas text-[clamp(2rem,8vw,3rem)] leading-[0.95] tracking-[0.02em] text-white mb-10 mx-auto max-w-md">
+                  YOUR INVESTORS WILL ASK HOW THE MONEY FLOWS&nbsp;BACK.
+                </h2>
 
-          {/* ════════════════════════════════════════════════════════
-              FOOTER
-              ════════════════════════════════════════════════════════ */}
-          <footer className="pb-16 pt-8 px-8 max-w-lg mx-auto md:max-w-xl">
-            <div
-              className="h-[1px] w-full mb-8"
-              style={{ background: "rgba(255,255,255,0.06)" }}
-            />
-            <p
-              className="text-[12px] leading-[1.8] tracking-wide"
-              style={{ color: "rgba(255,255,255,0.20)" }}
-            >
-              For educational and informational purposes only. Not legal, tax,
-              or investment advice. Consult a qualified entertainment attorney
-              before making financing decisions.
-            </p>
-          </footer>
+                <button
+                  onClick={handleStartClick}
+                  className="h-[52px] px-12 btn-cta-primary mx-auto"
+                >
+                  BUILD YOUR WATERFALL
+                </button>
+              </div>
+            </Card>
 
+            {/* ════════════════════════════════════════════════════════
+                FOOTER
+                ════════════════════════════════════════════════════════ */}
+            <footer className="px-8 py-8 md:px-14 text-center">
+              <p
+                className="text-[11px] leading-[1.8] tracking-wide mx-auto max-w-md"
+                style={{ color: "rgba(255,255,255,0.15)" }}
+              >
+                For educational and informational purposes only. Not legal, tax,
+                or investment advice. Consult a qualified entertainment attorney
+                before making financing decisions.
+              </p>
+            </footer>
+
+          </div>
         </main>
       </div>
     </>


### PR DESCRIPTION
Architecture: Cards are presentation slide units stacked with 8px gaps. Background alternation (#111 → transparent → #0A0A0A → #111/#080808) creates visual rhythm without needing borders.

Landing page:
- Hero card: centered type, centered CTA, tall padding (py-20/py-28)
- Stats strip: transparent bg, centered mono data points
- Waterfall card: #111 bg, ledger rows (no nested boxes), centered profit
- Education card: #0A0A0A bg, left-aligned text within centered card
- With/Without: side-by-side on md+ (grid-cols-2), "Without" visually recessive (#080808 bg, dimmed text at 0.40/0.22 opacity)
- Pull quote: transparent card, italic mono, centered
- Closer CTA card: #111 bg, faint gold border-top, centered
- Footer: centered, 0.15 opacity text

Waterfall component:
- Lives inside parent card now, no own container
- Source line with subtle gold underline
- Deduction rows: bare label/number, 4% white hairlines
- Gold gradient divider before profit section
- Net profit: centered, 38px mono, gold
- 50/50 split: centered side-by-side, generous gap

CTA: centered via mx-auto on all instances. No left-aligned CTAs.

Card component: 8px border-radius, bg prop for alternation, no visible borders (bg color IS the boundary).

https://claude.ai/code/session_01FeEDjheyertyEv9W555feV