### PR TITLE
unify AppHeader across all pages & boost search bar visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useState } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import ErrorBoundary from "./components/ErrorBoundary";
 import OgBotFab from "./components/OgBotFab";
 import OgBotSheet from "./components/OgBotSheet";
@@ -48,17 +48,11 @@ const queryClient = new QueryClient();
 const AppShell = () => {
   const [isBotOpen, setIsBotOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const location = useLocation();
-  const isLanding = location.pathname === "/";
-
   return (
     <>
-      {/* Landing page (v8) has its own pill nav — hide global header there */}
-      {!isLanding && (
-        <AppHeader
-          onMoreOpen={() => setIsMenuOpen(true)}
-        />
-      )}
+      <AppHeader
+        onMoreOpen={() => setIsMenuOpen(true)}
+      />
 
       <Suspense fallback={<PageLoader />}>
         <Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,6 @@ import { supabase } from "@/integrations/supabase/client";
 import { useHaptics } from "@/hooks/use-haptics";
 import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
-import MobileMenu from "@/components/MobileMenu";
 /*
   PAGE STACK — v12 Producer's Cut:
     1. PILL NAV     — fixed floating, logo + hamburger
@@ -27,7 +26,7 @@ const Index = () => {
   const [showLeadCapture, setShowLeadCapture] = useState(false);
   const [pendingDestination, setPendingDestination] = useState<string | null>(null);
   const [hasSession, setHasSession] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
+
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -127,7 +126,6 @@ const Index = () => {
 
   return (
     <>
-      <MobileMenu isOpen={menuOpen} onOpenChange={setMenuOpen} />
       <LeadCaptureModal
         isOpen={showLeadCapture}
         onClose={() => setShowLeadCapture(false)}
@@ -148,26 +146,6 @@ const Index = () => {
       `}</style>
 
       <div style={{ minHeight: "100vh", background: "#000", paddingTop: "80px", maxWidth: "430px", margin: "0 auto" }}>
-
-        {/* ═══ PILL NAV ═══ */}
-        <nav style={styles.pillNav}>
-          <span
-            style={styles.pillLogo}
-            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          >
-            <span style={{ color: "#D4AF37" }}>filmmaker.</span>
-            <span style={{ color: "#fff" }}>og</span>
-          </span>
-          <button
-            onClick={() => { haptics.light(); setMenuOpen(true); }}
-            style={styles.pillHamburger}
-            aria-label="Menu"
-          >
-            <span style={{ ...styles.hamburgerLine, width: "16px" }} />
-            <span style={{ ...styles.hamburgerLine, width: "16px" }} />
-            <span style={{ ...styles.hamburgerLine, width: "10px" }} />
-          </button>
-        </nav>
 
         {/* ═══ § 1 HERO ═══ */}
         <section ref={heroRef} style={styles.hero}>
@@ -493,33 +471,6 @@ const styles: Record<string, React.CSSProperties> = {
     background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.6), transparent)",
     transform: "skewX(-20deg)",
     animation: "lp-shimmer 5s cubic-bezier(0.16, 1, 0.3, 1) infinite",
-  },
-
-  /* ── Pill Nav ── */
-  pillNav: {
-    position: "fixed", top: "16px", left: "50%", transform: "translateX(-50%)",
-    width: "calc(100% - 32px)", maxWidth: "390px",
-    background: "rgba(6,6,6,0.85)",
-    border: "1px solid rgba(212,175,55,0.38)",
-    borderRadius: "999px",
-    padding: "10px 10px 10px 24px",
-    backdropFilter: "blur(24px)",
-    WebkitBackdropFilter: "blur(24px)",
-    boxShadow: "0 2px 24px rgba(0,0,0,0.8)",
-    display: "flex", alignItems: "center", justifyContent: "space-between",
-    zIndex: 100,
-  },
-  pillLogo: {
-    fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.7rem", letterSpacing: "0.06em", cursor: "pointer",
-  },
-  pillHamburger: {
-    width: "40px", height: "40px", borderRadius: "50%",
-    display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "4px",
-    background: "rgba(212,175,55,0.06)", border: "1px solid rgba(212,175,55,0.20)",
-    cursor: "pointer",
-  },
-  hamburgerLine: {
-    display: "block", height: "1px", background: "#D4AF37",
   },
 
   /* ── § 1 HERO ── */

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -798,15 +798,15 @@ const s: Record<string, React.CSSProperties> = {
     transform: "translateY(-50%)",
     width: 18,
     height: 18,
-    color: "rgba(212,175,55,0.50)",
+    color: "rgba(212,175,55,0.60)",
     pointerEvents: "none",
     transition: "color 0.3s",
   },
   searchInput: {
     width: "100%",
-    background: "rgba(212,175,55,0.06)",
-    border: "1px solid rgba(212,175,55,0.35)",
-    boxShadow: "0 0 12px rgba(212,175,55,0.04)",
+    background: "rgba(212,175,55,0.08)",
+    border: "1px solid rgba(212,175,55,0.45)",
+    boxShadow: "0 0 12px rgba(212,175,55,0.06), inset 0 1px 4px rgba(0,0,0,0.3)",
     borderRadius: 12,
     color: "rgba(255,255,255,0.95)",
     fontFamily: "'Inter', sans-serif",
@@ -1154,7 +1154,7 @@ if (typeof document !== "undefined" && !document.getElementById(RESPONSIVE_STYLE
   style.id = RESPONSIVE_STYLE_ID;
   style.textContent = `
     a, button { -webkit-tap-highlight-color: transparent; }
-    .vault-search-input::placeholder { color: rgba(255,255,255,0.45) !important; }
+    .vault-search-input::placeholder { color: rgba(255,255,255,0.55) !important; }
     @media (max-width: 767px) {
       .vault-pinned-grid {
         display: flex !important;


### PR DESCRIPTION
- Remove custom pill nav from Index.tsx — homepage now uses the shared AppHeader with auto-hide-on-scroll, matching every other page
- Remove isLanding gate in App.tsx so AppHeader always mounts
- Remove duplicate MobileMenu from Index.tsx (already global in AppShell)
- Push search bar: border 0.35→0.45, bg 0.06→0.08, icon 0.50→0.60, placeholder 0.45→0.55, added inset shadow for depth

https://claude.ai/code/session_01XH5kiJW3CQwJGDC8wVoahj