### PR TITLE
refactor(landing): redesign page stack — add Arsenal, gold quote, bad…

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,30 +6,23 @@ import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import WaterfallCascade from "@/components/WaterfallCascade";
 /*
-  PAGE STACK — 7 sections:
-    1. HERO          — warm arrival, primary CTA
-    2. WATERFALL     — interactive proof (brownish cast fixed in component)
-    3. THE REALITY   — 2x2 numbered cells, no badges, pure black
-    4. WITH/WITHOUT  — vertical timeline format, continuous line + numbered circles
-    5. FREE          — price reveal, attorney anchor
-    6. QUOTE         — gold border, black bg, gold text (NOT gold bg)
-    7. CLOSER        — single CTA
-  PURE BLACK RULE (enforced):
-    - background: #000000 on ALL section cards
-    - background: transparent where no border needed
-    - NO rgba(212,175,55,x) fills anywhere — causes brownish cast on phones
-    - NO #111111 anywhere
-    - Gold appears ONLY as: border strokes, text color, circle fill on timeline nodes
-    - White appears ONLY as: body text, amounts
-    - Section separation: gold border 0.20–0.25 only
-  EYEBROW TREATMENT:
-    - Gold text + bottom gold underline accent (4px wide, 2px height, gold 0.60)
-    - Sits above section headline, provides visual anchor without fill color
-  WITH/WITHOUT TIMELINE:
-    - Vertical continuous line left side (gold for WITH, red for WITHOUT)
-    - Numbered circles on line (1, 2, 3) — filled gold/red, black number
-    - Items hang to the right of the line
-    - Two separate cards stacked, WITHOUT offset 16px right
+  PAGE STACK — 8 sections:
+    1. HERO         — warm arrival, primary CTA
+    2. WATERFALL    — interactive proof
+    3. THE REALITY  — 2x2 cost comparison: what knowledge actually costs
+    4. WITH/WITHOUT — timeline cards, continuous gold/red line + numbered circles
+    5. ARSENAL      — what you get, institutional tools section
+    6. QUOTE        — Miles' line, gold border on black
+    7. CLOSER       — attorney line + single CTA
+    8. FOOTER
+  FREE SECTION: deliberately removed.
+    The waterfall demo + Reality cells already prove value.
+    Attorney line moves into Closer as final pre-CTA anchor.
+    Standalone FREE section oversells — signals insecurity.
+  BACKGROUND RULES:
+    All sections: #000 + gold border (0.20–0.30)
+    No gold fills anywhere — causes brownish cast on phones
+    Gold = border strokes + text only
 */
 const Index = () => {
   const navigate  = useNavigate();
@@ -66,142 +59,64 @@ const Index = () => {
     const timeout = setTimeout(() => setCtaGlow(true), 2000);
     return () => clearTimeout(timeout);
   }, [prefersReducedMotion]);
-  const { ref: waterfallRef, inView: waterfallVisible } = useInView<HTMLDivElement>({ threshold: 0.1 });
-  const { ref: realityRef,   inView: realityVisible   } = useInView<HTMLDivElement>({ threshold: 0.1 });
-  const { ref: withRef,      inView: withVisible      } = useInView<HTMLDivElement>({ threshold: 0.1 });
-  const { ref: priceRef,     inView: priceVisible     } = useInView<HTMLDivElement>({ threshold: 0.2 });
-  const { ref: quoteRef,     inView: quoteVisible     } = useInView<HTMLDivElement>({ threshold: 0.3 });
-  const { ref: closerRef,    inView: closerVisible    } = useInView<HTMLDivElement>({ threshold: 0.2 });
+  /* ── Scroll refs ── */
+  const { ref: waterfallRef, inView: waterfallVisible } = useInView<HTMLDivElement>({ threshold: 0.1  });
+  const { ref: realityRef,   inView: realityVisible   } = useInView<HTMLDivElement>({ threshold: 0.1  });
+  const { ref: withRef,      inView: withVisible      } = useInView<HTMLDivElement>({ threshold: 0.1  });
+  const { ref: arsenalRef,   inView: arsenalVisible   } = useInView<HTMLDivElement>({ threshold: 0.15 });
+  const { ref: quoteRef,     inView: quoteVisible     } = useInView<HTMLDivElement>({ threshold: 0.3  });
+  const { ref: closerRef,    inView: closerVisible    } = useInView<HTMLDivElement>({ threshold: 0.2  });
   /* ── Data ── */
+  // Reality cells: stat / bold white label / cold one-liner
   const realityCells = [
-    { num: "1", stat: "15–25%",  label: "Sales Agent Cut",         cold: "Before your investors see a dollar." },
-    { num: "2", stat: "$850/hr", label: "Entertainment Attorney",  cold: "If they'll take the meeting."        },
-    { num: "3", stat: "30 Sec",  label: "The Investor Test",       cold: "Before the room decides."            },
-    { num: "4", stat: "$0",      label: "Equity Position",         cold: "You're last. Every time."            },
+    { stat: "$800/hr",   label: "Entertainment Attorney", cold: "If they'll take the meeting."           },
+    { stat: "$5K+",      label: "Producing Consultant",   cold: "If you can afford one."                 },
+    { stat: "$200K",     label: "Film School",            cold: "Four years you don't have."             },
+    { stat: "Your Time", label: "Trial & Error",          cold: "Your investors won't get a second one." },
   ];
+  // With / Without items
   const withItems = [
-    { title: "Returns Mapped",         body: "Every investor sees exactly what they get back — and when."          },
-    { title: "Nothing Hidden",         body: "Fees, splits, and repayment order visible before you commit."        },
-    { title: "Your Margins, Confirmed",body: "Run the numbers on your backend points before you shoot a frame."   },
+    {
+      title: "Returns Mapped",
+      body:  "Every investor sees exactly what they get back — and when.",
+    },
+    {
+      title: "Nothing Hidden",
+      body:  "Fees, splits, and repayment order visible before you commit.",
+    },
+    {
+      title: "Your Margins, Confirmed",
+      body:  "Run the numbers on your backend points before you shoot a frame.",
+    },
   ];
   const withoutItems = [
-    { title: "The Question You Can't Answer", body: "'How do I get my money back?' — and you're improvising."              },
-    { title: "Surprises After Signatures",    body: "Fees and splits you didn't model surface after the deal closes."       },
-    { title: "Dead Backend Points",           body: "Sales agent commission you forgot makes them worthless."               },
+    {
+      title: "The Question You Can't Answer",
+      body:  "'How do I get my money back?' — and you're improvising.",
+    },
+    {
+      title: "Surprises After Signatures",
+      body:  "Fees and splits you didn't model surface after the deal closes.",
+    },
+    {
+      title: "Dead Backend Points",
+      body:  "Sales agent commission you forgot makes them worthless.",
+    },
   ];
-  /* ── Shared helpers ── */
+  /* ── Shared style helpers ── */
+  const contentCard = (extra?: React.CSSProperties): React.CSSProperties => ({
+    borderRadius: "8px",
+    background:   "#000000",
+    border:       "1px solid rgba(212,175,55,0.12)",
+    boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.06)",
+    ...extra,
+  });
   const reveal = (visible: boolean, delay = 0): React.CSSProperties => ({
     opacity:         prefersReducedMotion || visible ? 1 : 0,
     transform:       prefersReducedMotion || visible ? "translateY(0)" : "translateY(20px)",
     transition:      prefersReducedMotion ? "none" : "opacity 700ms ease-out, transform 700ms ease-out",
     transitionDelay: prefersReducedMotion || delay === 0 ? "0ms" : `${delay}ms`,
   });
-  /* Eyebrow — gold text with short underline accent */
-  const Eyebrow = ({ children }: { children: React.ReactNode }) => (
-    <div className="mb-4">
-      <span
-        className="font-mono text-[12px] uppercase tracking-[0.16em] text-gold-full pb-1.5"
-        style={{ borderBottom: "2px solid rgba(212,175,55,0.50)" }}
-      >
-        {children}
-      </span>
-    </div>
-  );
-  /* Timeline card — used for both WITH and WITHOUT */
-  const TimelineCard = ({
-    eyebrow,
-    items,
-    accent,       // gold or red
-    offset = 0,
-    visible,
-    revealDelay = 0,
-  }: {
-    eyebrow: string;
-    items: { title: string; body: string }[];
-    accent: "gold" | "red";
-    offset?: number;
-    visible: boolean;
-    revealDelay?: number;
-  }) => {
-    const lineColor   = accent === "gold" ? "rgba(212,175,55,0.70)" : "rgba(200,60,60,0.70)";
-    const circleBg    = accent === "gold" ? "#D4AF37"               : "rgba(180,40,40,1)";
-    const circleText  = accent === "gold" ? "#000"                  : "#fff";
-    const eyebrowColor= accent === "gold" ? "rgba(212,175,55,1)"    : "rgba(210,70,70,1)";
-    const borderColor = accent === "gold" ? "rgba(212,175,55,0.22)" : "rgba(200,60,60,0.22)";
-    return (
-      <div
-        className="px-6 py-7 overflow-hidden"
-        style={{
-          marginLeft:   `${offset}px`,
-          borderRadius: "8px",
-          background:   "#000000",
-          border:       `1px solid ${borderColor}`,
-          ...reveal(visible, revealDelay),
-        }}
-      >
-        {/* Eyebrow */}
-        <div className="mb-5">
-          <span
-            className="font-mono text-[12px] uppercase tracking-[0.16em] pb-1.5"
-            style={{
-              color:        eyebrowColor,
-              borderBottom: `2px solid ${accent === "gold" ? "rgba(212,175,55,0.50)" : "rgba(200,60,60,0.40)"}`,
-            }}
-          >
-            {eyebrow}
-          </span>
-        </div>
-        {/* Timeline */}
-        <div className="relative">
-          {/* Continuous vertical line */}
-          <div
-            className="absolute"
-            style={{
-              left:       "13px",
-              top:        "14px",
-              bottom:     "14px",
-              width:      "2px",
-              background: lineColor,
-            }}
-          />
-          <div className="flex flex-col gap-7">
-            {items.map((item, i) => (
-              <div
-                key={item.title}
-                className="flex gap-5 items-start"
-                style={reveal(visible, revealDelay + 100 + i * 120)}
-              >
-                {/* Numbered circle — sits on the line */}
-                <div
-                  className="relative flex-shrink-0 flex items-center justify-center font-mono text-[11px] font-bold z-10"
-                  style={{
-                    width:        "28px",
-                    height:       "28px",
-                    borderRadius: "50%",
-                    background:   circleBg,
-                    color:        circleText,
-                    border:       "2px solid #000",
-                    marginTop:    "0px",
-                  }}
-                >
-                  {i + 1}
-                </div>
-                {/* Content */}
-                <div className="pt-0.5">
-                  <p className="text-[16px] font-semibold text-white leading-snug mb-1">
-                    {item.title}
-                  </p>
-                  <p className="text-[14px] leading-relaxed text-ink-body">
-                    {item.body}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    );
-  };
   return (
     <>
       <LeadCaptureModal
@@ -219,16 +134,17 @@ const Index = () => {
           className="flex-1 flex flex-col items-center"
           style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         >
-          <div className="w-full max-w-xl md:max-w-2xl lg:max-w-3xl px-5 md:px-8 flex flex-col gap-8 py-6">
-            {/* ══════════════════════════════
+          <div className="w-full max-w-xl md:max-w-2xl lg:max-w-3xl px-5 md:px-8 flex flex-col gap-8 lg:gap-20 py-6">
+            {/* ═══════════════════════════════════════════
                 1. HERO
-                ══════════════════════════════ */}
+                ═══════════════════════════════════════════ */}
             <div
-              className="px-6 py-10 md:px-8 md:py-14 text-center overflow-hidden"
+              className="px-6 py-10 md:px-8 md:py-12 lg:py-14 text-center overflow-hidden"
               style={{
                 borderRadius: "8px",
-                background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.30)",
+                background:   "radial-gradient(ellipse at center top, rgba(212,175,55,0.08) 0%, rgba(212,175,55,0.03) 40%, transparent 100%)",
+                border:       "1px solid rgba(212,175,55,0.25)",
+                boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.06), 0 0 40px rgba(212,175,55,0.03)",
               }}
             >
               <p className="font-mono text-[14px] uppercase tracking-[0.20em] mb-6 text-gold-full">
@@ -246,169 +162,295 @@ const Index = () => {
                 </button>
               </div>
             </div>
-            {/* ══════════════════════════════
+            {/* ═══════════════════════════════════════════
                 2. WATERFALL
-                ══════════════════════════════ */}
+                ═══════════════════════════════════════════ */}
             <div
               ref={waterfallRef}
               className="px-5 py-7 md:px-6 md:py-9 overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.20)",
-                ...reveal(waterfallVisible),
-              }}
+              style={{ ...contentCard(), ...reveal(waterfallVisible) }}
             >
               <WaterfallCascade />
             </div>
-            {/* ══════════════════════════════
+            {/* ═══════════════════════════════════════════
                 3. THE REALITY
-                2x2 grid — no badge circles,
-                no italic copy, no fills.
-                Stat / bold label / cold line.
-                Pure black cells, gold borders.
-                ══════════════════════════════ */}
+                2x2 numbered cells.
+                Anatomy per cell (ref Image 2 + Image 3):
+                  — Circle number badge: centered on top border
+                  — Large gold stat
+                  — Bold white label ALL CAPS
+                  — Cold one-liner in ink-secondary
+                Grid has pt-6 to give badge room to bleed out.
+                ═══════════════════════════════════════════ */}
             <div
               ref={realityRef}
               className="px-6 py-8 md:px-8 md:py-10 overflow-hidden"
-              style={{
-                borderRadius: "8px",
-                background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.20)",
-                ...reveal(realityVisible),
-              }}
+              style={{ ...contentCard(), ...reveal(realityVisible) }}
             >
-              <Eyebrow>The Reality</Eyebrow>
+              <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-gold-full mb-3">
+                The Reality
+              </p>
               <p className="text-[16px] leading-relaxed text-ink-body mb-8">
                 Most producers walk into distribution meetings without knowing these numbers.
               </p>
-              <div className="grid grid-cols-2 gap-3">
+              {/* pt-5 gives the absolute-positioned number badge room to bleed above each cell */}
+              <div className="grid grid-cols-2 gap-4 pt-5">
                 {realityCells.map((cell, i) => (
                   <div
-                    key={cell.num}
-                    className="px-4 py-5"
+                    key={cell.label}
+                    className="relative px-4 pt-8 pb-5"
                     style={{
                       borderRadius: "6px",
-                      background:   "#000000",
-                      border:       "1px solid rgba(212,175,55,0.18)",
+                      background:   "#111111",
+                      border:       "1px solid rgba(212,175,55,0.15)",
                       ...reveal(realityVisible, i * 90),
                     }}
                   >
-                    {/* Large gold stat */}
+                    {/* Circle number badge — sits on top border, centered */}
+                    <div
+                      className="absolute left-1/2 font-mono text-[11px] font-bold text-black flex items-center justify-center"
+                      style={{
+                        top:             "-14px",
+                        transform:       "translateX(-50%)",
+                        width:           "28px",
+                        height:          "28px",
+                        borderRadius:    "50%",
+                        background:      "#D4AF37",
+                        border:          "2px solid #000",
+                        lineHeight:      "1",
+                      }}
+                    >
+                      {i + 1}
+                    </div>
+                    {/* Stat — gold, large, the number */}
                     <p className="font-mono text-[22px] md:text-[26px] font-bold text-gold-full tabular-nums leading-none mb-2">
                       {cell.stat}
                     </p>
-                    {/* Bold white label */}
-                    <p className="text-[11px] font-bold text-white uppercase tracking-[0.08em] mb-2 leading-snug">
+                    {/* Label — bold white, all caps */}
+                    <p className="text-[11px] font-bold text-white uppercase tracking-[0.08em] mb-3 leading-snug">
                       {cell.label}
                     </p>
-                    {/* Cold one-liner */}
-                    <p className="text-[14px] leading-relaxed text-ink-secondary">
+                    {/* Cold one-liner — small, muted, gut-punch */}
+                    <p className="text-[14px] leading-relaxed text-ink-secondary italic">
                       {cell.cold}
                     </p>
                   </div>
                 ))}
               </div>
             </div>
-            {/* ══════════════════════════════
+            {/* ═══════════════════════════════════════════
                 4. WITH / WITHOUT
-                Vertical timeline, continuous
-                gold/red line, numbered circles.
-                WITHOUT offset 16px right.
-                ══════════════════════════════ */}
+                Two full-width stacked cards.
+                WITHOUT offset 16px right — visual ladder stagger.
+                ✓ gold badge / ✗ red badge per item.
+                Each item: bold white title + body copy.
+                ═══════════════════════════════════════════ */}
             <div ref={withRef} className="flex flex-col gap-3">
-              <TimelineCard
-                eyebrow="With Your Waterfall"
-                items={withItems}
-                accent="gold"
-                offset={0}
-                visible={withVisible}
-                revealDelay={0}
-              />
-              <TimelineCard
-                eyebrow="Without A Waterfall"
-                items={withoutItems}
-                accent="red"
-                offset={16}
-                visible={withVisible}
-                revealDelay={200}
-              />
+              {/* WITH YOUR WATERFALL */}
+              <div
+                className="px-6 py-7 overflow-hidden"
+                style={{
+                  ...contentCard({
+                    border: "1px solid rgba(212,175,55,0.20)",
+                  }),
+                  ...reveal(withVisible),
+                }}
+              >
+                <p className="font-mono text-[12px] uppercase tracking-[0.16em] text-gold-full mb-5">
+                  With Your Waterfall
+                </p>
+                <div className="flex flex-col gap-5">
+                  {withItems.map((item, i) => (
+                    <div
+                      key={item.title}
+                      className="flex gap-4 items-start"
+                      style={reveal(withVisible, 100 + i * 100)}
+                    >
+                      {/* Gold check badge */}
+                      <div
+                        className="flex-shrink-0 flex items-center justify-center text-black font-bold text-[14px]"
+                        style={{
+                          width:        "32px",
+                          height:       "32px",
+                          borderRadius: "6px",
+                          background:   "#D4AF37",
+                          marginTop:    "2px",
+                        }}
+                      >
+                        ✓
+                      </div>
+                      <div>
+                        <p className="text-[16px] font-semibold text-white leading-snug mb-1">
+                          {item.title}
+                        </p>
+                        <p className="text-[14px] leading-relaxed text-ink-body">
+                          {item.body}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              {/* WITHOUT A WATERFALL — offset 16px right for stagger */}
+              <div
+                className="px-6 py-7 overflow-hidden"
+                style={{
+                  marginLeft:   "16px",
+                  borderRadius: "8px",
+                  background:   "#000000",
+                  border:       "1px solid rgba(220,60,60,0.25)",
+                  boxShadow:    "inset 0 1px 0 rgba(255,255,255,0.04)",
+                  ...reveal(withVisible, 200),
+                }}
+              >
+                <p className="font-mono text-[12px] uppercase tracking-[0.16em] mb-5"
+                  style={{ color: "rgba(220,80,80,0.9)" }}>
+                  Without A Waterfall
+                </p>
+                <div className="flex flex-col gap-5">
+                  {withoutItems.map((item, i) => (
+                    <div
+                      key={item.title}
+                      className="flex gap-4 items-start"
+                      style={reveal(withVisible, 300 + i * 100)}
+                    >
+                      {/* Red X badge */}
+                      <div
+                        className="flex-shrink-0 flex items-center justify-center font-bold text-[14px]"
+                        style={{
+                          width:        "32px",
+                          height:       "32px",
+                          borderRadius: "6px",
+                          background:   "rgba(180,40,40,0.25)",
+                          border:       "1px solid rgba(220,60,60,0.40)",
+                          color:        "rgba(220,80,80,1)",
+                          marginTop:    "2px",
+                        }}
+                      >
+                        ✕
+                      </div>
+                      <div>
+                        <p className="text-[16px] font-semibold text-white leading-snug mb-1">
+                          {item.title}
+                        </p>
+                        <p className="text-[14px] leading-relaxed text-ink-body">
+                          {item.body}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
-            {/* ══════════════════════════════
-                5. FREE
-                Pure black, gold border 0.25.
-                No gradient — clean reveal.
-                ══════════════════════════════ */}
+            {/* ═══════════════════════════════════════════
+                5. ARSENAL
+                What you get. Institutional tools section.
+                Two-part card: headline block + inner sub-block
+                with left gold bar accent (ref: Image 3 from session).
+                ═══════════════════════════════════════════ */}
             <div
-              ref={priceRef}
-              className="px-6 py-10 md:px-8 md:py-12 text-center overflow-hidden"
+              ref={arsenalRef}
+              className="overflow-hidden"
               style={{
                 borderRadius: "8px",
                 background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.25)",
-                ...reveal(priceVisible),
+                border:       "1px solid rgba(212,175,55,0.22)",
+                ...reveal(arsenalVisible),
               }}
             >
-              <Eyebrow>What This Costs</Eyebrow>
-              <p className="font-bebas text-[72px] md:text-[88px] leading-[1.0] tracking-[0.06em] text-white mb-5">
-                FREE
-              </p>
-              <p className="max-w-sm mx-auto text-[16px] leading-relaxed text-ink-body">
-                An entertainment attorney bills $500–$850/hr to walk you through
-                waterfall mechanics. This gives you the financial x-ray for free.
-              </p>
+              {/* Top block — WHAT YOU GET */}
+              <div
+                className="px-6 py-8 md:px-8 md:py-10 text-center"
+                style={{ borderBottom: "1px solid rgba(212,175,55,0.15)" }}
+              >
+                <p className="font-mono text-[12px] uppercase tracking-[0.18em] text-gold-full mb-3"
+                  style={{ borderBottom: "2px solid rgba(212,175,55,0.45)", display: "inline-block", paddingBottom: "6px" }}
+                >
+                  What You Get
+                </p>
+                <h3 className="font-bebas text-[clamp(2.4rem,7vw,3.6rem)] leading-[0.96] tracking-[0.06em] text-gold-full mt-4 mb-4">
+                  THE ARSENAL
+                </h3>
+                <p className="max-w-sm mx-auto text-[16px] leading-relaxed text-ink-body">
+                  Institutional-grade deal tools. Built for independent producers
+                  who can't afford to learn the hard way.
+                </p>
+              </div>
+              {/* Bottom block — INSIDE THE ARSENAL */}
+              <div
+                className="relative px-6 py-8 md:px-8 md:py-10"
+                style={{
+                  borderLeft: "3px solid rgba(212,175,55,0.70)",
+                }}
+              >
+                <p className="font-mono text-[12px] uppercase tracking-[0.18em] text-gold-full mb-4">
+                  Inside The Arsenal
+                </p>
+                <h4 className="font-bebas text-[clamp(1.8rem,5vw,2.4rem)] leading-[1.0] tracking-[0.06em] mb-4">
+                  <span className="text-gold-full">NO</span>
+                  <span className="text-white"> GUESSWORK.</span>
+                </h4>
+                <p className="text-[16px] leading-relaxed text-ink-body">
+                  Whether you're modeling your first deal or walking into a meeting
+                  with real capital, there's a tier built for you.
+                </p>
+              </div>
             </div>
-            {/* ══════════════════════════════
-                6. QUOTE
-                Pure black bg. Full gold border.
-                Gold text. NOT a gold background.
-                The gold-bg version read as a
-                coupon/warning label — wrong register.
-                ══════════════════════════════ */}
+            {/* ═══════════════════════════════════════════
+                6. QUOTE CALLOUT
+                Gold background #D4AF37, black text.
+                Miles' line verbatim — no edits.
+                Only gold-bg element on the page.
+                No eyebrow, no headline — just the quote.
+                Scroll reveal on visibility.
+                ═══════════════════════════════════════════ */}
             <div
               ref={quoteRef}
               className="px-7 py-8 md:px-8 md:py-10 overflow-hidden"
               style={{
                 borderRadius: "8px",
-                background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.60)",
+                background:   "#D4AF37",
                 ...reveal(quoteVisible),
               }}
             >
               <div className="flex gap-4 items-start">
+                {/* Quote mark accent */}
                 <span
-                  className="flex-shrink-0 font-bebas text-[48px] text-gold-full leading-none"
-                  style={{ marginTop: "-8px", opacity: 0.40 }}
+                  className="flex-shrink-0 font-bebas text-[48px] text-black leading-none"
+                  style={{ marginTop: "-8px", opacity: 0.25 }}
                 >
                   "
                 </span>
-                <p className="text-[16px] md:text-[18px] font-semibold text-gold-full leading-relaxed">
+                <p className="text-[16px] md:text-[18px] font-semibold text-black leading-relaxed">
                   The creative vision is only half the battle. The other half is proving
                   you can execute that vision responsibly and deliver a return.
                 </p>
               </div>
             </div>
-            {/* ══════════════════════════════
+            {/* ═══════════════════════════════════════════
                 7. CLOSER
-                Strongest gold border on page.
-                One headline. One sentence. One CTA.
-                ══════════════════════════════ */}
+                Attorney line is the final price anchor —
+                lands right before the CTA where it matters.
+                ═══════════════════════════════════════════ */}
             <div
               ref={closerRef}
               data-section="closer"
               className="px-6 py-12 md:px-8 md:py-16 text-center overflow-hidden"
               style={{
                 borderRadius: "8px",
+                border:       "1px solid rgba(212,175,55,0.30)",
                 background:   "#000000",
-                border:       "1px solid rgba(212,175,55,0.35)",
                 ...reveal(closerVisible),
               }}
             >
               <h2 className="font-bebas text-[32px] md:text-[44px] leading-[1.05] tracking-[0.06em] text-white mb-5">
-                YOUR INVESTORS WILL{"\u00A0"}ASK HOW THE MONEY FLOWS BACK.
+                YOUR INVESTORS WILL{" "}ASK HOW THE MONEY FLOWS BACK.
               </h2>
-              <p className="max-w-xs mx-auto text-[16px] leading-relaxed text-ink-body mb-8">
+              <p className="max-w-xs mx-auto text-[16px] leading-relaxed text-ink-body mb-3">
                 Run the math before the meeting.
+              </p>
+              <p className="max-w-xs mx-auto text-[14px] leading-relaxed text-ink-secondary mb-8">
+                An entertainment attorney bills $850/hr for this. Yours is free.
               </p>
               <div className="w-full max-w-[280px] mx-auto">
                 <button
@@ -420,17 +462,12 @@ const Index = () => {
               </div>
             </div>
             {/* FOOTER */}
-            <footer className="pt-2 pb-8 px-4 text-center">
-              <div
-                className="pt-6"
-                style={{ borderTop: "1px solid rgba(212,175,55,0.12)" }}
-              >
-                <p className="text-ink-body text-[12px] tracking-[0.02em] leading-relaxed mx-auto max-w-sm">
-                  For educational and informational purposes only. Not legal, tax,
-                  or investment advice. Consult a qualified entertainment attorney
-                  before making financing decisions.
-                </p>
-              </div>
+            <footer className="pt-4 pb-6 px-4 text-center">
+              <p className="text-ink-body text-[12px] tracking-[0.02em] leading-relaxed mx-auto max-w-sm">
+                For educational and informational purposes only. Not legal, tax,
+                or investment advice. Consult a qualified entertainment attorney
+                before making financing decisions.
+              </p>
             </footer>
           </div>
         </main>


### PR DESCRIPTION
…ge cards, remove FREE section

- Remove standalone FREE section (oversells, signals insecurity)
- Move attorney price anchor into Closer as pre-CTA line
- Add Arsenal section: two-part card with gold bar accent, "What You Get" / "Inside The Arsenal"
- Quote callout: gold bg (#D4AF37) with black text (only gold-bg element on page)
- Reality cells: new cost-comparison data ($800/hr, $5K+, $200K, Your Time), circle number badges centered on top border, #111 cell bg, italic cold lines
- With/Without: replace timeline with check/X badge format (✓ gold / ✕ red squares)
- Hero: radial gradient glow, inset box-shadow
- contentCard helper for consistent section styling
- Remove Eyebrow/TimelineCard components, priceRef/priceVisible
- lg:gap-20 restored for desktop spacing
- Footer simplified (no gold divider)

https://claude.ai/code/session_01Sth5SNokjXfHsp3rw6yNMS