### PR TITLE
fix(auth): SIGNED_IN redirect handler, async session gate, input clip…

### DIFF
--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -16,10 +16,9 @@ const nameSchema = z.string().min(1, "Name is required").max(100);
 interface LeadCaptureModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
 }
 
-const LeadCaptureModal = ({ isOpen, onClose, onSuccess }: LeadCaptureModalProps) => {
+const LeadCaptureModal = ({ isOpen, onClose }: LeadCaptureModalProps) => {
   const { toast } = useToast();
   const haptics = useHaptics();
   const [name, setName] = useState("");

--- a/src/components/ui/premium-input.tsx
+++ b/src/components/ui/premium-input.tsx
@@ -63,6 +63,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
             onBlur={handleBlur}
             style={{
               flex: 1,
+              minWidth: 0,
               background: "transparent",
               border: "none",
               outline: "none",
@@ -73,8 +74,8 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
               textAlign: "right" as const,
               lineHeight: 1,
               fontVariantNumeric: "tabular-nums",
-              letterSpacing: "-0.02em",
-              padding: 0,
+              letterSpacing: "0",
+              padding: "0 4px 0 0",
               height: "48px",
             }}
             {...props}
@@ -82,7 +83,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
         </div>
 
         {/* Action hint — static, no animation */}
-        {needsAttention && actionHint && (
+        {needsAttention && actionHint && isEmpty && (
           <div style={{
             display: "flex",
             alignItems: "center",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,32 +24,34 @@ const Index = () => {
   const haptics = useHaptics();
 
   const [showLeadCapture, setShowLeadCapture] = useState(false);
-  const [pendingDestination, setPendingDestination] = useState<string | null>(null);
-  const [hasSession, setHasSession] = useState(false);
 
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.user) setHasSession(true);
-    });
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) setHasSession(true);
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (session?.user) {
+        // Magic link callback landed here instead of /calculator —
+        // catch it and forward. Only fires on fresh sign-in, not
+        // on TOKEN_REFRESHED or returning visitors.
+        if (event === 'SIGNED_IN') {
+          navigate('/calculator');
+        }
+      }
     });
     return () => subscription.unsubscribe();
-  }, []);
+  }, [navigate]);
 
-  const gatedNavigate = useCallback((destination: string) => {
-    if (!hasSession) {
-      setPendingDestination(destination);
-      setShowLeadCapture(true);
-    } else {
+  const gatedNavigate = useCallback(async (destination: string) => {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
       navigate(destination);
+    } else {
+      setShowLeadCapture(true);
     }
-  }, [hasSession, navigate]);
+  }, [navigate]);
 
-  const handleCTA = () => {
+  const handleCTA = async () => {
     haptics.medium();
-    gatedNavigate("/calculator");
+    await gatedNavigate("/calculator");
   };
 
   const prefersReducedMotion =
@@ -129,11 +131,6 @@ const Index = () => {
       <LeadCaptureModal
         isOpen={showLeadCapture}
         onClose={() => setShowLeadCapture(false)}
-        onSuccess={() => {
-          setHasSession(true);
-          setShowLeadCapture(false);
-          navigate(pendingDestination || "/calculator");
-        }}
       />
 
       {/* ── Keyframe injection ── */}


### PR DESCRIPTION
…ping

- Add SIGNED_IN event handler in Index.tsx to catch magic link callbacks and redirect to /calculator (the only code-level mechanism since onSuccess was dead code)
- Make gatedNavigate async — checks Supabase session directly instead of reading stale React state, preventing race on fresh page loads
- Remove dead onSuccess prop from LeadCaptureModal (never invoked — user leaves app to click email link, modal unmounts)
- Remove dead hasSession/pendingDestination state now unused
- Fix number clipping on dollar inputs: remove negative letter-spacing, add minWidth:0 for flex overflow, add 4px right padding
- Add defensive isEmpty guard on action hint rendering

https://claude.ai/code/session_01CbCW8sGPrDK9sePg9NGg9w