### PR TITLE
fix(calculator): drop ?tab=budget from magic link redirect, hide FAB …

### DIFF
--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -47,7 +47,7 @@ const LeadCaptureModal = ({ isOpen, onClose }: LeadCaptureModalProps) => {
     setLoading(true);
 
     try {
-      const redirectTo = `${window.location.origin}/calculator?tab=budget`;
+      const redirectTo = `${window.location.origin}/calculator`;
       const { error } = await supabase.auth.signInWithOtp({
         email: email.trim(),
         options: {
@@ -74,7 +74,7 @@ const LeadCaptureModal = ({ isOpen, onClose }: LeadCaptureModalProps) => {
   const handleResend = async () => {
     setLoading(true);
     try {
-      const redirectTo = `${window.location.origin}/calculator?tab=budget`;
+      const redirectTo = `${window.location.origin}/calculator`;
       const { error } = await supabase.auth.signInWithOtp({
         email: email.trim(),
         options: {

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { Sparkles } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
    OgBotFab — floating action button for the OG bot
-   Bottom-right corner, hides when closer section is in viewport
-   to avoid overlapping the conversion CTA.
+   Bottom-right corner. Hidden on /calculator (overlaps TabBar)
+   and when closer section is in viewport on the landing page.
    ═══════════════════════════════════════════════════════════════════ */
 
 interface OgBotFabProps {
@@ -14,19 +15,25 @@ interface OgBotFabProps {
 
 const OgBotFab = ({ onTap }: OgBotFabProps) => {
   const haptics = useHaptics();
-  const [hidden, setHidden] = useState(false);
+  const location = useLocation();
+  const [hiddenByCloser, setHiddenByCloser] = useState(false);
+
+  // Hide on calculator — FAB overlaps TabBar
+  const onCalculator = location.pathname.startsWith("/calculator");
 
   useEffect(() => {
     const closer = document.querySelector('[data-section="closer"]');
     if (!closer) return;
 
     const obs = new IntersectionObserver(
-      ([entry]) => setHidden(entry.isIntersecting),
+      ([entry]) => setHiddenByCloser(entry.isIntersecting),
       { threshold: 0.3 },
     );
     obs.observe(closer);
     return () => obs.disconnect();
   }, []);
+
+  const hidden = onCalculator || hiddenByCloser;
 
   return (
     <button


### PR DESCRIPTION
…on calculator page

Remove ?tab=budget query param from both redirect URLs in LeadCaptureModal so the calculator defaults to the project tab as intended. Add useLocation to OgBotFab to hide the FAB when on /calculator, preventing z-index collision with TabBar.

https://claude.ai/code/session_01C2GKpBjVTtjZNqBJfHZZex