### PR TITLE
refactor(landing): intro text into WaterfallCascade, add What It Mode…

### DIFF
--- a/src/components/WaterfallCascade.tsx
+++ b/src/components/WaterfallCascade.tsx
@@ -1,44 +1,36 @@
 import { useState, useEffect, useRef } from "react";
-
 /*
    TYPE HIERARCHY (enforced):
-     Acquisition Price label   → text-[14px] mono uppercase (data label)
-     Acquisition Price amount  → text-[18px]/text-[20px] mono bold (largest in ledger)
-     Deduction row names       → text-[14px] (body tier)
-     Deduction row amounts     → text-[14px] mono (matches names)
+     Acquisition Price label   → text-[14px] mono uppercase ink-body
+     Acquisition Price amount  → text-[18px]/text-[20px] mono bold white
+     Deduction row names       → text-[14px] font-medium ink-body
+     Deduction row amounts     → text-[14px] mono white
      Net Profits label         → text-[12px] mono uppercase gold-full (climactic tier)
-     Net Profits amount        → text-[28px]/text-[32px] mono bold gold-full (largest number, reveal)
-     Producer/Investor labels  → text-[12px] mono uppercase ink-secondary (subordinate — NOT gold)
-     Producer/Investor amounts → text-[18px]/text-[20px] mono bold white (subordinate to Net Profits)
-
-   HIERARCHY RATIONALE:
-     Net Profits is the climactic reveal — full gold label + full gold number.
-     Producer/Investor are a mechanical split of those profits, not a new tier.
-     Using gold-full on the split labels made them read as co-equal to Net Profits.
-     ink-secondary (0.40) correctly subordinates them: you care about the total first,
-     then how it divides. The split card backgrounds are also #111 (neutral/subordinate)
-     vs the profit box's gold-ghost tint — reinforcing the same hierarchy visually.
+     Net Profits amount        → text-[28px]/text-[32px] mono bold gold-full (only gold number — the punchline)
+     Producer/Investor labels  → text-[12px] mono uppercase ink-secondary (subordinate, NOT gold)
+     Producer/Investor amounts → text-[18px]/text-[20px] mono bold white (readable, subordinate)
+   INTRO TEXT:
+     Moved inside this component (previously floated outside in Index.tsx).
+     The framing sentence belongs with the component it introduces.
+   ZEBRA ROWS:
+     Even rows: rgba(212,175,55,0.12) — warmer than previous 0.08.
+     Reads as gold-tinted financial table, not generic gray striping.
 */
-
-const TOTAL   = 3_000_000;
-const PROFIT  = 417_500;
-
+const TOTAL  = 3_000_000;
+const PROFIT = 417_500;
 const deductions = [
-  { name: "CAM Fees",          amount:   22_500 },
-  { name: "Sales Agent",       amount:  450_000 },
-  { name: "Senior Debt",       amount:  440_000 },
-  { name: "Mezzanine",         amount:  230_000 },
+  { name: "CAM Fees",          amount:    22_500 },
+  { name: "Sales Agent",       amount:   450_000 },
+  { name: "Senior Debt",       amount:   440_000 },
+  { name: "Mezzanine",         amount:   230_000 },
   { name: "Equity Recoupment", amount: 1_440_000 },
 ];
-
 const fmt = (n: number) => `$${n.toLocaleString()}`;
-
 const WaterfallCascade = () => {
-  const [revealed,     setRevealed     ] = useState(false);
-  const [profitCount,  setProfitCount  ] = useState(0);
-  const [splitVisible, setSplitVisible ] = useState(false);
+  const [revealed,     setRevealed    ] = useState(false);
+  const [profitCount,  setProfitCount ] = useState(0);
+  const [splitVisible, setSplitVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -55,14 +47,13 @@ const WaterfallCascade = () => {
     obs.observe(el);
     return () => { obs.disconnect(); clearTimeout(delay); };
   }, []);
-
   useEffect(() => {
     if (!revealed) return;
     let rafId: number;
     const timeout = setTimeout(() => {
-      const dur = 1400;
+      const dur   = 1400;
       const start = performance.now();
-      const step = (now: number) => {
+      const step  = (now: number) => {
         const t     = Math.min((now - start) / dur, 1);
         const eased = 1 - Math.pow(1 - t, 3);
         setProfitCount(Math.round(eased * PROFIT));
@@ -72,27 +63,31 @@ const WaterfallCascade = () => {
     }, 1400);
     return () => { clearTimeout(timeout); cancelAnimationFrame(rafId); };
   }, [revealed]);
-
   useEffect(() => {
     if (!revealed) return;
     const timeout = setTimeout(() => setSplitVisible(true), 2000);
     return () => clearTimeout(timeout);
   }, [revealed]);
-
   return (
     <div ref={containerRef} className="pt-2 pb-2">
-
-      {/* Ledger card — gold-medium border, true black interior */}
+      {/* Intro framing — sits inside the component, above the ledger */}
+      <p
+        className="text-center text-ink-body text-[16px] md:text-[18px] leading-relaxed mb-6 px-2"
+        style={{ textWrap: "balance" as never }}
+      >
+        This is what happens to $3M in revenue before you see a dollar.
+      </p>
+      {/* Ledger card — true black interior, gold-medium border */}
       <div
         className="overflow-hidden"
         style={{
-          border: "1px solid rgba(212,175,55,0.15)",
+          border:       "1px solid rgba(212,175,55,0.15)",
           borderRadius: "8px",
-          background: "#000",
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+          background:   "#000000",
+          boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.06)",
         }}
       >
-        {/* Acquisition price header row */}
+        {/* Acquisition price header */}
         <div className="flex justify-between items-baseline px-5 pt-5 pb-4">
           <span className="font-mono text-[14px] uppercase tracking-[0.12em] text-ink-body">
             Acquisition Price
@@ -101,52 +96,47 @@ const WaterfallCascade = () => {
             {fmt(TOTAL)}
           </span>
         </div>
-
-        {/* Deduction rows — zebra-striped with gold-subtle tint */}
+        {/* Deduction rows — gold-tinted zebra at 0.12 (warmer than previous 0.08) */}
         <div
           className="px-5 pt-2 pb-4"
           style={{
-            opacity:   revealed ? 1 : 0,
-            transform: revealed ? "translateY(0)" : "translateY(16px)",
-            transition: "opacity 500ms ease-out, transform 500ms ease-out",
+            opacity:         revealed ? 1 : 0,
+            transform:       revealed ? "translateY(0)" : "translateY(16px)",
+            transition:      "opacity 500ms ease-out, transform 500ms ease-out",
             transitionDelay: "150ms",
           }}
         >
-          {deductions.map((d, i) => {
-            const isEven = i % 2 === 0;
-            return (
-              <div
-                key={d.name}
-                className="flex justify-between items-baseline rounded-md"
-                style={{
-                  padding:    "9px 8px",
-                  margin:     "0 -8px",
-                  background: isEven ? "rgba(212,175,55,0.08)" : "transparent",
-                }}
-              >
-                <span className="text-[14px] font-medium text-ink-body">
-                  {d.name}
-                </span>
-                <span className="font-mono text-[14px] font-medium text-white tabular-nums">
-                  <span className="text-ink-secondary">{"\u2212"}</span>{fmt(d.amount)}
-                </span>
-              </div>
-            );
-          })}
+          {deductions.map((d, i) => (
+            <div
+              key={d.name}
+              className="flex justify-between items-baseline rounded-md"
+              style={{
+                padding:    "9px 8px",
+                margin:     "0 -8px",
+                background: i % 2 === 0 ? "rgba(212,175,55,0.12)" : "transparent",
+              }}
+            >
+              <span className="text-[14px] font-medium text-ink-body">
+                {d.name}
+              </span>
+              <span className="font-mono text-[14px] font-medium text-white tabular-nums">
+                <span className="text-ink-secondary">{"\u2212"}</span>{fmt(d.amount)}
+              </span>
+            </div>
+          ))}
         </div>
       </div>
-
-      {/* Net Profits box — full gold border + gold-ghost bg = climactic reveal */}
+      {/* Net Profits — climactic reveal. Only gold number in the component. */}
       <div
         className="mt-2 py-5 text-center"
         style={{
-          borderRadius: "8px",
-          border:       "1px solid rgba(212,175,55,1.0)",
-          background:   "rgba(212,175,55,0.08)",
-          boxShadow:    "0 0 16px 0px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)",
-          opacity:      revealed ? 1 : 0,
-          transform:    revealed ? "translateY(0)" : "translateY(16px)",
-          transition:   "opacity 500ms ease-out, transform 500ms ease-out",
+          borderRadius:    "8px",
+          border:          "1px solid rgba(212,175,55,1.0)",
+          background:      "rgba(212,175,55,0.08)",
+          boxShadow:       "0 0 16px 0px rgba(212,175,55,0.08), inset 0 1px 0 rgba(212,175,55,0.08)",
+          opacity:         revealed ? 1 : 0,
+          transform:       revealed ? "translateY(0)" : "translateY(16px)",
+          transition:      "opacity 500ms ease-out, transform 500ms ease-out",
           transitionDelay: "1400ms",
         }}
       >
@@ -157,10 +147,10 @@ const WaterfallCascade = () => {
           ${profitCount.toLocaleString()}
         </span>
       </div>
-
-      {/* Producer / Investor split — subordinate to Net Profits
-          Labels: ink-secondary (not gold) — these are a split mechanic, not a new tier.
-          Backgrounds: #111 neutral — cooler than the profit box's gold-ghost tint. */}
+      {/* Producer / Investor split
+          Labels: ink-secondary — subordinate, not a waterfall tier
+          Numbers: full white — high contrast on #111, clearly subordinate to gold above
+          Background: #111 — cooler than profit box gold-ghost tint */}
       <div className="grid grid-cols-2 gap-2 mt-2">
         {([
           { label: "Producer", amount: "$208,750", delay: 0   },
@@ -170,16 +160,15 @@ const WaterfallCascade = () => {
             key={c.label}
             className="px-3.5 py-3.5 text-center"
             style={{
-              borderRadius: "8px",
-              border:       "1px solid rgba(212,175,55,0.15)",
-              background:   "#111111",
-              opacity:      splitVisible ? 1 : 0,
-              transform:    splitVisible ? "translateY(0)" : "translateY(16px)",
-              transition:   "opacity 500ms ease-out, transform 500ms ease-out",
+              borderRadius:    "8px",
+              border:          "1px solid rgba(212,175,55,0.15)",
+              background:      "#111111",
+              opacity:         splitVisible ? 1 : 0,
+              transform:       splitVisible ? "translateY(0)" : "translateY(16px)",
+              transition:      "opacity 500ms ease-out, transform 500ms ease-out",
               transitionDelay: `${c.delay}ms`,
             }}
           >
-            {/* ink-secondary: subordinate label — NOT gold-full */}
             <p className="font-mono text-[12px] tracking-[0.14em] uppercase font-semibold mb-1 text-ink-secondary">
               {c.label}
             </p>
@@ -189,7 +178,6 @@ const WaterfallCascade = () => {
           </div>
         ))}
       </div>
-
       <p className="font-mono text-[12px] text-ink-secondary text-center mt-3.5">
         Hypothetical $1.8M budget{"\u00A0"}{"\u00B7"}{"\u00A0"}$3M
         acquisition{"\u00A0"}{"\u00B7"}{"\u00A0"}50/50 net profit split
@@ -197,5 +185,4 @@ const WaterfallCascade = () => {
     </div>
   );
 };
-
 export default WaterfallCascade;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,13 +5,29 @@ import { useHaptics } from "@/hooks/use-haptics";
 import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import WaterfallCascade from "@/components/WaterfallCascade";
+/*
+  PAGE STACK (7 sections):
+    1. HERO              — warm arrival, primary CTA
+    2. WATERFALL         — interactive proof, intro text inside component
+    3. THE REALITY       — 2x2 stat grid, one sentence per cell
+    4. PRODUCERS         — 3 numbered sub-blocks, diagnosis section
+    5. WHAT IT MODELS    — 2x3 grid showing calculator scope, solution proof
+    6. WHAT THIS COSTS   — FREE reveal, attorney anchor, standalone
+    7. CLOSER            — pure emotional close, single CTA
+  BACKGROUND RULES:
+    Warm cards (Hero, Closer): radial-gradient gold-ghost + gold-strong border (0.25)
+    Content sections (2–6):    #000000 + gold border 0.12
+    Internal sub-elements:     #111111 + gold border 0.15
+  #111 NEVER appears at section level — only inside sections.
+  Every section is identifiable by gold border on pure black, not by fill color.
+*/
 const Index = () => {
-  const navigate = useNavigate();
-  const haptics = useHaptics();
-  const [showLeadCapture, setShowLeadCapture] = useState(false);
+  const navigate  = useNavigate();
+  const haptics   = useHaptics();
+  const [showLeadCapture,    setShowLeadCapture   ] = useState(false);
   const [pendingDestination, setPendingDestination] = useState<string | null>(null);
-  const [hasSession, setHasSession] = useState(false);
-  const [ctaGlow, setCtaGlow] = useState(false);
+  const [hasSession,         setHasSession        ] = useState(false);
+  const [ctaGlow,            setCtaGlow           ] = useState(false);
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session?.user) setHasSession(true);
@@ -42,54 +58,81 @@ const Index = () => {
   }, [prefersReducedMotion]);
   /* ── Scroll-reveal refs ── */
   const { ref: waterfallRef, inView: waterfallVisible } = useInView<HTMLDivElement>({ threshold: 0.15 });
-  const { ref: caseRef,      inView: caseVisible      } = useInView<HTMLDivElement>({ threshold: 0.2  });
-  const { ref: realityRef,   inView: realityVisible   } = useInView<HTMLDivElement>({ threshold: 0.15 });
+  const { ref: realityRef,   inView: realityVisible   } = useInView<HTMLDivElement>({ threshold: 0.1  });
   const { ref: wrongRef,     inView: wrongVisible     } = useInView<HTMLDivElement>({ threshold: 0.1  });
+  const { ref: modelsRef,    inView: modelsVisible    } = useInView<HTMLDivElement>({ threshold: 0.1  });
   const { ref: priceRef,     inView: priceVisible     } = useInView<HTMLDivElement>({ threshold: 0.2  });
   const { ref: closerRef,    inView: closerVisible    } = useInView<HTMLDivElement>({ threshold: 0.2  });
-  /* ── Data ── */
+  /* ── Section data ── */
   const realityQuadrants = [
     {
-      stat: "15–25%",
-      label: "Negotiating Blind",
-      body: "Sales agents take off the top before your investors see a dollar — and most producers agree to it without modeling the impact.",
+      stat:  "15–25%",
+      label: "Off The Top",
+      body:  "Sales agents take their commission before your investors see a single dollar.",
     },
     {
-      stat: "$850/hr",
+      stat:  "$850/hr",
       label: "Legal Reality",
-      body: "That's what an entertainment attorney bills to explain waterfall mechanics. The math doesn't change — just who explains it.",
+      body:  "That's what an entertainment attorney bills to walk you through this math.",
     },
     {
-      stat: "30 Sec",
+      stat:  "30 Sec",
       label: "The Investor Test",
-      body: "That's how long you have to explain your recoupment stack before an investor decides whether you know your deal.",
+      body:  "How long you have to explain your recoupment stack before a room goes cold.",
     },
     {
-      stat: "$0",
-      label: "Net Profit Position",
-      body: "Equity investors sit last. Without modeling every tier above them, they cannot calculate their actual return — and neither can you.",
+      stat:  "$0",
+      label: "Equity Position",
+      body:  "Equity investors sit last. Every tier above them gets paid first — every time.",
     },
   ];
   const producerMistakes = [
     {
-      number: "01",
-      label: "The Waterfall Assumption",
+      number:    "01",
+      label:     "The Waterfall Assumption",
       statement: "They package the deal before modeling who gets paid.",
-      body: "Most producers promise investor returns based on revenue projections — without mapping the recoupment order. By the time the money moves, the waterfall they agreed to makes those returns mathematically impossible.",
+      body:      "Most producers promise investor returns based on revenue projections — without mapping the recoupment order. By the time the money moves, the waterfall they agreed to makes those returns mathematically impossible.",
     },
     {
-      number: "02",
-      label: "The Promise Problem",
+      number:    "02",
+      label:     "The Promise Problem",
       statement: "They over-commit because they've never run the math.",
-      body: "A 50% ROI sounds reasonable until you model the sales agent commission, distributor fee, senior debt, and equity recoupment sitting above it. The promise was made before anyone built the waterfall.",
+      body:      "A 50% ROI sounds reasonable until you model the sales agent commission, distributor fee, senior debt, and equity recoupment sitting above it. The promise was made before anyone built the waterfall.",
     },
     {
-      number: "03",
-      label: "The Hidden Cost Stack",
+      number:    "03",
+      label:     "The Hidden Cost Stack",
       statement: "They don't account for every cost in the stack.",
-      body: "CAM fees, E&O insurance, delivery costs, guild residuals — these come off the top before the waterfall even starts. Miss them in the budget and the shortfall shows up after the money is gone.",
+      body:      "CAM fees, E&O insurance, delivery costs, guild residuals — these come off the top before the waterfall even starts. Miss them in the budget and the shortfall shows up after the money is gone.",
     },
   ];
+  const modelsCells = [
+    { label: "Off-the-Top Fees",     desc: "CAM, E&O, delivery, guild residuals"      },
+    { label: "Sales Agent Take",      desc: "Commission rate, gross vs. adjusted gross" },
+    { label: "Senior Debt",           desc: "Principal + interest repayment order"      },
+    { label: "Mezzanine & Equity",    desc: "Recoupment position and rate"              },
+    { label: "Net Profit Split",      desc: "Producer / investor distribution tiers"    },
+    { label: "Breakeven Point",       desc: "Minimum revenue to clear the stack"        },
+  ];
+  /* ── Shared style helpers ── */
+  const contentCard = (extraStyle?: React.CSSProperties): React.CSSProperties => ({
+    borderRadius: "8px",
+    background:   "#000000",
+    border:       "1px solid rgba(212,175,55,0.12)",
+    boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.06)",
+    ...extraStyle,
+  });
+  const subCell: React.CSSProperties = {
+    borderRadius: "6px",
+    background:   "#111111",
+    border:       "1px solid rgba(212,175,55,0.15)",
+  };
+  const scrollReveal = (visible: boolean, delay = 0): React.CSSProperties => ({
+    opacity:         prefersReducedMotion || visible ? 1 : 0,
+    transform:       prefersReducedMotion || visible ? "translateY(0)" : "translateY(20px)",
+    transition:      prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
+    transitionDelay: prefersReducedMotion ? "0ms" : `${delay}ms`,
+  });
   return (
     <>
       <LeadCaptureModal
@@ -109,15 +152,17 @@ const Index = () => {
         >
           <div className="w-full max-w-xl md:max-w-2xl lg:max-w-3xl px-5 md:px-8 flex flex-col gap-8 lg:gap-20 py-6">
             {/* ════════════════════════════════════════════════════════
-                1. HERO — primary conversion card (untouched)
+                1. HERO — warm arrival card
+                   Radial gold-ghost bg + gold-strong border.
+                   Untouched from previous version.
                 ════════════════════════════════════════════════════════ */}
             <div
               className="px-6 py-10 md:px-8 md:py-12 lg:py-14 text-center overflow-hidden"
               style={{
                 borderRadius: "8px",
-                background: "radial-gradient(ellipse at center top, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 40%, transparent 100%)",
-                border: "1px solid rgba(212,175,55,0.25)",
-                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06), 0 0 40px rgba(212,175,55,0.03)",
+                background:   "radial-gradient(ellipse at center top, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 40%, transparent 100%)",
+                border:       "1px solid rgba(212,175,55,0.25)",
+                boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.06), 0 0 40px rgba(212,175,55,0.03)",
               }}
             >
               <p className="font-mono text-[14px] uppercase tracking-[0.20em] mb-6 text-gold-full">
@@ -136,77 +181,34 @@ const Index = () => {
               </div>
             </div>
             {/* ════════════════════════════════════════════════════════
-                2. WATERFALL CASCADE — stripped outer card, sits on page black
-                   The component's internal ledger card handles its own bg + border.
-                   The #111 outer wrapper was creating a gray sandwich — removed.
+                2. WATERFALL — interactive proof-of-concept
+                   No outer card wrapper — component sits on page black.
+                   Intro text moved inside WaterfallCascade component.
+                   Section wrapper handles scroll reveal only.
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={waterfallRef}
               className="overflow-hidden"
-              style={{
-                opacity: prefersReducedMotion || waterfallVisible ? 1 : 0,
-                transform: prefersReducedMotion || waterfallVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-              }}
+              style={scrollReveal(waterfallVisible)}
             >
-              <p
-                className="text-center text-ink-body text-[16px] md:text-[18px] leading-relaxed mb-6 px-2"
-                style={{ textWrap: "balance" as never }}
-              >
-                This is what happens to $3M in revenue before you see a dollar.
-              </p>
               <WaterfallCascade />
             </div>
             {/* ════════════════════════════════════════════════════════
-                3. WHY IT MATTERS — education card (untouched)
-                ════════════════════════════════════════════════════════ */}
-            <div
-              ref={caseRef}
-              className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background: "rgba(212,175,55,0.03)",
-                border: "1px solid rgba(212,175,55,0.25)",
-                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                opacity: prefersReducedMotion || caseVisible ? 1 : 0,
-                transform: prefersReducedMotion || caseVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-              }}
-            >
-              <p className="font-mono text-[14px] uppercase tracking-[0.20em] text-gold-full mb-5">
-                Why This Matters
-              </p>
-              <h2 className="font-bebas text-[28px] md:text-[36px] leading-[1.05] tracking-[0.06em] text-white mb-5">
-                KNOW YOUR DEAL BEFORE YOU SIGN&nbsp;IT
-              </h2>
-              <p className="text-[16px] leading-relaxed text-ink-body">
-                Every film deal has a pecking order — distributors, sales agents,
-                lenders, and investors all get paid before you do.
-                That's called a <span className="text-gold-full font-medium">waterfall</span>.
-                This tool lets you map every fee, split, and repayment tier so you
-                walk into those conversations already knowing the math.
-              </p>
-            </div>
-            {/* ════════════════════════════════════════════════════════
-                4. THE REALITY — 2x2 quadrant grid
-                   Each cell: large mono stat → label → 1-sentence body
-                   Outer card: #111 elevated. Inner cells: #000 void.
+                3. THE REALITY — 2x2 stat grid
+                   Outer: #000 + gold-subtle border (0.12).
+                   Cells: #111 sub-elements, one sentence per cell.
+                   Framing sentence above the grid sets context.
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={realityRef}
               className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background: "#111111",
-                border: "1px solid rgba(212,175,55,0.15)",
-                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                opacity: prefersReducedMotion || realityVisible ? 1 : 0,
-                transform: prefersReducedMotion || realityVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-              }}
+              style={{ ...contentCard(), ...scrollReveal(realityVisible) }}
             >
-              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-6">
+              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-3">
                 The Reality
+              </p>
+              <p className="text-[16px] leading-relaxed text-ink-body mb-7" style={{ maxWidth: "520px" }}>
+                Most producers walk into distribution meetings without knowing these numbers.
               </p>
               <div className="grid grid-cols-2 gap-3">
                 {realityQuadrants.map((q, i) => (
@@ -214,16 +216,11 @@ const Index = () => {
                     key={q.label}
                     className="px-4 py-5"
                     style={{
-                      borderRadius: "6px",
-                      background: "#000000",
-                      border: "1px solid rgba(212,175,55,0.12)",
-                      opacity: prefersReducedMotion || realityVisible ? 1 : 0,
-                      transform: prefersReducedMotion || realityVisible ? "translateY(0)" : "translateY(12px)",
-                      transition: prefersReducedMotion ? "none" : "opacity 600ms ease-out, transform 600ms ease-out",
-                      transitionDelay: prefersReducedMotion ? "0ms" : `${i * 100}ms`,
+                      ...subCell,
+                      ...scrollReveal(realityVisible, i * 80),
                     }}
                   >
-                    <p className="font-mono text-[22px] md:text-[26px] font-bold text-gold-full mb-1 tabular-nums">
+                    <p className="font-mono text-[22px] md:text-[26px] font-bold text-gold-full mb-1 tabular-nums leading-none">
                       {q.stat}
                     </p>
                     <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-secondary mb-3">
@@ -237,26 +234,18 @@ const Index = () => {
               </div>
             </div>
             {/* ════════════════════════════════════════════════════════
-                5. WHAT PRODUCERS GET WRONG — new section
-                   3 numbered sub-blocks inside one card.
-                   Pattern: number + label → bold statement → body paragraph.
-                   Dividers between blocks (rgba white 0.08).
-                   Tinted background (gold-ghost) to differentiate from Reality.
+                4. WHAT PRODUCERS GET WRONG — diagnosis section
+                   Outer: #000 + gold-subtle border (0.12).
+                   3 numbered sub-blocks, text-only (no sub-cards).
+                   Dividers: rgba white 0.08 between blocks.
+                   Structure per block: number + gold label → bold statement → body.
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={wrongRef}
               className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background: "rgba(212,175,55,0.03)",
-                border: "1px solid rgba(212,175,55,0.15)",
-                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                opacity: prefersReducedMotion || wrongVisible ? 1 : 0,
-                transform: prefersReducedMotion || wrongVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-              }}
+              style={{ ...contentCard(), ...scrollReveal(wrongVisible) }}
             >
-              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-4">
+              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-3">
                 What Producers Get Wrong
               </p>
               <h2 className="font-bebas text-[26px] md:text-[32px] leading-[1.05] tracking-[0.06em] text-white mb-7">
@@ -270,66 +259,94 @@ const Index = () => {
                       style={{ height: "1px", background: "rgba(255,255,255,0.08)" }}
                     />
                   )}
-                  <div>
-                    <div className="flex items-baseline gap-3 mb-2">
-                      <span className="font-mono text-[12px] text-ink-secondary tracking-[0.14em]">
-                        {m.number}
-                      </span>
-                      <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-gold-full">
-                        {m.label}
-                      </span>
-                    </div>
-                    <p className="text-[16px] md:text-[17px] font-semibold text-white leading-snug mb-2">
-                      {m.statement}
-                    </p>
-                    <p className="text-[14px] md:text-[16px] leading-relaxed text-ink-body">
-                      {m.body}
-                    </p>
+                  <div className="flex items-baseline gap-3 mb-2">
+                    <span className="font-mono text-[12px] text-ink-secondary tracking-[0.14em]">
+                      {m.number}
+                    </span>
+                    <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-gold-full">
+                      {m.label}
+                    </span>
                   </div>
+                  <p className="text-[16px] md:text-[17px] font-semibold text-white leading-snug mb-2">
+                    {m.statement}
+                  </p>
+                  <p className="text-[14px] md:text-[16px] leading-relaxed text-ink-body">
+                    {m.body}
+                  </p>
                 </div>
               ))}
             </div>
             {/* ════════════════════════════════════════════════════════
-                6. WHAT THIS COSTS — pure black bg (reveal feel), FREE enlarged
-                   Sub-cards removed — they were feature bullets in disguise.
-                   bg: #000 (not #111) so "FREE" lands as a reveal against page black.
+                5. WHAT IT MODELS — solution proof
+                   Bridges the problem (sections 3–4) to the CTA (sections 6–7).
+                   Shows the calculator's scope before asking them to use it.
+                   Outer: #000 + gold-subtle border (0.12).
+                   2x3 grid of sub-cells: label + one-line description.
+                   Tight, scannable, institutional — not a feature list.
+                ════════════════════════════════════════════════════════ */}
+            <div
+              ref={modelsRef}
+              className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
+              style={{ ...contentCard(), ...scrollReveal(modelsVisible) }}
+            >
+              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-3">
+                What It Models
+              </p>
+              <h2 className="font-bebas text-[26px] md:text-[32px] leading-[1.05] tracking-[0.06em] text-white mb-2">
+                EVERY TIER. EVERY FEE. EVERY SPLIT.
+              </h2>
+              <p className="text-[16px] leading-relaxed text-ink-body mb-7" style={{ maxWidth: "520px" }}>
+                The calculator maps the full recoupment stack — from gross revenue to net profit position.
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                {modelsCells.map((cell, i) => (
+                  <div
+                    key={cell.label}
+                    className="px-4 py-4"
+                    style={{
+                      ...subCell,
+                      ...scrollReveal(modelsVisible, i * 60),
+                    }}
+                  >
+                    <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-gold-full mb-2">
+                      {cell.label}
+                    </p>
+                    <p className="text-[14px] leading-relaxed text-ink-body">
+                      {cell.desc}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            {/* ════════════════════════════════════════════════════════
+                6. WHAT THIS COSTS — FREE reveal, standalone
+                   #000 background so FREE lands as a reveal on true black.
+                   Attorney anchor creates reciprocity before the ask.
+                   No sub-cards — they were feature bullets in disguise.
+                   No CTA here — that belongs only in the closer.
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={priceRef}
               className="px-6 py-10 md:px-8 md:py-12 text-center overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background: "#000000",
-                border: "1px solid rgba(212,175,55,0.15)",
-                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-                opacity: prefersReducedMotion || priceVisible ? 1 : 0,
-                transform: prefersReducedMotion || priceVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
-              }}
+              style={{ ...contentCard(), ...scrollReveal(priceVisible) }}
             >
               <p className="font-mono text-[14px] uppercase tracking-[0.20em] text-gold-full mb-4">
                 What This Costs
               </p>
-              <p className="font-bebas text-[56px] md:text-[64px] leading-[1.0] tracking-[0.06em] text-white mb-4">
+              <p className="font-bebas text-[64px] md:text-[80px] leading-[1.0] tracking-[0.06em] text-white mb-4">
                 FREE
               </p>
-              <p className="max-w-md mx-auto text-[14px] md:text-[16px] leading-relaxed text-ink-body mb-7">
+              <p className="max-w-md mx-auto text-[16px] leading-relaxed text-ink-body">
                 An entertainment attorney bills $500–$850/hr to walk you through
                 waterfall mechanics. This gives you the financial x-ray for free.
               </p>
-              <div className="w-full max-w-[280px] mx-auto">
-                <button
-                  onClick={handleStartClick}
-                  className="w-full h-14 rounded-sm btn-cta-primary font-bold"
-                >
-                  BUILD YOUR WATERFALL
-                </button>
-              </div>
             </div>
             {/* ════════════════════════════════════════════════════════
-                5. CLOSER — warmest card, support copy added, CTA copy differentiated
-                   Support sentence: fear acknowledgment before the button.
-                   CTA copy: "RUN YOUR DEAL FREE" — matches emotional context.
+                7. CLOSER — pure emotional close
+                   Warmest card: radial gold-ghost bg + gold-strong border (0.25).
+                   One headline. One support sentence. One CTA.
+                   No price info — that's handled above.
+                   CTA copy: "RUN YOUR DEAL FREE" — matches earned emotional context.
                 ════════════════════════════════════════════════════════ */}
             <div
               ref={closerRef}
@@ -337,19 +354,17 @@ const Index = () => {
               className="px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
               style={{
                 borderRadius: "8px",
-                border: "1px solid rgba(212,175,55,0.25)",
-                background: "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 60%, transparent 100%)",
-                boxShadow: "0 0 60px rgba(212,175,55,0.03), inset 0 1px 0 rgba(255,255,255,0.06)",
-                opacity: prefersReducedMotion || closerVisible ? 1 : 0,
-                transform: prefersReducedMotion || closerVisible ? "translateY(0)" : "translateY(20px)",
-                transition: prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
+                border:       "1px solid rgba(212,175,55,0.25)",
+                background:   "radial-gradient(ellipse at center 70%, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 60%, transparent 100%)",
+                boxShadow:    "0 0 60px rgba(212,175,55,0.04), inset 0 1px 0 rgba(255,255,255,0.06)",
+                ...scrollReveal(closerVisible),
               }}
             >
               <h2 className="font-bebas text-[32px] md:text-[44px] leading-[1.05] tracking-[0.06em] text-white mb-4">
                 YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
               </h2>
               <p className="max-w-sm mx-auto text-[16px] leading-relaxed text-ink-body mb-7">
-                Most producers walk in with projections. No waterfall. No recoupment order.
+                Most producers walk in with projections and no waterfall.
                 Run the math before the meeting.
               </p>
               <div className="w-full max-w-[280px] mx-auto">
@@ -362,7 +377,7 @@ const Index = () => {
               </div>
             </div>
             {/* ════════════════════════════════════════════════════════
-                8. FOOTER — disclaimer (untouched)
+                FOOTER — disclaimer
                 ════════════════════════════════════════════════════════ */}
             <footer className="pt-4 pb-6 px-4 text-center">
               <p className="text-ink-body text-[12px] tracking-[0.02em] leading-relaxed mx-auto max-w-sm">


### PR DESCRIPTION
…ls section, extract shared style helpers, warmer zebra rows, enlarged FREE, remove mid-page CTAs

- WaterfallCascade: move intro framing sentence inside component, bump zebra tint from 0.08 to 0.12, update hierarchy comment block
- Index: add 7-section page stack with background rules comment, extract contentCard/subCell/scrollReveal style helpers, add "What It Models" 2x3 grid section, tighten Reality quadrant copy, enlarge FREE to 64/80px, remove CTA from price section, remove "Why This Matters" card (merged into Reality framing), update section borders to 0.12 standard

https://claude.ai/code/session_01Sth5SNokjXfHsp3rw6yNMS