### PR TITLE
Add universal haptic feedback with iOS visual pulse fallback

### DIFF
--- a/src/components/calculator/TabBar.tsx
+++ b/src/components/calculator/TabBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { DollarSign, Layers, Handshake, ArrowDownUp, ClipboardList } from "lucide-react";
+import { useHaptics } from "@/hooks/use-haptics";
 
 export type TabId = 'budget' | 'stack' | 'deal' | 'waterfall' | 'project';
 
@@ -104,6 +105,7 @@ const s: Record<string, React.CSSProperties> = {
 
 const TabBar = ({ activeTab, onTabChange, completedTabs = [], disabledTabs = [] }: TabBarProps) => {
   const [pressedId, setPressedId] = useState<TabId | null>(null);
+  const haptics = useHaptics();
 
   return (
     <nav style={s.container}>
@@ -130,7 +132,7 @@ const TabBar = ({ activeTab, onTabChange, completedTabs = [], disabledTabs = [] 
         return (
           <button
             key={tab.id}
-            onClick={() => !isDisabled && onTabChange(tab.id)}
+            onClick={(e) => { if (!isDisabled) { haptics.light(e); onTabChange(tab.id); } }}
             onMouseDown={() => setPressedId(tab.id)}
             onMouseUp={() => setPressedId(null)}
             onMouseLeave={() => setPressedId(null)}

--- a/src/components/calculator/WaterfallDeck.tsx
+++ b/src/components/calculator/WaterfallDeck.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { useState, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
+import { useHaptics } from "@/hooks/use-haptics";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -1498,6 +1499,7 @@ const ConclusionSection = ({
 
 const CTASection = () => {
   const navigate = useNavigate();
+  const haptics = useHaptics();
   const [showLeadCapture, setShowLeadCapture] = useState(false);
 
   const gatedNavigate = useCallback(async (destination: string) => {
@@ -1578,7 +1580,7 @@ const CTASection = () => {
           {/* Primary CTA — gated */}
           <div style={{ marginBottom: "16px" }}>
             <span
-              onClick={() => gatedNavigate("/store/the-full-analysis")}
+              onClick={(e) => { haptics.medium(e); gatedNavigate("/store/the-full-analysis"); }}
               style={{
                 display: "inline-block",
                 padding: "16px 36px",
@@ -1602,7 +1604,7 @@ const CTASection = () => {
           {/* Free snapshot — lead capture */}
           <div style={{ marginTop: "12px" }}>
             <span
-              onClick={() => setShowLeadCapture(true)}
+              onClick={(e) => { haptics.light(e); setShowLeadCapture(true); }}
               style={{
                 display: "inline-block",
                 padding: "12px 28px",

--- a/src/components/calculator/budget/BudgetInput.tsx
+++ b/src/components/calculator/budget/BudgetInput.tsx
@@ -487,7 +487,7 @@ const BudgetInput = ({ inputs, guilds, onUpdateInput, onToggleGuild, onNext }: B
                   opacity: 0,
                   animation: `pillIn 0.3s ease-out ${0.05 + i * 0.05}s forwards`,
                 }}
-                onClick={() => { haptics.light(); onUpdateInput("budget", qa.value); }}
+                onClick={(e) => { haptics.light(e); onUpdateInput("budget", qa.value); }}
               >
                 <span>{qa.label}</span>
                 <span style={isOn ? s.quickLabelOn : s.quickLabel}>{qa.tier}</span>
@@ -514,7 +514,7 @@ const BudgetInput = ({ inputs, guilds, onUpdateInput, onToggleGuild, onNext }: B
                   ...(isSelected ? s.guildOn : s.guild),
                   ...(isPressed ? { transform: "scale(0.96)" } : {}),
                 }}
-                onClick={() => { haptics.light(); onToggleGuild(guild.key); }}
+                onClick={(e) => { haptics.light(e); onToggleGuild(guild.key); }}
                 onPointerDown={() => setPressedGuild(guild.key)}
                 onPointerUp={() => setPressedGuild(null)}
                 onPointerLeave={() => setPressedGuild(null)}

--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
 import { WaterfallInputs, GuildState, CapitalSelections, CAM_PCT } from "@/lib/waterfall";
 import ChapterCard, { cardH, cardHSub } from "../ChapterCard";
+import { useHaptics } from "@/hooks/use-haptics";
 
 interface DealInputProps {
   inputs: WaterfallInputs;
@@ -479,6 +480,7 @@ const s: Record<string, React.CSSProperties> = {
 };
 
 const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext, genre }: DealInputProps) => {
+  const haptics = useHaptics();
   const inputRef = useRef<HTMLInputElement>(null);
   const [hasFocused, setHasFocused] = useState(false);
   const [hasPulsed, setHasPulsed] = useState(false);
@@ -676,7 +678,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext, genre }:
       </div>
 
       {/* Adjust Assumptions lever */}
-      <button style={s.levTrigger} onClick={() => setLeversOpen(!leversOpen)}>
+      <button style={s.levTrigger} onClick={(e) => { haptics.light(e); setLeversOpen(!leversOpen); }}>
         <div style={s.levLeft}>
           <span style={s.levTitle}>Adjust Assumptions</span>
           <span style={s.levVals}>Sales fee {inputs.salesFee}% · Marketing {formatShort(inputs.salesExp)}</span>
@@ -739,7 +741,7 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext, genre }:
 
       {/* CTA */}
       <div style={hasRevenue ? s.revealVis : s.reveal}>
-        <button style={s.cta} onClick={onNext}>
+        <button style={s.cta} onClick={(e) => { haptics.medium(e); onNext(); }}>
           See the Waterfall
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <line x1="5" y1="12" x2="19" y2="12" />

--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -262,7 +262,6 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
   const selectedCount = Object.values(selections).filter(Boolean).length;
 
   const handleToggle = (key: keyof CapitalSourceSelections) => {
-    haptics.light();
     setJustToggled(key);
     onToggle(key);
     setTimeout(() => setJustToggled(null), 200);
@@ -296,7 +295,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
             return (
               <button
                 key={option.key}
-                onClick={() => handleToggle(option.key)}
+                onClick={(e) => { haptics.light(e); handleToggle(option.key); }}
                 style={{
                   ...(isSelected ? s.siOn : s.si),
                   // Re-apply borderBottom separately since si/siOn override border

--- a/src/components/calculator/stack/StackInputCard.tsx
+++ b/src/components/calculator/stack/StackInputCard.tsx
@@ -225,7 +225,7 @@ const StackInputCard = ({
         <div className="flex items-center gap-3 pt-2">
           {/* Back */}
           <button
-            onClick={() => { haptics.light(); onBack(); }}
+            onClick={(e) => { haptics.light(e); onBack(); }}
             className={cn(
               "flex-1 py-3 flex items-center justify-center gap-2",
               "transition-all active:scale-[0.98] rounded-md"
@@ -239,7 +239,7 @@ const StackInputCard = ({
           {/* Skip (if no value) or Next (if has value) */}
           {hasAmount ? (
             <button
-              onClick={() => { haptics.light(); onNext(); }}
+              onClick={(e) => { haptics.light(e); onNext(); }}
               className={cn(
                 "flex-[2] py-3 flex items-center justify-center gap-2",
                 "transition-all active:scale-[0.98] rounded-md"
@@ -251,7 +251,7 @@ const StackInputCard = ({
             </button>
           ) : showSkip && onSkip ? (
             <button
-              onClick={() => { haptics.light(); onSkip?.(); }}
+              onClick={(e) => { haptics.light(e); onSkip?.(); }}
               className={cn(
                 "flex-[2] py-3 flex items-center justify-center gap-2",
                 "transition-all active:scale-[0.98] rounded-md"

--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -297,7 +297,7 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
                     ...(isSelected ? s.pillOn : s.pill),
                     ...(isPressed ? { transform: "scale(0.96)" } : {}),
                   }}
-                  onClick={() => { haptics.light(); handleGenreSelect(genre); }}
+                  onClick={(e) => { haptics.light(e); handleGenreSelect(genre); }}
                   onPointerDown={() => setPressedPill(genre)}
                   onPointerUp={() => setPressedPill(null)}
                   onPointerLeave={() => setPressedPill(null)}
@@ -337,7 +337,7 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
                     ...(isSelected ? s.pillOn : s.pill),
                     ...(isPressed ? { transform: "scale(0.96)" } : {}),
                   }}
-                  onClick={() => { haptics.light(); update("status", status); }}
+                  onClick={(e) => { haptics.light(e); update("status", status); }}
                   onPointerDown={() => setPressedPill(`status-${status}`)}
                   onPointerUp={() => setPressedPill(null)}
                   onPointerLeave={() => setPressedPill(null)}
@@ -352,7 +352,7 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
         {/* Team Details — collapsible */}
         <button
           style={s.expTrigger}
-          onClick={() => { haptics.light(); setTeamOpen(!teamOpen); }}
+          onClick={(e) => { haptics.light(e); setTeamOpen(!teamOpen); }}
         >
           <div style={s.expLeft}>
             <span style={s.expTitle}>Team Details</span>

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -99,7 +99,8 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
   }, [isLocked, isDemoMode]);
 
   // Handler for "Run Demo" button on Locked Screen
-  const handleRunDemo = () => {
+  const handleRunDemo = (e?: React.MouseEvent) => {
+    haptics.medium(e);
     setIsDemoMode(true);
   };
 
@@ -166,7 +167,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
             </p>
 
             <button
-              onClick={handleRunDemo}
+              onClick={(e) => handleRunDemo(e)}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -308,7 +309,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
                 Demo Mode
               </span>
               <button
-                onClick={() => setIsDemoMode(false)}
+                onClick={(e) => { haptics.light(e); setIsDemoMode(false); }}
                 style={{
                   display: "flex",
                   alignItems: "center",

--- a/src/hooks/use-haptics.ts
+++ b/src/hooks/use-haptics.ts
@@ -1,13 +1,97 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 /**
  * Premium Haptic Feedback Hook
- * Provides tactile feedback for interactive elements using the Vibration API.
- * Gracefully degrades on devices without vibration support.
+ *
+ * Android: Uses the Vibration API for real tactile feedback.
+ * iOS / unsupported: Falls back to a micro-scale + opacity pulse
+ * on the event target, giving a visual "press" feel.
+ *
+ * Usage:
+ *   haptics.light()            — fire-and-forget (vibration only)
+ *   haptics.light(e)           — vibration + visual pulse on e.currentTarget
+ *   haptics.medium(e)          — stronger vibration + visual pulse
  */
+
+const HAS_VIBRATE = typeof navigator !== "undefined" && "vibrate" in navigator;
+
+// CSS class for the visual pulse — injected once
+const PULSE_CLASS = "haptic-pulse";
+const PULSE_HEAVY_CLASS = "haptic-pulse-heavy";
+const PULSE_SUCCESS_CLASS = "haptic-pulse-success";
+
+let styleInjected = false;
+const injectStyles = () => {
+  if (styleInjected || typeof document === "undefined") return;
+  styleInjected = true;
+  const style = document.createElement("style");
+  style.id = "haptic-pulse-styles";
+  style.textContent = `
+    @keyframes hapticPulse {
+      0%   { transform: scale(1);    opacity: 1; }
+      40%  { transform: scale(0.97); opacity: 0.85; }
+      100% { transform: scale(1);    opacity: 1; }
+    }
+    @keyframes hapticPulseHeavy {
+      0%   { transform: scale(1);    opacity: 1; }
+      35%  { transform: scale(0.95); opacity: 0.80; }
+      100% { transform: scale(1);    opacity: 1; }
+    }
+    @keyframes hapticPulseSuccess {
+      0%   { transform: scale(1);    opacity: 1; }
+      25%  { transform: scale(0.97); opacity: 0.85; }
+      50%  { transform: scale(1.01); opacity: 1; }
+      75%  { transform: scale(0.99); opacity: 0.95; }
+      100% { transform: scale(1);    opacity: 1; }
+    }
+    .${PULSE_CLASS} {
+      animation: hapticPulse 150ms ease-out !important;
+    }
+    .${PULSE_HEAVY_CLASS} {
+      animation: hapticPulseHeavy 200ms ease-out !important;
+    }
+    .${PULSE_SUCCESS_CLASS} {
+      animation: hapticPulseSuccess 300ms ease-out !important;
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+type HapticEvent =
+  | React.MouseEvent
+  | React.TouchEvent
+  | React.PointerEvent
+  | { currentTarget: HTMLElement | null }
+  | undefined;
+
+const applyVisualPulse = (e: HapticEvent, className: string) => {
+  if (!e) return;
+  const el = (e as { currentTarget: HTMLElement | null }).currentTarget;
+  if (!el || !(el instanceof HTMLElement)) return;
+
+  // Remove any existing pulse first so re-triggers work
+  el.classList.remove(PULSE_CLASS, PULSE_HEAVY_CLASS, PULSE_SUCCESS_CLASS);
+  // Force reflow to restart animation
+  void el.offsetWidth;
+  el.classList.add(className);
+
+  const cleanup = () => {
+    el.classList.remove(className);
+    el.removeEventListener("animationend", cleanup);
+  };
+  el.addEventListener("animationend", cleanup);
+};
+
 export const useHaptics = () => {
+  const initialized = useRef(false);
+
+  if (!initialized.current) {
+    injectStyles();
+    initialized.current = true;
+  }
+
   const vibrate = useCallback((pattern: number | number[]) => {
-    if ('vibrate' in navigator) {
+    if (HAS_VIBRATE) {
       try {
         navigator.vibrate(pattern);
       } catch {
@@ -17,23 +101,41 @@ export const useHaptics = () => {
   }, []);
 
   return {
-    /** Quick tap - for toggles and minor interactions (10ms) */
-    light: useCallback(() => vibrate(10), [vibrate]),
-    
+    /** Quick tap - for toggles, pills, minor interactions (10ms) */
+    light: useCallback((e?: HapticEvent) => {
+      vibrate(10);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_CLASS);
+    }, [vibrate]),
+
     /** Button press - standard button feedback (25ms) */
-    medium: useCallback(() => vibrate(25), [vibrate]),
-    
+    medium: useCallback((e?: HapticEvent) => {
+      vibrate(25);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_CLASS);
+    }, [vibrate]),
+
     /** Important action - for significant UI changes (50ms) */
-    heavy: useCallback(() => vibrate(50), [vibrate]),
-    
+    heavy: useCallback((e?: HapticEvent) => {
+      vibrate(50);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_HEAVY_CLASS);
+    }, [vibrate]),
+
     /** Success pattern - for successful form submissions */
-    success: useCallback(() => vibrate([30, 50, 30]), [vibrate]),
-    
+    success: useCallback((e?: HapticEvent) => {
+      vibrate([30, 50, 30]);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_SUCCESS_CLASS);
+    }, [vibrate]),
+
     /** Error pattern - for form errors or failed actions */
-    error: useCallback(() => vibrate([50, 30, 50, 30, 50]), [vibrate]),
-    
+    error: useCallback((e?: HapticEvent) => {
+      vibrate([50, 30, 50, 30, 50]);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_HEAVY_CLASS);
+    }, [vibrate]),
+
     /** Step change - for navigation between wizard steps */
-    step: useCallback(() => vibrate(35), [vibrate]),
+    step: useCallback((e?: HapticEvent) => {
+      vibrate(35);
+      if (!HAS_VIBRATE || e) applyVisualPulse(e, PULSE_CLASS);
+    }, [vibrate]),
   };
 };
 

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -286,7 +286,9 @@ const WorkingModelPopup = ({
   onDecline: () => void;
   onClose: () => void;
   loading: boolean;
-}) => (
+}) => {
+  const haptics = useHaptics();
+  return (
   <div style={{
     position: "fixed", inset: 0, zIndex: 200,
     display: "flex", alignItems: "flex-end", justifyContent: "center",
@@ -312,7 +314,7 @@ const WorkingModelPopup = ({
     >
       {/* Close */}
       <button
-        onClick={onClose}
+        onClick={(e) => { haptics.light(e); onClose(); }}
         disabled={loading}
         style={{
           position: "absolute", top: "16px", right: "16px", zIndex: 10,
@@ -416,7 +418,7 @@ const WorkingModelPopup = ({
         {/* CTAs */}
         <div style={{ display: "flex", flexDirection: "column", gap: "10px", paddingTop: "4px" }}>
           <button
-            onClick={onAccept}
+            onClick={(e) => { haptics.medium(e); onAccept(); }}
             disabled={loading}
             style={{
               ...s.btnCta,
@@ -430,7 +432,7 @@ const WorkingModelPopup = ({
             {loading ? "CONNECTING..." : "YES, ADD FOR $79"}
           </button>
           <button
-            onClick={onDecline}
+            onClick={(e) => { haptics.light(e); onDecline(); }}
             disabled={loading}
             style={{
               background: "none", border: "none", cursor: "pointer",
@@ -448,7 +450,8 @@ const WorkingModelPopup = ({
       </div>
     </div>
   </div>
-);
+  );
+};
 
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -489,6 +492,7 @@ const ProductCard = ({
   index: number;
 }) => {
   const [hovered, setHovered] = useState(false);
+  const haptics = useHaptics();
   const isFeatured = product.featured;
 
   const cardStyle: React.CSSProperties = {
@@ -562,7 +566,7 @@ const ProductCard = ({
       {/* Action */}
       <div style={s.actionBlock}>
         <button
-          onClick={onBuy}
+          onClick={(e) => { haptics.medium(e); onBuy(); }}
           style={isFeatured ? s.btnCta : s.btnOutline}
           onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
           onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
@@ -571,7 +575,7 @@ const ProductCard = ({
         </button>
         {onBuy10 && (
           <button
-            onClick={onBuy10}
+            onClick={(e) => { haptics.medium(e); onBuy10(); }}
             style={{ ...s.btnOutline, marginTop: "8px", fontSize: "12px" }}
             onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
             onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
@@ -581,6 +585,7 @@ const ProductCard = ({
         )}
         <button
           onClick={(e) => {
+            haptics.light(e);
             e.stopPropagation();
             window.location.href = `/store/${product.slug}`;
           }}
@@ -611,6 +616,7 @@ const ServiceCard = ({
   index: number;
 }) => {
   const [hovered, setHovered] = useState(false);
+  const haptics = useHaptics();
   const isTop = product.tier === 4;
 
   const cardStyle: React.CSSProperties = {
@@ -692,7 +698,7 @@ const ServiceCard = ({
       {/* Action */}
       <div style={s.actionBlock}>
         <button
-          onClick={onBuy}
+          onClick={(e) => { haptics.medium(e); onBuy(); }}
           style={isTop ? s.btnCta : s.btnOutline}
           onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
           onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
@@ -701,6 +707,7 @@ const ServiceCard = ({
         </button>
         <button
           onClick={(e) => {
+            haptics.light(e);
             e.stopPropagation();
             window.location.href = `/store/${product.slug}`;
           }}
@@ -727,10 +734,12 @@ const FaqItem = ({
   faq: { q: string; a: string };
   isOpen: boolean;
   onToggle: () => void;
-}) => (
+}) => {
+  const haptics = useHaptics();
+  return (
   <div style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>
     <button
-      onClick={onToggle}
+      onClick={(e) => { haptics.light(e); onToggle(); }}
       style={{
         width: "100%",
         display: "flex",
@@ -788,7 +797,8 @@ const FaqItem = ({
       </div>
     )}
   </div>
-);
+  );
+};
 
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -1139,7 +1149,7 @@ const Store = () => {
               transition: "background 0.2s, border-color 0.2s",
               cursor: "pointer",
             }}
-            onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
+            onMouseDown={(e) => { haptics.medium(e); (e.currentTarget.style.transform = "scale(0.98)"); }}
             onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
           >
             <Mail style={{ width: "16px", height: "16px" }} />


### PR DESCRIPTION
Enhanced useHaptics hook to provide visual micro-scale animations as a fallback when navigator.vibrate() is unavailable (iOS Safari). Every haptic method now optionally accepts the event to apply a CSS pulse animation on the target element.

Added haptics to 18+ previously missing interactive elements:
- TabBar: all 5 tab navigation buttons
- DealInput: Adjust Assumptions toggle, See the Waterfall CTA
- WaterfallTab: Run Demo button, Exit Demo button
- WaterfallDeck: Get the Full Analysis CTA, Export Free Snapshot
- Store: all ProductCard/ServiceCard buy buttons, FAQ toggles, Working Model popup accept/decline/close, bespoke Get In Touch

Updated existing haptic call sites to pass click events for visual feedback on iOS: BudgetInput pills/guilds, ProjectTab genre/status pills, StackInputCard nav buttons, CapitalSelect toggles.

https://claude.ai/code/session_014VV2GsdHqc9KtrBqqXJHxL