### PR TITLE
refactor(landing): restructure hero + waterfall + case sections

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -7,9 +7,9 @@ import { useState, useEffect, useRef } from "react";
      Deduction row names       → text-[14px] (body tier)
      Deduction row amounts     → text-[14px] mono (matches names)
      Net Profits label         → text-[12px] mono uppercase gold
-     Net Profits amount        → text-[28px]/text-[32px] mono bold WHITE (largest number)
+     Net Profits amount        → text-[28px]/text-[32px] mono bold GOLD (largest number, climactic reveal)
      Producer/Investor labels  → text-[12px] mono uppercase gold
-     Producer/Investor amounts → text-[18px]/text-[20px] mono bold (subordinate to Net Profits)
+     Producer/Investor amounts → text-[18px]/text-[20px] mono bold WHITE (subordinate to Net Profits)
 */
 
 const TOTAL = 3_000_000;
@@ -38,11 +38,11 @@ const WaterfallCascade = () => {
     const obs = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          delay = setTimeout(() => setRevealed(true), 400);
+          delay = setTimeout(() => setRevealed(true), 200);
           obs.disconnect();
         }
       },
-      { threshold: 0.25 }
+      { threshold: 0.15 }
     );
     obs.observe(el);
     return () => { obs.disconnect(); clearTimeout(delay); };
@@ -139,7 +139,7 @@ const WaterfallCascade = () => {
         <p className="font-mono text-[12px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
           Net Profits
         </p>
-        <span className="font-mono text-[28px] md:text-[32px] font-bold text-white tracking-tight tabular-nums">
+        <span className="font-mono text-[28px] md:text-[32px] font-bold text-gold-full tracking-tight tabular-nums">
           ${profitCount.toLocaleString()}
         </span>
       </div>
@@ -166,7 +166,7 @@ const WaterfallCascade = () => {
             <p className="font-mono text-[12px] tracking-[0.14em] uppercase font-semibold mb-1 text-gold-full">
               {c.label}
             </p>
-            <span className="font-mono text-[18px] md:text-[20px] font-bold text-gold-full tabular-nums">
+            <span className="font-mono text-[18px] md:text-[20px] font-bold text-white tabular-nums">
               {c.amount}
             </span>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -37,27 +37,16 @@ const Index = () => {
     && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   useEffect(() => {
     if (prefersReducedMotion) return;
-    const timeout = setTimeout(() => setCtaGlow(true), 3500);
+    const timeout = setTimeout(() => setCtaGlow(true), 2000);
     return () => clearTimeout(timeout);
   }, [prefersReducedMotion]);
   /* ── Scroll-reveal refs ── */
   const { ref: waterfallRef, inView: waterfallVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: caseRef, inView: caseVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
+  const { ref: evidenceRef, inView: evidenceVisible } = useInView<HTMLDivElement>({ threshold: 0.1 });
   const { ref: priceRef, inView: priceVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: closerRef, inView: closerVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
-  /* ── Evidence panel data — the two strongest ── */
-  const evidencePanels = [
-    {
-      label: "NEGOTIATING BLIND",
-      body: "Sales agents take 15-25% off the top. CAM fees eat another 1-2% of gross. The distributor takes their fee before your investors see anything. If you don't know these numbers going in, you're not negotiating.",
-      punchline: "You're guessing.",
-    },
-    {
-      label: "THE MEETING YOU'RE NOT READY FOR",
-      body: "You walk into an investor meeting. They ask where their money sits in the recoupment stack. If you can't answer that in 30 seconds with actual numbers, the meeting is over.",
-      punchline: "They just won't tell you it's over.",
-    },
-  ];
+
   return (
     <>
       <LeadCaptureModal
@@ -75,12 +64,12 @@ const Index = () => {
           className="flex-1 flex flex-col items-center"
           style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         >
-          <div className="w-full max-w-xl px-5 md:px-8 flex flex-col gap-8 py-6">
+          <div className="w-full max-w-xl md:max-w-2xl lg:max-w-3xl px-5 md:px-8 flex flex-col gap-8 lg:gap-14 py-6">
             {/* ════════════════════════════════════════════════════════
                 1. HERO — primary conversion card
                 ════════════════════════════════════════════════════════ */}
             <div
-              className="px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
+              className="px-6 py-10 md:px-8 md:py-12 lg:py-14 text-center overflow-hidden"
               style={{
                 borderRadius: "8px",
                 background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 40%, transparent 100%)",
@@ -91,14 +80,10 @@ const Index = () => {
               <p className="font-mono text-[14px] uppercase tracking-[0.20em] mb-6 text-gold-full">
                 Film Finance Simulator
               </p>
-              <h1 className="font-bebas text-[clamp(3.2rem,11vw,4.8rem)] leading-[0.96] tracking-[0.06em] text-white mb-4">
+              <h1 className="font-bebas text-[clamp(3.2rem,9vw,5.2rem)] leading-[0.96] tracking-[0.06em] text-white mb-4">
                 SEE WHERE EVERY DOLLAR GOES
               </h1>
-              <p className="text-[16px] md:text-[18px] leading-[1.7] text-ink-body tracking-[0.02em] mx-auto max-w-sm mb-8" style={{ textWrap: "balance" as never }}>
-                Model your waterfall. Know every fee, split, and&nbsp;return
-                — before your investor asks.
-              </p>
-              <div className="w-full max-w-[280px] mx-auto">
+              <div className="w-full max-w-[280px] lg:max-w-[320px] mx-auto">
                 <button
                   onClick={handleStartClick}
                   className={`w-full h-14 rounded-sm btn-cta-primary font-bold${ctaGlow ? " animate-cta-glow-pulse" : ""}`}
@@ -116,109 +101,112 @@ const Index = () => {
               style={{
                 borderRadius: "8px",
                 background: "#111111",
-                border: "1px solid rgba(212,175,55,0.15)",
+                border: "1px solid rgba(212,175,55,0.25)",
                 boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                 opacity: prefersReducedMotion || waterfallVisible ? 1 : 0,
                 transform: prefersReducedMotion || waterfallVisible ? "translateY(0)" : "translateY(20px)",
                 transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
               }}
             >
-              <p className="max-w-2xl mx-auto text-center text-ink-body text-[16px] leading-relaxed mb-8">
-                The waterfall dictates who gets paid first, who gets paid last, and how much is left by the time it reaches you.
+              <p className="text-center text-ink-body text-[16px] md:text-[18px] leading-relaxed mb-8" style={{ textWrap: "balance" as never }}>
+                This is what happens to $3M in revenue before you see a dollar.
               </p>
               <WaterfallCascade />
             </div>
             {/* ════════════════════════════════════════════════════════
-                3. THE CASE — merged education + evidence
-                   Wide card → 2-up evidence grid below
+                3. EDUCATION — "Why This Matters" conceptual card
                 ════════════════════════════════════════════════════════ */}
-            <div ref={caseRef} className="flex flex-col gap-4">
-              {/* Education card — the "why" */}
+            <div
+              ref={caseRef}
+              className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
+              style={{
+                borderRadius: "8px",
+                background: "rgba(212,175,55,0.03)",
+                border: "1px solid rgba(212,175,55,0.25)",
+                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+                opacity: prefersReducedMotion || caseVisible ? 1 : 0,
+                transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(20px)",
+                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
+              }}
+            >
+              <p className="font-mono text-[14px] uppercase tracking-[0.20em] text-gold-full mb-5">
+                Why This Matters
+              </p>
+              <h2 className="font-bebas text-[28px] md:text-[36px] leading-[1.05] tracking-[0.06em] text-white mb-5">
+                KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
+              </h2>
+              <p className="text-[16px] leading-relaxed text-ink-body">
+                Every film deal has a pecking order — distributors, sales agents,
+                lenders, and investors all get paid before you do.
+                That's called a <span className="text-gold-full font-medium">waterfall</span>.
+                This tool lets you map every fee, split, and repayment tier so you
+                walk into those conversations already knowing the math.
+              </p>
+            </div>
+
+            {/* ════════════════════════════════════════════════════════
+                4. EVIDENCE — "The Reality" practical card
+                ════════════════════════════════════════════════════════ */}
+            <div
+              ref={evidenceRef}
+              className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
+              style={{
+                borderRadius: "8px",
+                background: "#111111",
+                border: "1px solid rgba(212,175,55,0.25)",
+                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+                opacity: prefersReducedMotion || evidenceVisible ? 1 : 0,
+                transform: prefersReducedMotion || evidenceVisible ? "translateY(0)" : "translateY(20px)",
+                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
+              }}
+            >
+              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-5">
+                The Reality
+              </p>
+
+              {/* Evidence Block 1 — NEGOTIATING BLIND */}
               <div
-                className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
                 style={{
-                  borderRadius: "8px",
-                  background: "rgba(212,175,55,0.03)",
-                  border: "1px solid rgba(212,175,55,0.15)",
-                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                  opacity: prefersReducedMotion || caseVisible ? 1 : 0,
-                  transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(20px)",
+                  opacity: prefersReducedMotion || evidenceVisible ? 1 : 0,
+                  transform: prefersReducedMotion || evidenceVisible ? "translateY(0)" : "translateY(12px)",
                   transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
                 }}
               >
-                <p className="font-mono text-[14px] uppercase tracking-[0.20em] text-gold-full mb-5">
-                  Why This Matters
+                <p className="font-mono text-[20px] md:text-[24px] font-bold text-gold-full mb-1">
+                  15–25%
                 </p>
-                <h2 className="font-bebas text-[28px] md:text-[36px] leading-[1.05] tracking-[0.06em] text-white mb-5">
-                  KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
-                </h2>
-                <p className="text-[16px] leading-relaxed text-ink-body">
-                  Every film deal has a pecking order — distributors, sales agents,
-                  lenders, and investors all get paid before you do.
-                  That's called a <span className="text-gold-full font-medium">waterfall</span>.
-                  This tool lets you map every fee, split, and repayment tier so you
-                  walk into those conversations already knowing the math.
+                <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-4">
+                  Negotiating Blind
+                </p>
+                <p className="text-[14px] md:text-[16px] leading-relaxed text-ink-body mb-3">
+                  Sales agents take 15-25% off the top. CAM fees eat another 1-2% of gross. The distributor takes their fee before your investors see anything. If you don't know these numbers going in, you're not negotiating.
+                </p>
+                <p className="font-mono text-[14px] uppercase tracking-[0.12em] text-white font-medium">
+                  You're guessing.
                 </p>
               </div>
-              {/* Evidence panels — 2-up grid */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {evidencePanels.map((panel, i) => (
-                  <div
-                    key={panel.label}
-                    className="p-5 md:p-6 overflow-hidden"
-                    style={{
-                      borderRadius: "8px",
-                      background: "#111111",
-                      border: "1px solid rgba(212,175,55,0.15)",
-                      opacity: prefersReducedMotion || caseVisible ? 1 : 0,
-                      transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(20px)",
-                      transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-                      transitionDelay: prefersReducedMotion ? "0ms" : `${(i + 1) * 200}ms`,
-                    }}
-                  >
-                    <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-4">
-                      {panel.label}
-                    </p>
-                    <p className="text-[14px] md:text-[16px] leading-relaxed text-ink-body mb-4">
-                      {panel.body}
-                    </p>
-                    <p className="font-mono text-[14px] uppercase tracking-[0.12em] text-white font-medium">
-                      {panel.punchline}
-                    </p>
-                  </div>
-                ))}
-              </div>
-              {/* Evidence sub-cards — compact stat pair, always 2-up */}
+
+              {/* Divider */}
+              <div className="my-6 md:my-8" style={{ height: "1px", background: "rgba(255,255,255,0.06)" }} />
+
+              {/* Evidence Block 2 — THE MEETING YOU'RE NOT READY FOR */}
               <div
-                className="grid grid-cols-2 gap-2"
                 style={{
-                  opacity: prefersReducedMotion || caseVisible ? 1 : 0,
-                  transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(12px)",
-                  transition: prefersReducedMotion ? "none" : "opacity 500ms ease-out, transform 500ms ease-out",
-                  transitionDelay: prefersReducedMotion ? "0ms" : "400ms",
+                  opacity: prefersReducedMotion || evidenceVisible ? 1 : 0,
+                  transform: prefersReducedMotion || evidenceVisible ? "translateY(0)" : "translateY(12px)",
+                  transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
+                  transitionDelay: prefersReducedMotion ? "0ms" : "200ms",
                 }}
               >
-                {[
-                  { number: "15–25%", label: "Sales agent off-the-top" },
-                  { number: "EVERY HAND", label: "In the pot before you" },
-                ].map((card) => (
-                  <div
-                    key={card.label}
-                    className="px-3.5 py-3.5 text-center"
-                    style={{
-                      borderRadius: "8px",
-                      background: "#111111",
-                      border: "1px solid rgba(212,175,55,0.15)",
-                    }}
-                  >
-                    <p className="font-mono text-[18px] md:text-[20px] font-bold text-gold-full mb-1">
-                      {card.number}
-                    </p>
-                    <p className="font-mono text-[12px] uppercase tracking-[0.12em] text-ink-body">
-                      {card.label}
-                    </p>
-                  </div>
-                ))}
+                <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-4">
+                  The Meeting You're Not Ready For
+                </p>
+                <p className="text-[14px] md:text-[16px] leading-relaxed text-ink-body mb-3">
+                  You walk into an investor meeting. They ask where their money sits in the recoupment stack. If you can't answer that in 30 seconds with actual numbers, the meeting is over.
+                </p>
+                <p className="font-mono text-[14px] uppercase tracking-[0.12em] text-white font-medium">
+                  They just won't tell you it's over.
+                </p>
               </div>
             </div>
             {/* ════════════════════════════════════════════════════════


### PR DESCRIPTION
- Responsive content column: max-w-xl → md:2xl → lg:3xl
- Hero: remove redundant subtext, tighten padding, faster CTA glow (2s)
- Waterfall: frame text replaces intro sentence, gold hierarchy fix (net profits → gold, splits → white), faster animation trigger
- The Case: education card + evidence card replace compound section
  - Kill orphaned stat sub-blocks (redundant with evidence text)
  - Evidence card with integrated lead stat + internal dividers
  - "THE REALITY" eyebrow for evidence card entry point
- All values use canonical design system tokens (4-tier gold opacity)

https://claude.ai/code/session_01Hb4ZDqe2Sm1VTMayYHjqJt