### PR TITLE
Fix semantic colors and Resources pinned card alignment

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -688,7 +688,7 @@ const styles: Record<string, React.CSSProperties> = {
   tierIntro: { fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.7)", lineHeight: 1.5, margin: "28px 24px 0" },
   tierChecklist: { padding: "24px", display: "flex", flexDirection: "column", gap: "16px" },
   checkItem: { display: "flex", gap: "12px", alignItems: "flex-start" },
-  checkMark: { color: "#D4AF37", fontSize: "14px", fontWeight: 600, lineHeight: 1.3 },
+  checkMark: { color: "#3CB371", fontSize: "14px", fontWeight: 600, lineHeight: 1.3 },
   checkText: { fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.85)", lineHeight: 1.45 },
   tierAction: { padding: "0 24px 36px" },
   btnSnapshot: {
@@ -770,8 +770,8 @@ const styles: Record<string, React.CSSProperties> = {
     background: "#000", display: "grid", gridTemplateColumns: "22px 1fr", gap: "10px",
     padding: "18px 20px", alignItems: "flex-start", borderLeft: "1px solid rgba(212,175,55,0.08)",
   },
-  checkIconYes: { fontFamily: "'Roboto Mono', monospace", fontSize: "22px", paddingTop: "2px", color: "#D4AF37", textShadow: "0 0 12px rgba(212,175,55,0.5)" },
-  checkIconNo: { fontFamily: "'Roboto Mono', monospace", fontSize: "22px", paddingTop: "2px", color: "rgba(255,80,80,0.85)" },
+  checkIconYes: { fontFamily: "'Roboto Mono', monospace", fontSize: "22px", paddingTop: "2px", color: "#3CB371", textShadow: "0 0 12px rgba(60,179,113,0.4)" },
+  checkIconNo: { fontFamily: "'Roboto Mono', monospace", fontSize: "22px", paddingTop: "2px", color: "rgba(220,38,38,0.85)" },
   checkTextYes: { fontFamily: "'Inter', sans-serif", fontSize: "14px", lineHeight: 1.4, color: "rgba(255,255,255,0.85)" },
   checkTextNo: { fontFamily: "'Inter', sans-serif", fontSize: "14px", lineHeight: 1.4, color: "rgba(255,255,255,0.55)" },
 

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1225,8 +1225,8 @@ if (typeof document !== "undefined" && !document.getElementById(RESPONSIVE_STYLE
         scroll-snap-type: x mandatory !important;
         -webkit-overflow-scrolling: touch !important;
         gap: 12px !important;
-        margin: 0 -24px 0 -20px !important;
-        padding: 0 20px 8px 20px !important;
+        margin: 0 -24px 0 -24px !important;
+        padding: 0 20px 8px 24px !important;
         scrollbar-width: none !important;
       }
       .vault-pinned-grid::-webkit-scrollbar { display: none !important; }


### PR DESCRIPTION
- WITH column check icons: gold (#D4AF37) → green (#3CB371) to signal "you get this" as a verdict, not decoration
- WITHOUT column X icons: orphan red rgba(255,80,80) → canonical red rgba(220,38,38) per design system
- Arsenal tier card feature checks: gold → green (same logic)
- Resources pinned cards: fix 4px left misalignment on mobile by correcting margin/padding asymmetry

https://claude.ai/code/session_01DVffMYHs3mkkcARHLQvvZd