### PR TITLE
fix(calculator): strip PremiumInput — kill old token system, match bu…

### DIFF
--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -148,8 +148,8 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
                     <div
                       className="w-10 h-10 flex items-center justify-center transition-all"
                       style={isSelected
-                        ? { border: "1px solid #D4AF37", color: "#D4AF37", background: "rgba(212,175,55,0.05)", borderRadius: "var(--radius-sm)" }
-                        : { border: "1px solid rgba(255,255,255,0.15)", background: "#000", color: "rgba(255,255,255,0.40)", borderRadius: "var(--radius-sm)" }
+                        ? { border: "1px solid #D4AF37", color: "#D4AF37", background: "rgba(212,175,55,0.05)", borderRadius: "4px" }
+                        : { border: "1px solid rgba(255,255,255,0.15)", background: "#000", color: "rgba(255,255,255,0.40)", borderRadius: "4px" }
                       }
                     >
                       <Icon className="w-5 h-5 transition-colors" />

--- a/src/components/ui/premium-input.tsx
+++ b/src/components/ui/premium-input.tsx
@@ -1,80 +1,24 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
-import { Check, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 import { useMobileKeyboardScroll } from "@/hooks/use-mobile-keyboard";
 
 interface PremiumInputProps extends React.ComponentProps<"input"> {
-  /** Field has a valid value */
   isCompleted?: boolean;
-  /** Field is the next one to fill (triggers attention animation) */
   isNext?: boolean;
-  /** Field is currently focused */
-  isActive?: boolean;
-  /** Show currency prefix */
   showCurrency?: boolean;
-  /** Show percent suffix */
-  showPercent?: boolean;
-  /** Container className */
-  containerClassName?: string;
-  /** Label text */
-  label?: string;
-  /** Step number for multi-input steps */
-  stepNumber?: number;
-  /** Example text shown when empty */
-  example?: string;
-  /** Hint text that shows what to enter */
   actionHint?: string;
-  /** Validation hint shown below input */
-  hint?: React.ReactNode;
-  /** Make this a "hero" input with extra prominence */
-  isHero?: boolean;
 }
 
-/**
- * Premium Input Component
- *
- * Luxurious input field with:
- * - Continuous pulsing glow when needs attention
- * - Clear visual states (empty, focused, completed)
- * - Elegant micro-interactions
- * - Action hints guiding the user
- * - Mobile keyboard scroll-into-view handling
- */
 const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
-  (
-    {
-      className,
-      containerClassName,
-      type,
-      isCompleted = false,
-      isNext = false,
-      isActive = false,
-      showCurrency = false,
-      showPercent = false,
-      label,
-      stepNumber,
-      example,
-      actionHint,
-      hint,
-      isHero = false,
-      onFocus,
-      onBlur,
-      value,
-      ...props
-    },
-    ref
-  ) => {
+  ({ isCompleted = false, isNext = false, showCurrency = false, actionHint, value, onFocus, onBlur, ...props }, ref) => {
     const haptics = useHaptics();
     const [focused, setFocused] = React.useState(false);
-    const localActive = isActive || focused;
     const isEmpty = !value || value === "" || value === "0";
-    const needsAttention = isNext && isEmpty && !localActive;
+    const needsAttention = isNext && isEmpty && !focused;
 
-    // Mobile keyboard scroll handling
     const { ref: mobileRef, scrollIntoView } = useMobileKeyboardScroll<HTMLDivElement>();
 
-    // Merge refs: forward ref and our container ref
     const inputRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
@@ -82,10 +26,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
       setFocused(true);
       haptics.light();
       e.target.select();
-      
-      // Scroll input into view on mobile when keyboard opens
       scrollIntoView();
-      
       onFocus?.(e);
     };
 
@@ -94,213 +35,70 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
       onBlur?.(e);
     };
 
+    const hasValue = !isEmpty;
+
     return (
-      <div
-        ref={mobileRef}
-        className={cn(
-          "relative group",
-          containerClassName
-        )}
-      >
-        {/* Ambient glow for attention state - CONTINUOUS */}
-        {needsAttention && (
-          <div
-            className="absolute -inset-3 pointer-events-none animate-attention-glow rounded-sm"
+      <div ref={mobileRef}>
+        {/* Input row */}
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {showCurrency && (
+            <span style={{
+              fontFamily: "'Roboto Mono', monospace",
+              fontSize: "1.5rem",
+              fontWeight: 500,
+              color: hasValue ? "#D4AF37" : "rgba(212,175,55,0.35)",
+              lineHeight: 1,
+              marginRight: "8px",
+              flexShrink: 0,
+              transition: "color 0.2s ease",
+            }}>
+              $
+            </span>
+          )}
+
+          <input
+            ref={inputRef}
+            value={value}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             style={{
-              background: 'radial-gradient(ellipse at center, rgba(249, 224, 118, 0.15) 0%, transparent 70%)',
+              flex: 1,
+              background: "transparent",
+              border: "none",
+              outline: "none",
+              fontFamily: "'Roboto Mono', monospace",
+              fontSize: "1.5rem",
+              fontWeight: 500,
+              color: hasValue ? "rgba(255,255,255,0.85)" : "rgba(255,255,255,0.15)",
+              textAlign: "right" as const,
+              lineHeight: 1,
+              fontVariantNumeric: "tabular-nums",
+              letterSpacing: "-0.02em",
+              padding: 0,
+              height: "48px",
             }}
+            {...props}
           />
-        )}
-
-        {/* Hero glow effect */}
-        {isHero && !isEmpty && (
-          <div
-            className="absolute -inset-4 pointer-events-none"
-            style={{
-              background: 'radial-gradient(ellipse at center, rgba(212, 175, 55, 0.12) 0%, transparent 60%)',
-              filter: 'blur(20px)',
-            }}
-          />
-        )}
-
-        {/* Main input container */}
-        <div
-          className={cn(
-            "relative overflow-hidden transition-all duration-300 ease-out",
-            // Base styling
-            "bg-gradient-to-b from-bg-elevated to-bg-header",
-            // Border states with clear hierarchy
-            "border-2",
-            localActive
-              ? "border-gold-highlight shadow-[0_0_30px_rgba(249,224,118,0.35),inset_0_0_20px_rgba(249,224,118,0.05)] scale-[1.02]"
-              : isCompleted
-              ? "border-gold/60 bg-gradient-to-b from-bg-elevated to-bg-header"
-              : needsAttention
-              ? "border-gold/50 animate-border-glow"
-              : "border-border-subtle hover:border-border-default",
-            // Hero styling
-            isHero && "border-gold/40 shadow-[0_0_60px_rgba(212,175,55,0.15)]",
-            isHero && isCompleted && "shadow-[0_0_80px_rgba(212,175,55,0.25)]"
-          )}
-        >
-          {/* Shimmer effect on focus */}
-          {localActive && (
-            <div
-              className="absolute inset-0 pointer-events-none animate-shimmer"
-              style={{
-                background: 'linear-gradient(90deg, transparent 0%, rgba(249, 224, 118, 0.03) 50%, transparent 100%)',
-                backgroundSize: '200% 100%',
-              }}
-            />
-          )}
-
-          {/* Label row */}
-          <div className="flex items-center justify-between px-4 pt-4 pb-2">
-            <div className="flex items-center gap-3">
-              {/* Step number badge */}
-              {stepNumber && (
-                <div
-                  className={cn(
-                    "w-6 h-6 flex items-center justify-center text-xs font-mono font-medium transition-colors",
-                    isCompleted
-                      ? "bg-gold text-black"
-                      : needsAttention
-                      ? "bg-gold/20 text-gold border border-gold/50"
-                      : "bg-bg-surface text-text-dim border border-border-subtle"
-                  )}
-                >
-                  {isCompleted ? <Check className="w-3.5 h-3.5" /> : stepNumber}
-                </div>
-              )}
-
-              {/* Label */}
-              {label && (
-                <label
-                  className={cn(
-                    "text-xs uppercase tracking-[0.2em] font-semibold transition-colors",
-                    localActive
-                      ? "text-gold"
-                      : isCompleted
-                      ? "text-gold/80"
-                      : "text-text-dim"
-                  )}
-                >
-                  {label}
-                </label>
-              )}
-            </div>
-
-            {/* Completion indicator (if no step number) */}
-            {!stepNumber && isCompleted && !localActive && (
-              <div className="w-6 h-6 bg-gold flex items-center justify-center animate-scale-in">
-                <Check className="w-3.5 h-3.5 text-black" />
-              </div>
-            )}
-          </div>
-
-          {/* Input row */}
-          <div className="relative flex items-center px-4 pb-4">
-            {showCurrency && (
-              <span
-                className={cn(
-                  "font-mono text-2xl mr-3 flex-shrink-0 transition-all duration-300",
-                  localActive
-                    ? "text-gold scale-110"
-                    : isCompleted
-                    ? "text-gold/70"
-                    : "text-text-dim"
-                )}
-                style={{
-                  textShadow: localActive ? '0 0 20px rgba(212, 175, 55, 0.5)' : 'none',
-                }}
-              >
-                $
-              </span>
-            )}
-
-            <input
-              type={type}
-              className={cn(
-                "flex-1 bg-transparent border-0 outline-none",
-                "font-mono text-right transition-all tabular-nums",
-                isHero ? "h-16" : "h-12",
-                localActive
-                  ? isHero ? "text-text-primary text-4xl" : "text-text-primary text-2xl"
-                  : isCompleted
-                  ? isHero ? "text-text-primary text-4xl" : "text-text-primary text-2xl"
-                  : isHero ? "text-text-dim text-3xl" : "text-text-dim text-xl",
-                "placeholder:text-text-dim",
-                "focus:outline-none focus:ring-0",
-                className
-              )}
-              style={{
-                fontVariantNumeric: 'tabular-nums',
-                fontFeatureSettings: '"tnum" 1',
-              }}
-              ref={inputRef}
-              value={value}
-              onFocus={handleFocus}
-              onBlur={handleBlur}
-              {...props}
-            />
-
-            {showPercent && (
-              <span
-                className={cn(
-                  "font-mono text-2xl ml-3 flex-shrink-0 transition-all duration-300",
-                  localActive
-                    ? "text-gold scale-110"
-                    : isCompleted
-                    ? "text-gold/70"
-                    : "text-text-dim"
-                )}
-                style={{
-                  textShadow: localActive ? '0 0 20px rgba(212, 175, 55, 0.5)' : 'none',
-                }}
-              >
-                %
-              </span>
-            )}
-          </div>
-
-          {/* Action hint - shows what to do */}
-          {needsAttention && (
-            <div className="px-4 pb-4 animate-fade-in">
-              <div className="flex items-center gap-2 text-gold">
-                <ChevronRight className="w-4 h-4 animate-bounce-right" />
-                <span className="text-xs font-semibold tracking-wide">
-                  {actionHint || `Enter ${label?.toLowerCase() || 'value'} to continue`}
-                </span>
-              </div>
-            </div>
-          )}
-
-          {/* Example hint - shows format */}
-          {isEmpty && example && !needsAttention && !localActive && (
-            <div className="px-4 pb-4">
-              <span className="text-xs text-text-dim">
-                e.g., {example}
-              </span>
-            </div>
-          )}
-
-          {/* Validation/contextual hint */}
-          {hint && localActive && (
-            <div className="px-4 pb-4 animate-fade-in">
-              {hint}
-            </div>
-          )}
-
-          {/* Completed state left accent bar */}
-          {isCompleted && !localActive && (
-            <div className="absolute left-0 top-0 bottom-0 w-1 bg-gradient-to-b from-gold via-gold to-gold/50" />
-          )}
         </div>
 
-        {/* Bottom connector line for visual flow */}
-        {needsAttention && (
-          <div className="flex justify-center mt-3">
-            <div className="w-px h-6 bg-gradient-to-b from-gold/50 to-transparent animate-pulse-slow" />
+        {/* Action hint — static, no animation */}
+        {needsAttention && actionHint && (
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            marginTop: "12px",
+            color: "#D4AF37",
+          }}>
+            <ChevronRight style={{ width: "16px", height: "16px" }} />
+            <span style={{
+              fontFamily: "'Inter', sans-serif",
+              fontSize: "12px",
+              fontWeight: 600,
+              letterSpacing: "0.02em",
+            }}>
+              {actionHint}
+            </span>
           </div>
         )}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -617,46 +617,6 @@
   /* ═══════════════════════════════════════════════════════════════════
      ATTENTION ANIMATIONS
      ═══════════════════════════════════════════════════════════════════ */
-  .animate-attention-glow {
-    animation: attentionGlow 2s ease-in-out infinite;
-  }
-
-  @keyframes attentionGlow {
-    0%, 100% { opacity: 0.5; transform: scale(1); }
-    50% { opacity: 1; transform: scale(1.05); }
-  }
-
-  .animate-border-glow {
-    animation: borderGlow 1.5s ease-in-out infinite;
-  }
-
-  @keyframes borderGlow {
-    0%, 100% { border-color: var(--gold-strong); }
-    50% { border-color: var(--gold); }
-  }
-
-  .animate-shimmer {
-    animation: shimmer 2s linear infinite;
-  }
-
-  .animate-shimmer-slow {
-    animation: shimmer 3s linear infinite;
-  }
-
-  @keyframes shimmer {
-    0% { background-position: 200% 0; }
-    100% { background-position: -200% 0; }
-  }
-
-  .animate-pulse-slow {
-    animation: pulseSlow 3s ease-in-out infinite;
-  }
-
-  @keyframes pulseSlow {
-    0%, 100% { opacity: 0.6; }
-    50% { opacity: 1; }
-  }
-
   .animate-pulse-subtle {
     animation: pulseSubtle 2s ease-in-out infinite;
   }
@@ -664,15 +624,6 @@
   @keyframes pulseSubtle {
     0%, 100% { opacity: 0.9; transform: scale(1); }
     50% { opacity: 1; transform: scale(1.02); }
-  }
-
-  .animate-bounce-right {
-    animation: bounceRight 1s ease-in-out infinite;
-  }
-
-  @keyframes bounceRight {
-    0%, 100% { transform: translateX(0); }
-    50% { transform: translateX(4px); }
   }
 
   .animate-bounce-chevron {


### PR DESCRIPTION
…dget hero pattern

- Rebuilt PremiumInput as minimal inline-style input (no borders, no gradients, no animations) that disappears into its parent StackInputCard
- Removed 8 dead props (isActive, isHero, stepNumber, label, example, showPercent, containerClassName, hint) never consumed by StackInputCard
- Killed orphaned CSS animations: attentionGlow, borderGlow, shimmer, shimmerSlow, pulseSlow, bounceRight (confirmed zero consumers outside the old PremiumInput)
- Replaced var(--radius-sm) with raw 4px in CapitalSelect icon containers

https://claude.ai/code/session_01CbCW8sGPrDK9sePg9NGg9w