### PR TITLE
Landing page overhaul: font hierarchy, header width, red danger card,…

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -3,10 +3,10 @@ import { MoreVertical } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
-   AppHeader — floating pill
+   AppHeader — floating bar (matches max-w-xl card column)
    Left:  FILMMAKER.OG → home
    Right: ⋮ kebab → MobileMenu
-   320px centered pill, 8px radius, solid black, gold border
+   576px max, 12px radius, solid black, gold border
    ═══════════════════════════════════════════════════════════════════ */
 interface AppHeaderProps {
   onMoreOpen?: () => void;
@@ -27,15 +27,17 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
           style={{
             pointerEvents: "auto",
             width: "100%",
-            maxWidth: "320px",
+            maxWidth: "576px",
             height: "54px",
             marginTop: "max(12px, env(safe-area-inset-top, 12px))",
-            borderRadius: "8px",
+            marginLeft: "16px",
+            marginRight: "16px",
+            borderRadius: "12px",
             background: "#000000",
             border: "1px solid rgba(212,175,55,0.25)",
             boxShadow: "0 8px 32px rgba(0,0,0,0.95)",
-            paddingLeft: "16px",
-            paddingRight: "10px",
+            paddingLeft: "20px",
+            paddingRight: "12px",
           }}
         >
           <button
@@ -43,7 +45,7 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
             className="flex items-center hover:opacity-80 transition-opacity"
             aria-label="Go home"
           >
-            <span className="font-bebas text-[22px] tracking-[0.2em] text-gold">
+            <span className="font-bebas text-[28px] tracking-[0.14em] text-gold leading-none">
               FILMMAKER<span className="text-ink-body">.OG</span>
             </span>
           </button>

--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -68,10 +68,10 @@ const WaterfallCascade = () => {
       >
         {/* Acquisition price header row */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
-          <span className="font-bebas text-[22px] tracking-[0.06em]" style={{ color: "rgba(212,175,55,0.55)" }}>
+          <span className="font-bebas text-[22px] tracking-[0.06em] text-gold-text">
             Acquisition Price
           </span>
-          <span className="font-mono text-[17px] font-semibold text-gold tabular-nums">
+          <span className="font-mono text-[16px] font-medium text-gold tabular-nums">
             {fmt(TOTAL)}
           </span>
         </div>
@@ -107,7 +107,7 @@ const WaterfallCascade = () => {
                 <span className="text-[14px] font-medium text-ink-secondary">
                   {d.name}
                 </span>
-                <span className="font-mono text-[15px] font-medium text-ink-body tabular-nums">
+                <span className="font-mono text-[14px] font-medium text-ink-body tabular-nums">
                   <span className="text-ink-secondary">{"\u2212"}</span>{fmt(d.amount)}
                 </span>
               </div>
@@ -128,10 +128,7 @@ const WaterfallCascade = () => {
           transitionDelay: "1400ms",
         }}
       >
-        <p
-          className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold mb-1"
-          style={{ color: "rgba(212,175,55,0.55)" }}
-        >
+        <p className="font-mono text-[10px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-text">
           Net Profits
         </p>
         <span className="font-mono text-[32px] font-bold text-gold tracking-tight tabular-nums">
@@ -157,20 +154,17 @@ const WaterfallCascade = () => {
               transitionDelay: `${c.delay}ms`,
             }}
           >
-            <p
-              className="font-mono text-[10px] tracking-[0.16em] uppercase font-semibold mb-1"
-              style={{ color: "rgba(212,175,55,0.55)" }}
-            >
+            <p className="font-mono text-[10px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-text">
               {c.label}
             </p>
-            <span className="font-mono text-[20px] font-bold text-gold tabular-nums">
+            <span className="font-mono text-[22px] font-bold text-gold tabular-nums">
               {c.amount}
             </span>
           </div>
         ))}
       </div>
 
-      <p className="font-mono text-[12px] text-ink-ghost text-center mt-3.5">
+      <p className="font-mono text-[11px] text-ink-secondary text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,16 @@
     /* CTA Gold — buttons, links, interactive CTAs ONLY */
     --gold-cta: #F9E076;
 
+    /* ═══════════════════════════════════════════════════════════════════
+       RED DANGER — "Without" card, warnings, risk indicators
+       Same 4-tier opacity system as gold.
+       ═══════════════════════════════════════════════════════════════════ */
+    --red-danger: #DC3C3C;
+    --red-strong: rgba(220, 60, 60, 0.25);
+    --red-medium: rgba(220, 60, 60, 0.15);
+    --red-subtle: rgba(220, 60, 60, 0.08);
+    --red-ghost: rgba(220, 60, 60, 0.03);
+
     /* Legacy aliases — map old tokens to new spec for non-landing pages */
     --bg-card: #111111;
     --bg-header: #000000;
@@ -104,7 +114,9 @@
        ═══════════════════════════════════════════════════════════════════ */
     --text-primary: #FFFFFF;
     --text-secondary: rgba(255, 255, 255, 0.70);
+    --text-muted: rgba(255, 255, 255, 0.55);
     --text-tertiary: rgba(255, 255, 255, 0.40);
+    --gold-text: rgba(212, 175, 55, 0.60);
 
     /* BORDERS */
     --border-default: rgba(212, 175, 55, 0.15);

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -45,11 +45,22 @@ export const colors = {
   // CTA Gold — EXCLUSIVELY for clickable elements
   goldCta: '#F9E076',
 
-  // Text hierarchy — 4 tiers only
+  // Red danger — risk/warning indicators
+  redDanger: '#DC3C3C',
+  redStrong: 'rgba(220, 60, 60, 0.25)',
+  redMedium: 'rgba(220, 60, 60, 0.15)',
+  redSubtle: 'rgba(220, 60, 60, 0.08)',
+  redGhost: 'rgba(220, 60, 60, 0.03)',
+
+  // Text hierarchy — 5 tiers
   textPrimary: '#FFFFFF',
   textSecondary: 'rgba(255, 255, 255, 0.70)',
+  textMuted: 'rgba(255, 255, 255, 0.55)',
   textTertiary: 'rgba(255, 255, 255, 0.40)',
   textGhost: 'rgba(255, 255, 255, 0.06)',
+
+  // Gold label text
+  goldText: 'rgba(212, 175, 55, 0.60)',
 
   // White opacity helpers
   whiteStrong: 'rgba(255, 255, 255, 0.70)',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -111,11 +111,11 @@ const Index = () => {
           className="flex-1 flex flex-col items-center"
           style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         >
-          {/* Gamma-style card stack — narrow, centered, tight gaps */}
-          <div className="w-full max-w-xl px-4 md:px-6 flex flex-col gap-3 py-6">
+          {/* Gamma-style card stack — narrow, centered, breathing gaps */}
+          <div className="w-full max-w-xl px-5 md:px-8 flex flex-col gap-4 py-6">
 
             {/* ════════════════════════════════════════════════════════
-                1. HERO CARD — gold radial glow, gold headline, tight
+                1. HERO CARD — gold radial glow, gold headline
                 ════════════════════════════════════════════════════════ */}
             <Card
               accent
@@ -126,18 +126,15 @@ const Index = () => {
                 boxShadow: "inset 0 1px 0 rgba(212,175,55,0.06)",
               }}
             >
-              <p
-                className="font-mono text-[10px] uppercase tracking-[0.25em] mb-6"
-                style={{ color: "rgba(212,175,55,0.40)" }}
-              >
+              <p className="font-mono text-[11px] uppercase tracking-[0.20em] mb-6 text-gold-text">
                 Film Finance Simulator
               </p>
 
-              <h1 className="font-bebas text-[clamp(3rem,10vw,4.5rem)] leading-[0.93] tracking-[0.02em] text-gold mb-4">
+              <h1 className="font-bebas text-[clamp(3rem,10vw,4.5rem)] leading-[0.96] tracking-[0.02em] text-gold mb-4">
                 SEE WHERE EVERY DOLLAR GOES
               </h1>
 
-              <p className="text-[15px] leading-[1.7] text-ink-body tracking-[0.02em] mx-auto max-w-sm mb-8">
+              <p className="text-[16px] leading-[1.7] text-ink-body tracking-[0.02em] mx-auto max-w-sm mb-8">
                 Model your waterfall. Know every fee, split, and&nbsp;return
                 — before your investor asks.
               </p>
@@ -160,54 +157,59 @@ const Index = () => {
             </Card>
 
             {/* ════════════════════════════════════════════════════════
-                3. EDUCATION CARD — what is a waterfall
+                3A. EDUCATION CARD — why this matters
                 ════════════════════════════════════════════════════════ */}
             <Card className="px-6 py-8 md:px-8 md:py-10">
-              <p
-                className="font-mono text-[11px] uppercase tracking-[0.18em] text-gold mb-5"
-                style={{ opacity: 0.60 }}
-              >
+              <p className="font-mono text-[11px] uppercase tracking-[0.20em] text-gold-text mb-5">
                 Why This Matters
               </p>
 
-              <h2 className="font-bebas text-[clamp(1.8rem,7vw,2.4rem)] leading-[0.96] tracking-[0.02em] text-white mb-5">
+              <h2 className="font-bebas text-[clamp(2rem,7vw,2.6rem)] leading-[1.05] tracking-[0.02em] text-white mb-5">
                 KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
               </h2>
 
-              <div className="space-y-4">
-                <p className="text-[15px] leading-[1.75] text-ink-body">
-                  Every film deal has a pecking order — distributors, sales agents,
-                  lenders, and investors all get paid before you do.
-                  That's called a <span className="text-gold font-medium">waterfall</span>.
-                </p>
-                <p className="text-[15px] leading-[1.75] text-ink-body">
-                  This tool lets you model yours before you sign anything.
-                  Premium unlocks extended scenarios, financial modeling,
-                  and PDF exports.
-                </p>
-              </div>
+              <p className="text-[16px] leading-[1.7] text-ink-body">
+                Every film deal has a pecking order — distributors, sales agents,
+                lenders, and investors all get paid before you do.
+                That's called a <span className="text-gold font-medium">waterfall</span>.
+              </p>
 
               <a
                 href="/resources?tab=waterfall"
-                className="inline-block mt-6 font-mono text-[12px] tracking-[0.06em] text-gold-cta hover:opacity-70 transition-opacity"
+                className="inline-block mt-6 font-mono text-[11px] tracking-[0.06em] text-gold-cta hover:opacity-70 transition-opacity"
               >
                 What's a waterfall? {"\u2192"}
               </a>
             </Card>
 
             {/* ════════════════════════════════════════════════════════
-                4. WITH CARD — gold border, gold tint, checkmarks
+                3B. TOOL CARD — what you get
                 ════════════════════════════════════════════════════════ */}
-            <div ref={valueRef} className="flex flex-col gap-3">
-              <p className="text-[14px] text-ink-secondary italic leading-relaxed tracking-[0.01em] text-center px-2">
-                My first project premiered at Tribeca and landed on Netflix — and I still had to guess at the math.
+            <Card className="px-6 py-8 md:px-8 md:py-10">
+              <p className="font-mono text-[11px] uppercase tracking-[0.20em] text-gold-text mb-5">
+                What You Get
               </p>
 
+              <h2 className="font-bebas text-[clamp(2rem,7vw,2.6rem)] leading-[1.05] tracking-[0.02em] text-white mb-5">
+                MODEL YOURS BEFORE YOU SIGN&nbsp;ANYTHING
+              </h2>
+
+              <p className="text-[16px] leading-[1.7] text-ink-body">
+                This tool lets you build your own waterfall — map every fee,
+                split, and repayment tier. Premium unlocks extended scenarios,
+                financial modeling, and PDF&nbsp;exports.
+              </p>
+            </Card>
+
+            {/* ════════════════════════════════════════════════════════
+                4. WITH CARD — gold border, gold tint, checkmarks
+                ════════════════════════════════════════════════════════ */}
+            <div ref={valueRef} className="flex flex-col gap-4">
               <Card
                 accent
                 className="px-5 py-6 md:px-6 md:py-8"
               >
-                <h2 className="font-mono text-[13px] tracking-[0.14em] uppercase text-gold mb-6">
+                <h2 className="font-mono text-[11px] tracking-[0.14em] uppercase text-gold-text mb-6">
                   With your waterfall
                 </h2>
                 <ul className="flex flex-col gap-5" aria-label="Benefits of using a waterfall">
@@ -231,26 +233,23 @@ const Index = () => {
                         <span className="text-black text-[18px] font-bold leading-none" aria-hidden="true">{"\u2713"}</span>
                       </div>
                       <div>
-                        <p className="text-[15px] font-semibold text-ink leading-snug">{item.title}</p>
-                        <p className="text-[13px] text-ink-body leading-snug mt-1">{item.desc}</p>
+                        <p className="text-[14px] font-semibold text-ink leading-snug">{item.title}</p>
+                        <p className="text-[14px] text-ink-body leading-snug mt-1">{item.desc}</p>
                       </div>
                     </li>
                   ))}
                 </ul>
               </Card>
 
-              {/* 5. WITHOUT CARD — dimmed, ghosted, no gold */}
+              {/* 5. WITHOUT CARD — red danger treatment, readable */}
               <Card
                 className="px-5 py-6 md:px-6 md:py-8"
                 style={{
-                  background: "rgba(255,255,255,0.015)",
-                  border: "1px solid rgba(255,255,255,0.06)",
+                  background: "rgba(220,60,60,0.03)",
+                  border: "1px solid rgba(220,60,60,0.20)",
                 }}
               >
-                <h2
-                  className="font-mono text-[13px] tracking-[0.14em] uppercase mb-6"
-                  style={{ color: "rgba(255,255,255,0.30)" }}
-                >
+                <h2 className="font-mono text-[11px] tracking-[0.14em] uppercase mb-6 text-danger">
                   Without a waterfall
                 </h2>
                 <ul className="flex flex-col gap-5" aria-label="Risks without a waterfall">
@@ -268,15 +267,15 @@ const Index = () => {
                       <div
                         className="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5"
                         style={{
-                          background: "rgba(255,255,255,0.04)",
-                          border: "1px solid rgba(255,255,255,0.08)",
+                          background: "rgba(220,60,60,0.10)",
+                          border: "1px solid rgba(220,60,60,0.20)",
                         }}
                       >
-                        <span className="text-[16px] font-bold leading-none" aria-hidden="true" style={{ color: "rgba(255,255,255,0.25)" }}>{"\u2717"}</span>
+                        <span className="text-[16px] font-bold leading-none text-danger" aria-hidden="true">{"\u2717"}</span>
                       </div>
                       <div>
-                        <p className="text-[14px] font-semibold leading-snug" style={{ color: "rgba(255,255,255,0.50)" }}>{item.title}</p>
-                        <p className="text-[13px] leading-snug mt-1" style={{ color: "rgba(255,255,255,0.30)" }}>{item.desc}</p>
+                        <p className="text-[14px] font-semibold leading-snug text-ink-body">{item.title}</p>
+                        <p className="text-[14px] leading-snug mt-1 text-ink-muted">{item.desc}</p>
                       </div>
                     </li>
                   ))}
@@ -304,7 +303,7 @@ const Index = () => {
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.05] tracking-[0.04em] text-gold mb-6">
+                <h2 className="font-bebas text-[clamp(2rem,8vw,2.6rem)] leading-[1.05] tracking-[0.02em] text-gold mb-6">
                   YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
                 </h2>
                 <div className="w-full max-w-[300px] mx-auto">
@@ -319,10 +318,14 @@ const Index = () => {
             </Card>
 
             {/* ════════════════════════════════════════════════════════
-                7. FOOTER — no card, just whisper text
+                7. FOOTER — visible disclaimer with top rule
                 ════════════════════════════════════════════════════════ */}
-            <footer className="py-6 px-4 text-center">
-              <p className="text-ink-ghost text-[12px] tracking-wide leading-relaxed mx-auto max-w-sm">
+            <footer className="pt-4 pb-6 px-4 text-center">
+              <div
+                className="mx-auto max-w-[200px] mb-4 h-[1px]"
+                style={{ background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.12) 50%, transparent 100%)" }}
+              />
+              <p className="text-ink-secondary text-[11px] tracking-wide leading-relaxed mx-auto max-w-sm">
                 For educational and informational purposes only. Not legal, tax,
                 or investment advice. Consult a qualified entertainment attorney
                 before making financing decisions.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,7 @@ export default {
           subtle:    "rgba(212, 175, 55, 0.08)",         // background tints, hover fills
           ghost:     "rgba(212, 175, 55, 0.03)",         // ambient glow, large area tints
           deep:      "#7A5C12",                          // gradient depth, shadows
+          text:      "rgba(212, 175, 55, 0.60)",         // readable gold labels/eyebrows
           cta:       "#F9E076",                          // CTA buttons ONLY
           // Legacy aliases for non-landing pages
           label:     "rgba(212, 175, 55, 0.25)",
@@ -60,10 +61,20 @@ export default {
           "cta-subtle": "rgba(212, 175, 55, 0.08)",
         },
 
+        // ── RED DANGER: risk/warning — 4-tier opacity system ──
+        danger: {
+          DEFAULT:   "#DC3C3C",
+          strong:    "rgba(220, 60, 60, 0.25)",
+          medium:    "rgba(220, 60, 60, 0.15)",
+          subtle:    "rgba(220, 60, 60, 0.08)",
+          ghost:     "rgba(220, 60, 60, 0.03)",
+        },
+
         // ── WHITE TEXT: 4 tiers, no drift ──
         ink: {
           DEFAULT:   "#FFFFFF",                          // headlines, key numbers — FULL
           body:      "rgba(255, 255, 255, 0.70)",        // secondary / paragraph text
+          muted:     "rgba(255, 255, 255, 0.55)",        // readable subordinate text
           secondary: "rgba(255, 255, 255, 0.40)",        // tertiary, metadata
           ghost:     "rgba(255, 255, 255, 0.06)",        // hover bg, surface tints
         },


### PR DESCRIPTION
… readability

- Header: widen from 320px to 576px (matches max-w-xl card column), bump FILMMAKER.OG from 22px to 28px, border-radius 8→12px
- Hero: eyebrow 10px→11px with gold-text token (60% opacity), body 15px→16px, headline leading 0.93→0.96
- Education: split single card into two (Why This Matters + What You Get), remove unattributed quote between sections
- Without card: red danger treatment replacing invisible ghost-white, titles/descs now readable (ink-body/ink-muted), red X icons
- Footer: ink-ghost (6% white) → ink-secondary (40% white), add gold gradient top rule
- Card gap: 12px→16px, outer padding px-4→px-5 / md:px-6→md:px-8
- Font audit: unify eyebrows to 11px/0.20em, section headings to clamp(2rem,7vw,2.6rem)/1.05, body to 16px, items to 14px
- Letter-spacing: collapse 9 values to 4 tokens (0.02/0.06/0.14/0.20em)
- New design tokens: danger (red 4-tier), ink-muted (55%), gold-text (60%)
- WaterfallCascade: replace inline rgba with gold-text token, fix invisible footer note (ink-ghost→ink-secondary)

https://claude.ai/code/session_01GN6xfJnfri5W7w3UCn4Zy3