### PR TITLE
OgBot atmosphere + shimmer + hero card + fab visibility updates

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -129,8 +129,8 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           {onOpenBot && (
             <button
               onClick={() => { haptics.medium(); onOpenBot(); }}
-              onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
-              onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
+              onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(120,60,180,0.50), 0 0 60px rgba(120,60,180,0.20)"; }}
+              onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(120,60,180,0.30), 0 0 50px rgba(120,60,180,0.10)"; }}
               style={{
                 width: "100%",
                 display: "flex",
@@ -147,7 +147,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 transition: "transform 0.15s ease, box-shadow 0.3s ease",
               }}
             >
-              <Sparkles style={{ width: "20px", height: "20px", color: "#fff", filter: "drop-shadow(0 0 6px rgba(255,255,255,0.30))" }} />
+              <Sparkles style={{ width: "20px", height: "20px", color: "#D4AF37", filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))" }} />
               <span style={{
                 fontFamily: "'Bebas Neue', sans-serif",
                 fontSize: "1.4rem",

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -5,8 +5,8 @@ import { useHaptics } from "@/hooks/use-haptics";
 
 /* ═══════════════════════════════════════════════════════════════════
    OgBotFab — floating action button for the OG bot
-   Bottom-right corner. Hidden on /calculator (overlaps TabBar)
-   and when closer section is in viewport on the landing page.
+   Bottom-right corner. Repositioned above TabBar on /calculator.
+   Hidden when closer section is in viewport on the landing page.
    ═══════════════════════════════════════════════════════════════════ */
 
 interface OgBotFabProps {
@@ -17,9 +17,6 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
   const haptics = useHaptics();
   const location = useLocation();
   const [hiddenByCloser, setHiddenByCloser] = useState(false);
-
-  // Hide on calculator — FAB overlaps TabBar
-  const onCalculator = location.pathname.startsWith("/calculator");
 
   useEffect(() => {
     const closer = document.querySelector('[data-section="closer"]');
@@ -33,14 +30,15 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
     return () => obs.disconnect();
   }, []);
 
-  const hidden = onCalculator || hiddenByCloser;
+  const onCalculator = location.pathname.startsWith("/calculator");
+  const hidden = hiddenByCloser;
 
   return (
     <button
       onClick={() => { haptics.medium(); onTap?.(); }}
       className="fixed z-[140] flex items-center justify-center active:scale-90 transition-all duration-300"
       style={{
-        bottom: "calc(20px + env(safe-area-inset-bottom))",
+        bottom: onCalculator ? "calc(82px + env(safe-area-inset-bottom))" : "calc(20px + env(safe-area-inset-bottom))",
         right: "20px",
         width: "52px",
         height: "52px",

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -219,17 +219,26 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           paddingBottom: "calc(var(--bottom-bar-h) + env(safe-area-inset-bottom))",
           background: "#000",
           borderRadius: "12px 12px 0 0",
-          boxShadow: "0 -20px 60px rgba(120,60,180,0.12), 0 -40px 80px rgba(0,0,0,0.95)",
+          boxShadow: "0 -20px 60px rgba(120,60,180,0.20), 0 -40px 80px rgba(0,0,0,0.95)",
         }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
         {/* 1px gold gradient top-edge line */}
         <div
-          className="absolute top-0 left-0 right-0 h-[1px] pointer-events-none z-10"
+          className="absolute top-0 left-0 right-0 h-[3px] pointer-events-none z-10"
           style={{
-            background: "linear-gradient(to right, transparent 0%, rgba(120,60,180,0.35) 30%, rgba(120,60,180,0.35) 70%, transparent 100%)",
+            background: "linear-gradient(to right, transparent 0%, rgba(120,60,180,0.50) 30%, rgba(120,60,180,0.50) 70%, transparent 100%)",
             borderRadius: "12px 12px 0 0",
+          }}
+        />
+
+        {/* Purple atmospheric glow */}
+        <div
+          className="absolute top-0 left-0 right-0 pointer-events-none z-0"
+          style={{
+            height: "200px",
+            background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.12) 0%, transparent 70%)",
           }}
         />
 
@@ -241,7 +250,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* ── Sheet header ── */}
         <div
           className="px-6 pt-3 pb-5 flex-shrink-0 border-b"
-          style={{ borderColor: "rgba(120,60,180,0.15)" }}
+          style={{ borderColor: "rgba(120,60,180,0.25)" }}
         >
           <div className="flex items-end justify-between">
             <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none text-white">
@@ -277,8 +286,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
           {/* Empty state — example chips with eyebrow */}
           {ogMessages.length === 0 && (
-            <div className="flex flex-col items-center gap-5 pt-3">
-              <span className="font-bebas text-[22px] tracking-[0.14em] uppercase" style={{ color: "rgba(255,255,255,0.50)" }}>
+            <div className="flex flex-col items-center justify-center gap-5" style={{ minHeight: "100%" }}>
+              <img src={filmmakerFIcon} alt="" className="w-6 h-6 object-contain" style={{ opacity: 0.25 }} />
+              <span className="font-bebas text-[22px] tracking-[0.14em] uppercase" style={{ color: "rgba(255,255,255,0.60)" }}>
                 What do you want to know
               </span>
 
@@ -291,27 +301,27 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     disabled={ogLoading}
                     className="font-bebas text-[16px] tracking-[0.10em] px-5 py-3.5 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
                     onMouseEnter={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.30)";
-                      e.currentTarget.style.background = "rgba(120,60,180,0.08)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.40)";
+                      e.currentTarget.style.background = "rgba(120,60,180,0.12)";
                       e.currentTarget.style.color = "#FFFFFF";
                     }}
                     onMouseLeave={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.15)";
-                      e.currentTarget.style.background = "rgba(120,60,180,0.03)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.25)";
+                      e.currentTarget.style.background = "rgba(120,60,180,0.06)";
                       e.currentTarget.style.color = "rgba(255,255,255,0.70)";
                     }}
                     onTouchStart={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.30)";
-                      e.currentTarget.style.background = "rgba(120,60,180,0.08)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.40)";
+                      e.currentTarget.style.background = "rgba(120,60,180,0.12)";
                     }}
                     onTouchEnd={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.15)";
-                      e.currentTarget.style.background = "rgba(120,60,180,0.03)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.25)";
+                      e.currentTarget.style.background = "rgba(120,60,180,0.06)";
                     }}
                     style={{
                       borderRadius: "6px",
-                      borderColor: "rgba(120,60,180,0.15)",
-                      background: "rgba(120,60,180,0.03)",
+                      borderColor: "rgba(120,60,180,0.25)",
+                      background: "rgba(120,60,180,0.06)",
                       color: "rgba(255,255,255,0.70)",
                     }}
                   >
@@ -331,8 +341,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   className="relative max-w-[85%] px-4 py-3 border overflow-hidden"
                   style={{
                     borderRadius: "8px",
-                    background: "rgba(120,60,180,0.08)",
-                    borderColor: "rgba(120,60,180,0.12)",
+                    background: "rgba(120,60,180,0.12)",
+                    borderColor: "rgba(120,60,180,0.20)",
                   }}
                 >
                   <p className="text-[18px] text-white leading-relaxed">{msg.question}</p>
@@ -346,8 +356,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   style={{
                     borderRadius: "8px",
                     background: "#000",
-                    borderColor: "rgba(120,60,180,0.15)",
-                    boxShadow: "0 0 30px rgba(120,60,180,0.10)",
+                    borderColor: "rgba(120,60,180,0.25)",
+                    boxShadow: "0 0 30px rgba(120,60,180,0.18)",
                   }}
                 >
                   {/* Answer body */}
@@ -358,9 +368,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       <span className="font-bebas text-[15px] tracking-[0.15em] leading-none" style={{ color: "rgb(180,140,255)" }}>OG</span>
                       {msg.streaming && (
                         <div className="flex gap-1 ml-1">
-                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.40)", animationDelay: "0ms" }} />
-                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.40)", animationDelay: "150ms" }} />
-                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.40)", animationDelay: "300ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.60)", animationDelay: "0ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.60)", animationDelay: "150ms" }} />
+                          <div className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ background: "rgba(120,60,180,0.60)", animationDelay: "300ms" }} />
                         </div>
                       )}
                     </div>
@@ -385,17 +395,17 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* Input area */}
         <div
           className="px-5 pb-4 pt-3 flex-shrink-0 border-t"
-          style={{ borderColor: "rgba(120,60,180,0.15)", background: "#000" }}
+          style={{ borderColor: "rgba(120,60,180,0.25)", background: "#000" }}
         >
           <form onSubmit={handleOgSubmit}>
             <div
               className="flex gap-0 transition-colors"
               style={{
                 borderRadius: "8px",
-                border: "1px solid rgba(120,60,180,0.15)",
+                border: "1px solid rgba(120,60,180,0.25)",
               }}
-              onFocus={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.35)")}
-              onBlur={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.15)")}
+              onFocus={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.50)")}
+              onBlur={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.25)")}
             >
               <textarea
                 ref={inputRef}
@@ -404,7 +414,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   if (e.target.value.length <= 1500) setOgInput(e.target.value);
                 }}
                 onKeyDown={handleKeyDown}
-                placeholder="Ask a film industry question…"
+                placeholder="Ask about deals, packages, or your model…"
                 rows={2}
                 disabled={ogLoading}
                 className="flex-1 px-4 py-3 focus:outline-none text-[18px] text-white resize-none disabled:opacity-50 min-h-[56px]"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -173,7 +173,7 @@ const Index = () => {
       <style>{`
         @keyframes lp-shimmer {
           0% { left: -100%; }
-          20% { left: 200%; }
+          30% { left: 200%; }
           100% { left: 200%; }
         }
       `}</style>
@@ -190,7 +190,7 @@ const Index = () => {
               <em style={styles.heroEm}>Waterfall</em>
             </h1>
             <p style={styles.heroSub}>Your Deal Structure Begins Here.</p>
-            <div style={styles.heroCard}>
+            <div style={{ margin: "8px 24px 0" }}>
               <button onClick={handleCTA} style={styles.ctaBtn} onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.98)"; }} onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}>
                 <span style={{ position: "relative", zIndex: 1 }}>RUN MY WATERFALL</span>
                 <div style={styles.ctaShimmer} />
@@ -566,9 +566,9 @@ const styles: Record<string, React.CSSProperties> = {
   },
   ctaShimmer: {
     position: "absolute", top: 0, left: "-100%", width: "55%", height: "100%",
-    background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.28), transparent)",
+    background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
     transform: "skewX(-20deg)",
-    animation: "lp-shimmer 3s cubic-bezier(0.16, 1, 0.3, 1) infinite",
+    animation: "lp-shimmer 2.5s ease-in-out infinite",
   },
 
   /* ── § 1 HERO ── */
@@ -595,14 +595,6 @@ const styles: Record<string, React.CSSProperties> = {
     fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.5rem", textAlign: "center",
     marginBottom: "28px", lineHeight: 1.1, color: "#fff",
     marginTop: "8px", textShadow: "0 2px 12px rgba(0,0,0,0.9)",
-  },
-  heroCard: {
-    position: "relative",
-    border: "1px solid rgba(212,175,55,0.45)",
-    borderRadius: "12px",
-    padding: "16px 20px",
-    background: "rgba(0,0,0,0.75)",
-    margin: "8px 24px 0",
   },
 
   /* ── § 2 HOW IT WORKS ── */


### PR DESCRIPTION
- Recalibrate all purple opacities ~1.7x for OLED visibility
- Add atmospheric purple glow behind sheet header
- Widen top edge line to 3px with brighter gradient
- Add F icon and center empty state vertically
- Update placeholder to "Ask about deals, packages, or your model…"
- Brighten streaming dots, chip borders, answer card glow
- Make Sparkles icon gold in MobileMenu, add press glow
- Remove heroCard wrapper, keep CTA button with margin
- Faster shimmer: 2.5s cycle, ease-in-out, brighter flash
- Show FAB on /calculator repositioned above TabBar

https://claude.ai/code/session_015sScTYgzNV4CvqWPPz3GD6