### PR TITLE
feat: landing page design system compliance + visual hierarchy pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-title" content="FILMMAKER.OG" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>FILMMAKER.OG — See Where Every Dollar Goes</title>
     <meta name="description" content="Free film budget calculator and finance simulator. Model your production budget, capital stack, and recoupment waterfall. See who gets paid first, what equity investors earn, and what's left for you — before you sign." />
     <meta name="keywords" content="film budget calculator, movie budget template, film finance simulator, recoupment waterfall, capital stack, indie film budget, production budget breakdown, film investor returns, movie production cost, filmmaker tools" />

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -1,9 +1,11 @@
+import { useState, useEffect } from "react";
 import { Sparkles } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
    OgBotFab — floating action button for the OG bot
-   Bottom-right corner, always visible, opens the bot sheet.
+   Bottom-right corner, hides when closer section is in viewport
+   to avoid overlapping the conversion CTA.
    ═══════════════════════════════════════════════════════════════════ */
 
 interface OgBotFabProps {
@@ -12,11 +14,24 @@ interface OgBotFabProps {
 
 const OgBotFab = ({ onTap }: OgBotFabProps) => {
   const haptics = useHaptics();
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const closer = document.querySelector('[data-section="closer"]');
+    if (!closer) return;
+
+    const obs = new IntersectionObserver(
+      ([entry]) => setHidden(entry.isIntersecting),
+      { threshold: 0.3 },
+    );
+    obs.observe(closer);
+    return () => obs.disconnect();
+  }, []);
 
   return (
     <button
       onClick={() => { haptics.medium(); onTap?.(); }}
-      className="fixed z-[140] flex items-center justify-center active:scale-90 transition-transform"
+      className="fixed z-[140] flex items-center justify-center active:scale-90 transition-all duration-300"
       style={{
         bottom: "calc(20px + env(safe-area-inset-bottom))",
         right: "20px",
@@ -26,6 +41,8 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
         background: "#000000",
         border: "1px solid rgba(212,175,55,0.15)",
         boxShadow: "0 4px 20px rgba(0,0,0,0.80)",
+        opacity: hidden ? 0 : 1,
+        pointerEvents: hidden ? "none" : "auto",
       }}
       aria-label="Open OG assistant"
     >

--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -1,5 +1,17 @@
 import { useState, useEffect, useRef } from "react";
 
+/*
+   TYPE HIERARCHY (enforced):
+     Acquisition Price label   → text-[14px] mono uppercase (data label)
+     Acquisition Price amount  → text-[18px]/text-[20px] mono bold (largest in ledger)
+     Deduction row names       → text-[14px] (body tier)
+     Deduction row amounts     → text-[14px] mono (matches names)
+     Net Profits label         → text-[12px] mono uppercase gold
+     Net Profits amount        → text-[28px]/text-[32px] mono bold WHITE (largest number)
+     Producer/Investor labels  → text-[12px] mono uppercase gold
+     Producer/Investor amounts → text-[18px]/text-[20px] mono bold (subordinate to Net Profits)
+*/
+
 const TOTAL = 3_000_000;
 const PROFIT = 417_500;
 
@@ -63,15 +75,15 @@ const WaterfallCascade = () => {
     <div ref={containerRef} className="pt-2 pb-2">
       {/* Ledger card — gold border, black interior */}
       <div
-        className="overflow-hidden rounded-xl"
-        style={{ border: "1px solid rgba(212,175,55,0.15)", background: "#000" }}
+        className="overflow-hidden"
+        style={{ border: "1px solid rgba(212,175,55,0.15)", borderRadius: "8px", background: "#000" }}
       >
         {/* Acquisition price header row */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
-          <span className="font-bebas text-[22px] tracking-[0.06em] text-white-primary">
+          <span className="font-mono text-[14px] uppercase tracking-[0.12em]" style={{ color: "rgba(255,255,255,0.7)" }}>
             Acquisition Price
           </span>
-          <span className="font-mono text-sm md:text-base font-medium text-white-primary tabular-nums">
+          <span className="font-mono text-[18px] md:text-[20px] font-bold text-white tabular-nums">
             {fmt(TOTAL)}
           </span>
         </div>
@@ -104,10 +116,10 @@ const WaterfallCascade = () => {
                   transitionDelay: `${(i + 1) * 150}ms`,
                 }}
               >
-                <span className="text-sm font-medium text-white-primary">
+                <span className="text-[14px] font-medium" style={{ color: "rgba(255,255,255,0.7)" }}>
                   {d.name}
                 </span>
-                <span className="font-mono text-sm md:text-base font-medium text-white-primary tabular-nums">
+                <span className="font-mono text-[14px] font-medium text-white tabular-nums">
                   <span className="text-ink-secondary">{"\u2212"}</span>{fmt(d.amount)}
                 </span>
               </div>
@@ -118,8 +130,9 @@ const WaterfallCascade = () => {
 
       {/* Profit box — thick gold border + glow */}
       <div
-        className="mt-2 rounded-xl py-5 bg-black text-center"
+        className="mt-2 py-5 bg-black text-center"
         style={{
+          borderRadius: "8px",
           border: "2px solid rgba(212,175,55,1.0)",
           background: "rgba(212,175,55,0.08)",
           boxShadow: "0 0 16px 0px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)",
@@ -129,15 +142,15 @@ const WaterfallCascade = () => {
           transitionDelay: "1400ms",
         }}
       >
-        <p className="font-mono text-sm tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
+        <p className="font-mono text-[12px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
           Net Profits
         </p>
-        <span className="font-mono text-lg md:text-xl font-bold text-gold-full tracking-tight tabular-nums">
+        <span className="font-mono text-[28px] md:text-[32px] font-bold text-white tracking-tight tabular-nums">
           ${profitCount.toLocaleString()}
         </span>
       </div>
 
-      {/* Producer / Investor split — two small gold-bordered cards */}
+      {/* Producer / Investor split — two small cards */}
       <div className="grid grid-cols-2 gap-2 mt-2">
         {([
           { label: "Producer", amount: "$208,750", delay: 0 },
@@ -145,9 +158,10 @@ const WaterfallCascade = () => {
         ]).map((c) => (
           <div
             key={c.label}
-            className="px-3.5 py-3.5 text-center rounded-xl"
+            className="px-3.5 py-3.5 text-center"
             style={{
-              border: "1px solid rgba(212,175,55,0.15)",
+              borderRadius: "8px",
+              border: "1px solid rgba(255,255,255,0.15)",
               background: "rgba(212,175,55,0.08)",
               opacity: splitVisible ? 1 : 0,
               transform: splitVisible ? "translateY(0)" : "translateY(16px)",
@@ -155,17 +169,17 @@ const WaterfallCascade = () => {
               transitionDelay: `${c.delay}ms`,
             }}
           >
-            <p className="font-mono text-sm tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
+            <p className="font-mono text-[12px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
               {c.label}
             </p>
-            <span className="font-mono text-[22px] font-bold text-gold-full tabular-nums">
+            <span className="font-mono text-[18px] md:text-[20px] font-bold text-gold-full tabular-nums">
               {c.amount}
             </span>
           </div>
         ))}
       </div>
 
-      <p className="font-mono text-sm text-ink-secondary text-center mt-3.5">
+      <p className="font-mono text-[12px] text-ink-secondary text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
       </p>

--- a/src/hooks/useInView.tsx
+++ b/src/hooks/useInView.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 
 export function useInView<T extends HTMLElement>(options?: IntersectionObserverInit) {
   const ref = useRef<T | null>(null);
   const [inView, setInView] = useState(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableOptions = useMemo(() => options ?? { threshold: 0.12 }, [JSON.stringify(options)]);
 
   useEffect(() => {
     const el = ref.current;
@@ -12,16 +14,15 @@ export function useInView<T extends HTMLElement>(options?: IntersectionObserverI
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           setInView(true);
-          // we only need the entrance once — stop observing to keep work minimal
           obs.unobserve(entry.target);
         }
       });
-    }, options ?? { threshold: 0.12 });
+    }, stableOptions);
 
     observer.observe(el);
 
     return () => observer.disconnect();
-  }, [options]);
+  }, [stableOptions]);
 
   return { ref, inView };
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,19 +5,6 @@ import { useHaptics } from "@/hooks/use-haptics";
 import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import WaterfallCascade from "@/components/WaterfallCascade";
-/* ═══════════════════════════════════════════════════════════════════
-   SHARED PRIMITIVES — design-system compliant, token-based
-   ═══════════════════════════════════════════════════════════════════ */
-/** Gold gradient divider — fades from transparent edges to gold center */
-const Divider = () => (
-  <div
-    className="h-[1px] w-full"
-    style={{
-      background:
-        "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.25) 50%, transparent 100%)",
-    }}
-  />
-);
 const Index = () => {
   const navigate = useNavigate();
   const haptics = useHaptics();
@@ -54,6 +41,7 @@ const Index = () => {
     return () => clearTimeout(timeout);
   }, [prefersReducedMotion]);
   /* ── Scroll-reveal refs ── */
+  const { ref: waterfallRef, inView: waterfallVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: caseRef, inView: caseVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: priceRef, inView: priceVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: closerRef, inView: closerVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
@@ -87,13 +75,14 @@ const Index = () => {
           className="flex-1 flex flex-col items-center"
           style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         >
-          <div className="w-full max-w-xl px-5 md:px-8 flex flex-col gap-5 py-6">
+          <div className="w-full max-w-xl px-5 md:px-8 flex flex-col gap-8 py-6">
             {/* ════════════════════════════════════════════════════════
-                1. HERO — primary conversion card (rounded-2xl)
+                1. HERO — primary conversion card
                 ════════════════════════════════════════════════════════ */}
             <div
-              className="rounded-2xl px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
+              className="px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
               style={{
+                borderRadius: "8px",
                 background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 40%, transparent 100%)",
                 border: "1px solid rgba(212,175,55,0.25)",
                 boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06), 0 0 40px rgba(212,175,55,0.03)",
@@ -118,17 +107,20 @@ const Index = () => {
                 </button>
               </div>
             </div>
-            <Divider />
             {/* ════════════════════════════════════════════════════════
                 2. WATERFALL CASCADE — interactive proof-of-concept
-                   (rounded-xl data card treatment)
                 ════════════════════════════════════════════════════════ */}
             <div
-              className="rounded-xl px-5 py-6 md:px-6 md:py-8 overflow-hidden"
+              ref={waterfallRef}
+              className="px-5 py-6 md:px-6 md:py-8 overflow-hidden"
               style={{
-                background: "rgba(255,255,255,0.04)",
+                borderRadius: "8px",
+                background: "#111111",
                 border: "1px solid rgba(212,175,55,0.15)",
                 boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+                opacity: prefersReducedMotion || waterfallVisible ? 1 : 0,
+                transform: prefersReducedMotion || waterfallVisible ? "translateY(0)" : "translateY(20px)",
+                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
               }}
             >
               <p className="max-w-2xl mx-auto text-center text-white-body text-[16px] leading-relaxed mb-8">
@@ -136,7 +128,6 @@ const Index = () => {
               </p>
               <WaterfallCascade />
             </div>
-            <Divider />
             {/* ════════════════════════════════════════════════════════
                 3. THE CASE — merged education + evidence
                    Wide card → 2-up evidence grid below
@@ -144,9 +135,10 @@ const Index = () => {
             <div ref={caseRef} className="flex flex-col gap-4">
               {/* Education card — the "why" */}
               <div
-                className="rounded-xl px-6 py-8 md:px-8 md:py-10 overflow-hidden"
+                className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
                 style={{
-                  background: "rgba(255,255,255,0.04)",
+                  borderRadius: "8px",
+                  background: "rgba(212,175,55,0.03)",
                   border: "1px solid rgba(212,175,55,0.15)",
                   boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                   opacity: prefersReducedMotion || caseVisible ? 1 : 0,
@@ -157,7 +149,7 @@ const Index = () => {
                 <p className="font-mono text-[14px] uppercase tracking-[0.20em] text-gold-full mb-5">
                   Why This Matters
                 </p>
-                <h2 className="font-bebas text-[28px] md:text-[40px] leading-[1.05] tracking-[0.06em] text-white mb-5">
+                <h2 className="font-bebas text-[26px] md:text-[36px] leading-[1.05] tracking-[0.06em] text-white mb-5">
                   KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
                 </h2>
                 <p className="text-[16px] leading-relaxed text-white-body">
@@ -167,21 +159,16 @@ const Index = () => {
                   This tool lets you map every fee, split, and repayment tier so you
                   walk into those conversations already knowing the math.
                 </p>
-                <a
-                  href="/resources?tab=waterfall"
-                  className="inline-block mt-6 font-mono text-[14px] tracking-[0.06em] text-gold-cta hover:opacity-70 transition-opacity"
-                >
-                  What's a waterfall? {"\u2192"}
-                </a>
               </div>
               {/* Evidence panels — 2-up grid */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {evidencePanels.map((panel, i) => (
                   <div
                     key={panel.label}
-                    className="rounded-xl p-5 md:p-6 overflow-hidden"
+                    className="p-5 md:p-6 overflow-hidden"
                     style={{
-                      background: "rgba(255,255,255,0.04)",
+                      borderRadius: "8px",
+                      background: "#111111",
                       border: "1px solid rgba(212,175,55,0.15)",
                       opacity: prefersReducedMotion || caseVisible ? 1 : 0,
                       transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(20px)",
@@ -201,22 +188,54 @@ const Index = () => {
                         background: "linear-gradient(90deg, transparent 0%, rgba(212,175,55,0.25) 50%, transparent 100%)",
                       }}
                     />
-                    <p className="text-[14px] md:text-[16px] leading-relaxed text-white font-semibold">
+                    <p className="font-mono text-[14px] uppercase tracking-[0.12em] text-white font-medium">
                       {panel.punchline}
                     </p>
                   </div>
                 ))}
               </div>
+              {/* Evidence sub-cards — compact stat pair, always 2-up */}
+              <div
+                className="grid grid-cols-2 gap-2"
+                style={{
+                  opacity: prefersReducedMotion || caseVisible ? 1 : 0,
+                  transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(12px)",
+                  transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
+                  transitionDelay: prefersReducedMotion ? "0ms" : "400ms",
+                }}
+              >
+                {[
+                  { number: "15–25%", label: "Sales agent off-the-top" },
+                  { number: "EVERY HAND", label: "In the pot before you" },
+                ].map((card) => (
+                  <div
+                    key={card.label}
+                    className="px-3.5 py-3.5 text-center"
+                    style={{
+                      borderRadius: "8px",
+                      background: "#111111",
+                      border: "1px solid rgba(212,175,55,0.15)",
+                    }}
+                  >
+                    <p className="font-mono text-[18px] md:text-[20px] font-bold text-gold-full mb-1">
+                      {card.number}
+                    </p>
+                    <p className="font-mono text-[12px] uppercase tracking-[0.12em]" style={{ color: "rgba(255,255,255,0.7)" }}>
+                      {card.label}
+                    </p>
+                  </div>
+                ))}
+              </div>
             </div>
-            <Divider />
             {/* ════════════════════════════════════════════════════════
                 4. WHAT THIS COSTS — compact, centered
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={priceRef}
-              className="rounded-xl px-6 py-8 md:px-8 md:py-10 text-center overflow-hidden"
+              className="px-6 py-8 md:px-8 md:py-10 text-center overflow-hidden"
               style={{
-                background: "rgba(255,255,255,0.04)",
+                borderRadius: "8px",
+                background: "#111111",
                 border: "1px solid rgba(212,175,55,0.15)",
                 boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                 opacity: prefersReducedMotion || priceVisible ? 1 : 0,
@@ -243,15 +262,47 @@ const Index = () => {
                 </button>
               </div>
             </div>
-            <Divider />
+            {/* Resolution sub-cards — feature pair, always 2-up */}
+            <div
+              className="grid grid-cols-2 gap-2"
+              style={{
+                opacity: prefersReducedMotion || priceVisible ? 1 : 0,
+                transform: prefersReducedMotion || priceVisible ? "translateY(0)" : "translateY(12px)",
+                transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
+                transitionDelay: prefersReducedMotion ? "0ms" : "200ms",
+              }}
+            >
+              {[
+                { number: "EVERY TIER", label: "Off-tops through net profits" },
+                { number: "BREAKEVEN", label: "Know your number" },
+              ].map((card) => (
+                <div
+                  key={card.label}
+                  className="px-3.5 py-3.5 text-center"
+                  style={{
+                    borderRadius: "8px",
+                    background: "#111111",
+                    border: "1px solid rgba(212,175,55,0.15)",
+                  }}
+                >
+                  <p className="font-mono text-[18px] md:text-[20px] font-bold text-gold-full mb-1">
+                    {card.number}
+                  </p>
+                  <p className="font-mono text-[12px] uppercase tracking-[0.12em]" style={{ color: "rgba(255,255,255,0.7)" }}>
+                    {card.label}
+                  </p>
+                </div>
+              ))}
+            </div>
             {/* ════════════════════════════════════════════════════════
                 5. CLOSER CTA — emotional trigger + final conversion
-                   (rounded-2xl feature/CTA treatment)
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={closerRef}
-              className="rounded-2xl px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
+              data-section="closer"
+              className="px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
               style={{
+                borderRadius: "8px",
                 border: "1px solid rgba(212,175,55,0.25)",
                 background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 60%, transparent 100%)",
                 boxShadow: "0 0 60px rgba(212,175,55,0.03), inset 0 1px 0 rgba(255,255,255,0.06)",
@@ -260,13 +311,13 @@ const Index = () => {
                 transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
               }}
             >
-              <h2 className="font-bebas text-[28px] md:text-[40px] leading-[1.05] tracking-[0.06em] text-white mb-6">
+              <h2 className="font-bebas text-[32px] md:text-[44px] leading-[1.05] tracking-[0.06em] text-white mb-6">
                 YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
               </h2>
               <div className="w-full max-w-[280px] mx-auto">
                 <button
                   onClick={handleStartClick}
-                  className="w-full h-14 rounded-sm btn-cta-primary font-bold animate-cta-glow-pulse"
+                  className={`w-full h-14 rounded-sm btn-cta-primary font-bold${closerVisible ? " animate-cta-glow-pulse" : ""}`}
                 >
                   BUILD YOUR WATERFALL
                 </button>
@@ -276,8 +327,7 @@ const Index = () => {
                 6. FOOTER — disclaimer
                 ════════════════════════════════════════════════════════ */}
             <footer className="pt-4 pb-6 px-4 text-center">
-              <Divider />
-              <p className="text-white-tertiary text-[12px] tracking-wide leading-relaxed mx-auto max-w-sm mt-4">
+              <p className="text-ink-body text-[12px] tracking-wide leading-relaxed mx-auto max-w-sm">
                 For educational and informational purposes only. Not legal, tax,
                 or investment advice. Consult a qualified entertainment attorney
                 before making financing decisions.


### PR DESCRIPTION
- Remove Divider component and all instances, increase section gap to 8
- Fix all rounded-2xl/rounded-xl to inline borderRadius 8px max
- Differentiate H2 hierarchy: closer 32/44px, case 26/36px
- Evidence punchlines to mono uppercase for clear differentiation
- Education card background to gold-ghost for warmth escalation
- Add evidence + resolution sub-cards (2-up stat/feature pairs)
- Add waterfall scroll-reveal animation
- Closer CTA glow triggers on scroll, not page load
- Add data-section="closer" for FAB intersection observer
- Fix footer readability: bump white 0.40 at 12px to ink-body 0.70
- WaterfallCascade: fix all banned text sizes (text-sm/lg/xl → explicit px)
- WaterfallCascade: acquisition label to mono uppercase data label
- WaterfallCascade: Net Profits amount to 28/32px white (largest number)
- WaterfallCascade: Producer/Investor borders to white for differentiation
- OgBotFab: hide when closer section is in viewport
- useInView: stabilize options with useMemo to prevent re-renders
- index.html: add Google Fonts preconnect hints

https://claude.ai/code/session_016FTKZRUwm78WaczneKPP1y