### PR TITLE
Calculator tabs audit + MobileMenu/AppHeader fixes

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -72,7 +72,7 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
             marginRight: "16px",
             borderRadius: "12px",
             background: "rgba(6,6,6,0.85)",
-            border: "1px solid rgba(212,175,55,0.38)",
+            border: "1px solid rgba(212,175,55,0.35)",
             boxShadow: "0 2px 24px rgba(0,0,0,0.8)",
             backdropFilter: "blur(24px)",
             WebkitBackdropFilter: "blur(24px)",

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -66,7 +66,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
       <span style={{
         fontFamily: "'Roboto Mono', monospace",
         fontSize: "11px",
-        letterSpacing: "0.18em",
+        letterSpacing: "0.15em",
         textTransform: "uppercase" as const,
         color: "#D4AF37",
         whiteSpace: "nowrap" as const,
@@ -96,7 +96,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           background: "rgba(6,6,6,0.92)",
           backdropFilter: "blur(40px)",
           WebkitBackdropFilter: "blur(40px)",
-          borderRadius: "16px 16px 0 0",
+          borderRadius: "12px 12px 0 0",
           boxShadow: "0 -4px 60px rgba(212,175,55,0.08), 0 -2px 20px rgba(0,0,0,0.80)",
         }}
         onTouchStart={handleTouchStart}
@@ -123,7 +123,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
           </button>
         </div>
 
-        <div style={{ padding: "8px 20px 28px" }}>
+        <div style={{ padding: "8px 24px 28px" }}>
           {/* Primary Nav — 2×2 grid */}
           <div style={{ marginBottom: "16px" }}>
             <SectionLabel>Navigate</SectionLabel>

--- a/src/components/calculator/ChapterCard.tsx
+++ b/src/components/calculator/ChapterCard.tsx
@@ -27,7 +27,7 @@ const eyebrowS: Record<string, React.CSSProperties> = {
     display: "flex",
     alignItems: "center",
     gap: "12px",
-    margin: "0 -20px 16px",
+    margin: "0 -24px 16px",
   },
   eyebrowLine: {
     flex: 1,
@@ -118,7 +118,7 @@ const featureTopline: React.CSSProperties = {
 };
 
 const cardPad: React.CSSProperties = {
-  padding: "24px 20px",
+  padding: "24px 24px",
 };
 
 const cardH: React.CSSProperties = {

--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -35,7 +35,7 @@ const s: Record<string, React.CSSProperties> = {
   },
   heroZone: {
     textAlign: "center" as const,
-    padding: "28px 20px 20px",
+    padding: "28px 24px 20px",
     position: "relative" as const,
     zIndex: 1,
   },
@@ -146,7 +146,7 @@ const s: Record<string, React.CSSProperties> = {
     textAlign: "center" as const,
     marginTop: "14px",
     fontSize: "11px",
-    color: "rgba(255,255,255,0.30)",
+    color: "rgba(255,255,255,0.25)",
     lineHeight: 1.5,
   },
   // Quick pills
@@ -154,7 +154,7 @@ const s: Record<string, React.CSSProperties> = {
     display: "flex",
     justifyContent: "center",
     gap: "6px",
-    padding: "16px 20px 4px",
+    padding: "16px 24px 4px",
     flexWrap: "wrap" as const,
   },
   quickBtn: {
@@ -199,13 +199,13 @@ const s: Record<string, React.CSSProperties> = {
     boxShadow: "0 0 12px rgba(212,175,55,0.18)",
   },
   quickLabel: {
-    fontSize: "8px",
+    fontSize: "10px",
     textTransform: "uppercase" as const,
     letterSpacing: "0.1em",
-    color: "rgba(255,255,255,0.30)",
+    color: "rgba(255,255,255,0.25)",
   },
   quickLabelOn: {
-    fontSize: "8px",
+    fontSize: "10px",
     textTransform: "uppercase" as const,
     letterSpacing: "0.1em",
     color: "rgba(212,175,55,0.60)",
@@ -215,7 +215,7 @@ const s: Record<string, React.CSSProperties> = {
     display: "flex",
     alignItems: "center",
     gap: "8px",
-    padding: "20px 20px 12px",
+    padding: "20px 24px 12px",
   },
   innerDivLabel: {
     fontFamily: "'Inter', sans-serif",
@@ -235,7 +235,7 @@ const s: Record<string, React.CSSProperties> = {
   guildRow: {
     display: "flex",
     gap: "8px",
-    padding: "0 20px",
+    padding: "0 24px",
   },
   guild: {
     flex: 1,
@@ -245,7 +245,7 @@ const s: Record<string, React.CSSProperties> = {
     padding: "12px 10px",
     background: "rgba(212,175,55,0.02)",
     border: "1px solid rgba(212,175,55,0.18)",
-    borderRadius: "10px",
+    borderRadius: "8px",
     cursor: "pointer",
     transition: "all 0.15s",
     minHeight: "48px",
@@ -258,7 +258,7 @@ const s: Record<string, React.CSSProperties> = {
     padding: "12px 10px",
     background: "rgba(212,175,55,0.08)",
     border: "1px solid rgba(212,175,55,0.50)",
-    borderRadius: "10px",
+    borderRadius: "8px",
     cursor: "pointer",
     transition: "all 0.15s",
     minHeight: "48px",
@@ -311,14 +311,14 @@ const s: Record<string, React.CSSProperties> = {
   },
   guildDesc: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "9px",
+    fontSize: "10px",
     color: "rgba(255,255,255,0.25)",
   },
   guildHint: {
     textAlign: "center" as const,
     fontSize: "11px",
     color: "rgba(255,255,255,0.35)",
-    padding: "10px 20px 0",
+    padding: "10px 24px 0",
   },
   // CTA reveal
   reveal: {

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -55,7 +55,7 @@ const s: Record<string, React.CSSProperties> = {
   },
   heroZone: {
     textAlign: "center" as const,
-    padding: "28px 20px 20px",
+    padding: "28px 24px 20px",
     position: "relative" as const,
     zIndex: 1,
   },
@@ -164,7 +164,7 @@ const s: Record<string, React.CSSProperties> = {
     textAlign: "center" as const,
     marginTop: "14px",
     fontSize: "11px",
-    color: "rgba(255,255,255,0.30)",
+    color: "rgba(255,255,255,0.25)",
     lineHeight: 1.5,
   },
   // Market context
@@ -199,7 +199,7 @@ const s: Record<string, React.CSSProperties> = {
     pointerEvents: "auto" as const,
   },
   vHero: {
-    padding: "24px 20px 20px",
+    padding: "24px 24px 20px",
     textAlign: "center" as const,
     position: "relative" as const,
   },
@@ -299,7 +299,7 @@ const s: Record<string, React.CSSProperties> = {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    padding: "16px 20px",
+    padding: "16px 24px",
     background: "rgba(212,175,55,0.04)",
     borderTop: "1px solid rgba(212,175,55,0.15)",
   },
@@ -343,7 +343,7 @@ const s: Record<string, React.CSSProperties> = {
   levVals: {
     fontFamily: "'Roboto Mono', monospace",
     fontSize: "10px",
-    color: "rgba(255,255,255,0.30)",
+    color: "rgba(255,255,255,0.25)",
   },
   levBody: {
     maxHeight: 0,
@@ -398,7 +398,7 @@ const s: Record<string, React.CSSProperties> = {
     justifyContent: "space-between",
     marginTop: "6px",
     fontFamily: "'Roboto Mono', monospace",
-    fontSize: "9px",
+    fontSize: "10px",
     letterSpacing: "0.08em",
     textTransform: "uppercase" as const,
     color: "rgba(255,255,255,0.25)",

--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -70,7 +70,7 @@ const s: Record<string, React.CSSProperties> = {
     animation: "stepEnter 0.4s ease-out forwards",
   },
   headerPad: {
-    padding: "20px 16px 0",
+    padding: "20px 24px 0",
   },
   subLine: {
     marginBottom: "16px",

--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -35,9 +35,9 @@ const s: Record<string, React.CSSProperties> = {
   },
   flOpt: {
     fontWeight: 400,
-    letterSpacing: "0.05em",
+    letterSpacing: "0.06em",
     textTransform: "none" as const,
-    color: "rgba(255,255,255,0.22)",
+    color: "rgba(255,255,255,0.25)",
     marginLeft: "6px",
     fontSize: "10px",
   },
@@ -121,7 +121,7 @@ const s: Record<string, React.CSSProperties> = {
   expHint: {
     fontFamily: "'Inter', sans-serif",
     fontSize: "11px",
-    color: "rgba(255,255,255,0.22)",
+    color: "rgba(255,255,255,0.25)",
   },
   expBody: {
     maxHeight: 0,
@@ -141,7 +141,7 @@ const s: Record<string, React.CSSProperties> = {
   hint: {
     fontFamily: "'Inter', sans-serif",
     fontSize: "11px",
-    color: "rgba(255,255,255,0.22)",
+    color: "rgba(255,255,255,0.25)",
     marginTop: "6px",
     lineHeight: 1.4,
   },
@@ -197,7 +197,7 @@ const s: Record<string, React.CSSProperties> = {
   autosave: {
     textAlign: "center" as const,
     fontFamily: "'Roboto Mono', monospace",
-    fontSize: "9px",
+    fontSize: "10px",
     letterSpacing: "0.1em",
     textTransform: "uppercase" as const,
     color: "rgba(255,255,255,0.15)",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -72,7 +72,7 @@ const s: Record<string, React.CSSProperties> = {
   },
   main: {
     flex: 1,
-    padding: "20px",
+    padding: "24px",
     overflowY: "auto",
     paddingBottom: "calc(62px + 100px + env(safe-area-inset-bottom, 0px))",
   },


### PR DESCRIPTION
Fix 1 — Side padding 20px → 24px (coordinated):
  Calculator main, ChapterCard bleed margin/content padding,
  BudgetInput (5 instances), DealInput (3), CapitalSelect header

Fix 2 — Font sizes below 10px minimum:
  BudgetInput quickLabel/quickLabelOn 8px → 10px, guildDesc 9px → 10px
  DealInput levScale 9px → 10px, ProjectTab autosave 9px → 10px

Fix 3 — Orphan white opacity 0.22 → 0.25:
  ProjectTab flOpt, expHint, hint (3 instances)

Fix 4 — Orphan white opacity 0.30 → 0.25:
  BudgetInput heroHint, quickLabel; DealInput heroHint, levVals

Fix 5 — borderRadius 10px → 8px:
  BudgetInput guild/guildOn toggle containers

Fix 6 — Letter spacing 0.05em → 0.06em:
  ProjectTab flOpt

Fix 7-9 — MobileMenu: sheet radius 16px → 12px, padding 20px → 24px,
  brand label letter-spacing 0.18em → 0.15em

Fix 10 — AppHeader border gold 0.38 → 0.35

https://claude.ai/code/session_01DyHHGWrnmgHTR3mRp6qKR5