### PR TITLE
fix(waterfall): break deck out of parent padding so cards are visible

### DIFF
--- a/src/components/calculator/WaterfallDeck.tsx
+++ b/src/components/calculator/WaterfallDeck.tsx
@@ -1009,6 +1009,7 @@ const WaterfallDeck = ({ result, inputs, project, guilds, onExport }: WaterfallD
           scrollbarWidth: "none",
           gap: "12px",
           padding: "0 20px",
+          width: "100%",
         }}
       >
         {cards.map((card, i) => (

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -253,14 +253,16 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
             </div>
           )}
 
-          {/* THE DECK — no ChapterCard wrapper */}
-          <WaterfallDeck
-            result={activeResult}
-            inputs={activeInputs}
-            project={project}
-            guilds={activeGuilds}
-            onExport={isDemoMode ? undefined : onExport}
-          />
+          {/* THE DECK — breakout wrapper escapes s.main 20px padding */}
+          <div style={{ margin: "0 -20px" }}>
+            <WaterfallDeck
+              result={activeResult}
+              inputs={activeInputs}
+              project={project}
+              guilds={activeGuilds}
+              onExport={isDemoMode ? undefined : onExport}
+            />
+          </div>
 
           {/* Wiki link — below pagination */}
           <a


### PR DESCRIPTION
Add negative margin wrapper (margin: 0 -20px) around WaterfallDeck to escape Calculator's s.main 20px padding. Add explicit width: 100% on scroll container so flex-basis calc resolves correctly.

https://claude.ai/code/session_01LMDbREX6VmPvEbUdgsPiZR