### PR TITLE
Polish landing page: full-brightness social icons, lighter closer ove…

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -195,7 +195,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Instagram size={20} style={{ color: "rgba(212,175,55,0.40)" }} />
+                <Instagram size={20} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.2rem",
@@ -226,7 +226,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <svg width={20} height={20} viewBox="0 0 24 24" fill="rgba(212,175,55,0.40)" xmlns="http://www.w3.org/2000/svg">
+                <svg width={20} height={20} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
                   <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 0 0-.79-.05A6.34 6.34 0 0 0 3.15 15a6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.34-6.34V8.71a8.2 8.2 0 0 0 4.76 1.52v-3.4a4.85 4.85 0 0 1-1-.14z"/>
                 </svg>
                 <span style={{
@@ -259,7 +259,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange }: MobileMenuProps) =
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <svg width={20} height={20} viewBox="0 0 24 24" fill="rgba(212,175,55,0.40)" xmlns="http://www.w3.org/2000/svg">
+                <svg width={20} height={20} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
                   <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
                 </svg>
                 <span style={{

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -849,7 +849,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
 
   /* ── § 6 REALITY ── */
-  realitySection: { background: "#000", textAlign: "left", padding: "48px 24px 32px" },
+  realitySection: { background: "#000", textAlign: "left", padding: "64px 24px 32px" },
   blockquote: {
     fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.4rem", lineHeight: 0.95, color: "#fff",
     borderLeft: "3px solid #D4AF37", paddingLeft: "20px", marginBottom: "24px",
@@ -888,7 +888,7 @@ const styles: Record<string, React.CSSProperties> = {
   closerSection: {
     position: "relative", overflow: "hidden", textAlign: "center", marginTop: "48px",
     padding: "48px 24px 80px", borderTop: "1px solid rgba(212,175,55,0.25)",
-    backgroundImage: "linear-gradient(to bottom, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.48) 50%, rgba(0,0,0,0.75) 100%), url('/closer-bg.jpg')",
+    backgroundImage: "linear-gradient(to bottom, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.35) 50%, rgba(0,0,0,0.60) 100%), url('/closer-bg.jpg')",
     backgroundSize: "cover",
     backgroundPosition: "center top",
   },


### PR DESCRIPTION
…rlay, consistent section spacing

- Social icons (Instagram, TikTok, Facebook) now use #D4AF37 instead of 40% opacity rgba
- Closer section overlay reduced from 0.72/0.48/0.75 to 0.55/0.35/0.60 to let background image show through
- Reality section top padding changed from 48px to 64px to match other sections

https://claude.ai/code/session_01Tkoxg2udSeENAH6GP1x1mn