### PR TITLE
fix hero top padding & align pinned grid with content cards

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -476,7 +476,7 @@ const styles: Record<string, React.CSSProperties> = {
   /* ── § 1 HERO ── */
   hero: {
     position: "relative", textAlign: "center",
-    background: "#000", padding: "64px 24px 48px",
+    background: "#000", padding: "24px 24px 48px",
   },
   heroGlow: {
     position: "absolute", top: "-10%", left: 0, right: 0, height: "65%", pointerEvents: "none",

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -625,7 +625,7 @@ const s: Record<string, React.CSSProperties> = {
   },
   pinnedGrid: {
     display: "grid",
-    gridTemplateColumns: "1.4fr 1fr",
+    gridTemplateColumns: "repeat(2, 1fr)",
     gap: 20,
   },
   pinnedCard: {


### PR DESCRIPTION
- Reduce hero section top padding 64px→24px (AppHeader spacer already provides clearance, old value was for the removed pill nav)
- Change pinned grid from 1.4fr/1fr to repeat(2,1fr) to match the content card grid below for visual uniformity

https://claude.ai/code/session_01XH5kiJW3CQwJGDC8wVoahj