### PR TITLE
Menu restructure + bot sheet polish: 3-col grids, fab icon, brighter …

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -167,10 +167,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 transition: "transform 0.15s ease, box-shadow 0.3s ease",
               }}
             >
-              <Sparkles style={{ width: "20px", height: "20px", color: "#D4AF37", filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))", position: "relative", zIndex: 1 }} />
+              <Sparkles style={{ width: "24px", height: "24px", color: "#D4AF37", filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))", position: "relative", zIndex: 1 }} />
               <span style={{
                 fontFamily: "'Bebas Neue', sans-serif",
-                fontSize: "1.4rem",
+                fontSize: "1.6rem",
                 letterSpacing: "0.10em",
                 color: "#fff",
                 position: "relative",
@@ -187,10 +187,9 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
             </button>
           )}
 
-          {/* Nav — 2×2 compact grid */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px", marginBottom: "12px" }}>
+          {/* Nav — 3-col (matches social row) */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "8px", marginBottom: "12px" }}>
             {([
-              { path: "/",           label: "Home",       icon: <Home size={16} color="#D4AF37" /> },
               { path: "/calculator", label: "Calculator", icon: <Calculator size={16} color="#D4AF37" /> },
               { path: "/store",      label: "Shop",       icon: <ShoppingBag size={16} color="#D4AF37" /> },
               { path: "/resources",  label: "Resources",  icon: <BarChart2 size={16} color="#D4AF37" /> },
@@ -331,10 +330,39 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
             </div>
           </div>
 
-          {/* Connect — email + share */}
+          {/* Connect — home + email + share */}
           <div>
             <SectionLabel>Connect</SectionLabel>
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px", marginBottom: "12px" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "8px", marginBottom: "12px" }}>
+
+              {/* Home */}
+              <button
+                onClick={() => handleNavigate("/")}
+                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
+                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "6px",
+                  padding: "12px 8px",
+                  background: "rgba(255,255,255,0.03)",
+                  border: "1px solid rgba(212,175,55,0.20)",
+                  borderRadius: "6px",
+                  cursor: "pointer",
+                  transition: "transform 0.15s ease, border-color 0.25s ease",
+                }}
+              >
+                <Home size={16} color="#D4AF37" />
+                <span style={{
+                  fontFamily: "'Bebas Neue', sans-serif",
+                  fontSize: "1.0rem",
+                  letterSpacing: "0.1em",
+                  color: "rgba(255,255,255,0.85)",
+                  lineHeight: 1,
+                }}>Home</span>
+              </button>
 
               {/* Email */}
               <a
@@ -344,10 +372,11 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
                   display: "flex",
+                  flexDirection: "column",
                   alignItems: "center",
                   justifyContent: "center",
-                  gap: "10px",
-                  padding: "12px",
+                  gap: "6px",
+                  padding: "12px 8px",
                   background: "rgba(255,255,255,0.03)",
                   border: "1px solid rgba(212,175,55,0.20)",
                   borderRadius: "6px",
@@ -355,7 +384,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Mail size={16} style={{ color: "#D4AF37", flexShrink: 0 }} />
+                <Mail size={16} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.0rem",
@@ -372,10 +401,11 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
                   display: "flex",
+                  flexDirection: "column",
                   alignItems: "center",
                   justifyContent: "center",
-                  gap: "10px",
-                  padding: "12px",
+                  gap: "6px",
+                  padding: "12px 8px",
                   background: "rgba(255,255,255,0.03)",
                   border: "1px solid rgba(212,175,55,0.20)",
                   borderRadius: "6px",
@@ -383,7 +413,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Share2 size={16} style={{ color: "#D4AF37", flexShrink: 0 }} />
+                <Share2 size={16} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.0rem",

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useHaptics } from "@/hooks/use-haptics";
-import { SendHorizonal, RotateCcw, X } from "lucide-react";
+import { SendHorizonal, RotateCcw, X, Sparkles } from "lucide-react";
 import filmmakerFIcon from "@/assets/filmmaker-f-icon.png";
 import { cn } from "@/lib/utils";
 
@@ -246,7 +246,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
 
         <style>{`
           .og-input::placeholder {
-            color: rgba(180,140,255,0.45) !important;
+            color: rgba(255,255,255,0.40) !important;
           }
         `}</style>
 
@@ -258,7 +258,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* ── Sheet header ── */}
         <div
           className="px-6 pt-3 pb-5 flex-shrink-0 border-b"
-          style={{ borderColor: "rgba(212,175,55,0.15)" }}
+          style={{ borderColor: "rgba(212,175,55,0.25)" }}
         >
           <div className="flex items-end justify-between">
             <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none" style={{ color: "#D4AF37", textShadow: "0 0 20px rgba(212,175,55,0.25)" }}>
@@ -295,7 +295,18 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           {/* Empty state — example chips with eyebrow */}
           {ogMessages.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-5" style={{ minHeight: "100%" }}>
-              <img src={filmmakerFIcon} alt="" className="w-8 h-8 object-contain" style={{ opacity: 0.70 }} />
+              <div style={{
+                width: "48px",
+                height: "48px",
+                borderRadius: "10px",
+                background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow: "0 0 20px rgba(120,60,180,0.30)",
+              }}>
+                <Sparkles style={{ width: "26px", height: "26px", color: "#D4AF37", filter: "drop-shadow(0 0 4px rgba(212,175,55,0.40))" }} />
+              </div>
               <span className="font-bebas text-[22px] tracking-[0.14em] uppercase" style={{ color: "rgb(180,140,255)" }}>
                 What do you want to know
               </span>
@@ -314,7 +325,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       e.currentTarget.style.color = "#FFFFFF";
                     }}
                     onMouseLeave={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.25)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.35)";
                       e.currentTarget.style.background = "rgba(120,60,180,0.06)";
                       e.currentTarget.style.color = "rgba(255,255,255,0.75)";
                     }}
@@ -323,12 +334,12 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                       e.currentTarget.style.background = "rgba(120,60,180,0.12)";
                     }}
                     onTouchEnd={e => {
-                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.25)";
+                      e.currentTarget.style.borderColor = "rgba(120,60,180,0.35)";
                       e.currentTarget.style.background = "rgba(120,60,180,0.06)";
                     }}
                     style={{
                       borderRadius: "6px",
-                      borderColor: "rgba(120,60,180,0.25)",
+                      borderColor: "rgba(120,60,180,0.35)",
                       background: "rgba(120,60,180,0.06)",
                       color: "rgba(255,255,255,0.75)",
                     }}
@@ -403,7 +414,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
         {/* Input area */}
         <div
           className="px-5 pb-4 pt-3 flex-shrink-0 border-t"
-          style={{ borderColor: "rgba(212,175,55,0.15)", background: "transparent" }}
+          style={{ borderColor: "rgba(212,175,55,0.25)", background: "transparent" }}
         >
           <form onSubmit={handleOgSubmit}>
             <div


### PR DESCRIPTION
…borders

MobileMenu:
- ASK THE OG button: font 1.4→1.6rem, sparkles icon 20→24px
- Nav grid: 2×2→3-col, removed Home (moved to Connect)
- Connect row: 2-col→3-col, added Home cell with stacked layout
- All three rows now matching 3-col grids

OgBotSheet:
- Empty state: F icon PNG replaced with rendered purple gradient + gold sparkles
- Chip borders: 0.25→0.35 opacity (mouseLeave, touchEnd, resting style)
- Gold dividers: header and input area borders 0.15→0.25
- Placeholder text: purple→white at 0.40 opacity
- Added Sparkles import from lucide-react

https://claude.ai/code/session_01RNw7unzHj3GwJ88DPgadbJ