### PR TITLE
fix homepage gap & add idle-reveal to AppHeader

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -19,6 +19,7 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
 
   const [headerHidden, setHeaderHidden] = useState(false);
   const lastScrollY = useRef(0);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const handler = () => {
@@ -29,9 +30,16 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
         setHeaderHidden(false);
       }
       lastScrollY.current = currentY;
+
+      // Re-show header after user stops scrolling for 1.5s
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+      idleTimer.current = setTimeout(() => setHeaderHidden(false), 1500);
     };
     window.addEventListener('scroll', handler, { passive: true });
-    return () => window.removeEventListener('scroll', handler);
+    return () => {
+      window.removeEventListener('scroll', handler);
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
   }, []);
 
   const [searchFocused, setSearchFocused] = useState(false);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -145,7 +145,7 @@ const Index = () => {
         }
       `}</style>
 
-      <div style={{ minHeight: "100vh", background: "#000", paddingTop: "80px", maxWidth: "430px", margin: "0 auto" }}>
+      <div style={{ minHeight: "100vh", background: "#000", paddingTop: "0px", maxWidth: "430px", margin: "0 auto" }}>
 
         {/* ═══ § 1 HERO ═══ */}
         <section ref={heroRef} style={styles.hero}>


### PR DESCRIPTION
- Remove legacy paddingTop: 80px from Index.tsx (AppHeader spacer already handles clearance)
- Add 1.5s idle timer: header auto-reveals when scrolling stops, on top of existing scroll-up reveal

https://claude.ai/code/session_01XH5kiJW3CQwJGDC8wVoahj