### PR TITLE
fix(resources): align pinned cards with content grid on mobile

### DIFF
--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1168,7 +1168,7 @@ if (typeof document !== "undefined" && !document.getElementById(RESPONSIVE_STYLE
       }
       .vault-pinned-grid::-webkit-scrollbar { display: none !important; }
       .vault-pinned-grid > a {
-        flex: 0 0 78% !important;
+        flex: 0 0 calc(100vw - 48px) !important;
         scroll-snap-align: start !important;
         min-width: 0 !important;
       }


### PR DESCRIPTION
Change pinned card width from 78% to calc(100vw - 48px) so they match the full-width single-column content cards below on mobile viewports.

https://claude.ai/code/session_01MttrxPoxRkbHcBrgpMxm9t