### PR TITLE
Fix menu cell sizing, bot header icon, and text bumps

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -167,7 +167,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 transition: "transform 0.15s ease, box-shadow 0.3s ease",
               }}
             >
-              <Sparkles style={{ width: "24px", height: "24px", color: "#D4AF37", filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))", position: "relative", zIndex: 1 }} />
+              <Sparkles style={{ width: "26px", height: "26px", color: "#D4AF37", filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))", position: "relative", zIndex: 1 }} />
               <span style={{
                 fontFamily: "'Bebas Neue', sans-serif",
                 fontSize: "1.6rem",
@@ -190,9 +190,9 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           {/* Nav — 3-col (matches social row) */}
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "8px", marginBottom: "12px" }}>
             {([
-              { path: "/calculator", label: "Calculator", icon: <Calculator size={16} color="#D4AF37" /> },
-              { path: "/store",      label: "Shop",       icon: <ShoppingBag size={16} color="#D4AF37" /> },
-              { path: "/resources",  label: "Resources",  icon: <BarChart2 size={16} color="#D4AF37" /> },
+              { path: "/calculator", label: "Calculator", icon: <Calculator size={18} color="#D4AF37" /> },
+              { path: "/store",      label: "Shop",       icon: <ShoppingBag size={18} color="#D4AF37" /> },
+              { path: "/resources",  label: "Resources",  icon: <BarChart2 size={18} color="#D4AF37" /> },
             ] as const).map((item) => (
               <button
                 key={item.path}
@@ -215,7 +215,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 {item.icon}
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.88)",
                 }}>
@@ -252,10 +252,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Instagram size={16} style={{ color: "#D4AF37" }} />
+                <Instagram size={18} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                 }}>Instagram</span>
@@ -283,12 +283,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <svg width={16} height={16} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
+                <svg width={18} height={18} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
                   <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 0 0-.79-.05A6.34 6.34 0 0 0 3.15 15a6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.34-6.34V8.71a8.2 8.2 0 0 0 4.76 1.52v-3.4a4.85 4.85 0 0 1-1-.14z"/>
                 </svg>
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                 }}>TikTok</span>
@@ -316,12 +316,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <svg width={16} height={16} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
+                <svg width={18} height={18} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
                   <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
                 </svg>
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                 }}>Facebook</span>
@@ -354,10 +354,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Home size={16} color="#D4AF37" />
+                <Home size={18} color="#D4AF37" />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                   lineHeight: 1,
@@ -384,10 +384,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Mail size={16} style={{ color: "#D4AF37" }} />
+                <Mail size={18} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                   lineHeight: 1,
@@ -413,10 +413,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   transition: "transform 0.15s ease, border-color 0.25s ease",
                 }}
               >
-                <Share2 size={16} style={{ color: "#D4AF37" }} />
+                <Share2 size={18} style={{ color: "#D4AF37" }} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.0rem",
+                  fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.85)",
                   lineHeight: 1,
@@ -434,6 +434,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
               letterSpacing: "0.05em",
               lineHeight: 1.6,
               color: "rgba(255,255,255,0.40)",
+              textAlign: "center",
             }}>
               For educational and informational purposes only. Not legal, tax, or investment advice.
               Consult a qualified entertainment attorney before making financing decisions.

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useHaptics } from "@/hooks/use-haptics";
 import { SendHorizonal, RotateCcw, X, Sparkles } from "lucide-react";
-import filmmakerFIcon from "@/assets/filmmaker-f-icon.png";
 import { cn } from "@/lib/utils";
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -261,9 +260,24 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           style={{ borderColor: "rgba(212,175,55,0.25)" }}
         >
           <div className="flex items-end justify-between">
-            <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none" style={{ color: "#D4AF37", textShadow: "0 0 20px rgba(212,175,55,0.25)" }}>
-              ASK THE OG
-            </h2>
+            <div className="flex items-center gap-3">
+              <div style={{
+                width: "32px",
+                height: "32px",
+                borderRadius: "8px",
+                background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow: "0 0 12px rgba(120,60,180,0.25)",
+                flexShrink: 0,
+              }}>
+                <Sparkles style={{ width: "18px", height: "18px", color: "#D4AF37", filter: "drop-shadow(0 0 3px rgba(212,175,55,0.40))" }} />
+              </div>
+              <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none" style={{ color: "#D4AF37", textShadow: "0 0 20px rgba(212,175,55,0.25)" }}>
+                ASK THE OG
+              </h2>
+            </div>
             <div className="flex items-center gap-3 pb-0.5">
               {ogMessages.length > 0 && (
                 <button
@@ -295,19 +309,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
           {/* Empty state — example chips with eyebrow */}
           {ogMessages.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-5" style={{ minHeight: "100%" }}>
-              <div style={{
-                width: "48px",
-                height: "48px",
-                borderRadius: "10px",
-                background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                boxShadow: "0 0 20px rgba(120,60,180,0.30)",
-              }}>
-                <Sparkles style={{ width: "26px", height: "26px", color: "#D4AF37", filter: "drop-shadow(0 0 4px rgba(212,175,55,0.40))" }} />
-              </div>
-              <span className="font-bebas text-[22px] tracking-[0.14em] uppercase" style={{ color: "rgb(180,140,255)" }}>
+              <span className="font-bebas text-[24px] tracking-[0.14em] uppercase" style={{ color: "rgb(180,140,255)" }}>
                 What do you want to know
               </span>
 
@@ -318,7 +320,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     key={chip}
                     onClick={() => handleAsk(chip)}
                     disabled={ogLoading}
-                    className="font-bebas text-[16px] tracking-[0.10em] px-5 py-3.5 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
+                    className="font-bebas text-[17px] tracking-[0.10em] px-5 py-3.5 transition-all disabled:opacity-40 disabled:cursor-not-allowed border"
                     onMouseEnter={e => {
                       e.currentTarget.style.borderColor = "rgba(120,60,180,0.40)";
                       e.currentTarget.style.background = "rgba(120,60,180,0.12)";
@@ -383,7 +385,18 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   <div className="px-5 py-5">
                     {/* Inline attribution header */}
                     <div className="flex items-center gap-2 mb-3">
-                      <img src={filmmakerFIcon} alt="OG" className="w-4 h-4 object-contain" />
+                      <div style={{
+                        width: "20px",
+                        height: "20px",
+                        borderRadius: "5px",
+                        background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        flexShrink: 0,
+                      }}>
+                        <Sparkles style={{ width: "12px", height: "12px", color: "#D4AF37" }} />
+                      </div>
                       <span className="font-bebas text-[15px] tracking-[0.15em] leading-none" style={{ color: "#D4AF37" }}>OG</span>
                       {msg.streaming && (
                         <div className="flex gap-1 ml-1">
@@ -449,6 +462,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   className="px-5 font-bebas tracking-wider transition-all flex items-center gap-2 flex-shrink-0 disabled:opacity-30 disabled:cursor-not-allowed"
                   onMouseEnter={e => !e.currentTarget.disabled && (e.currentTarget.style.opacity = "0.8")}
                   onMouseLeave={e => (e.currentTarget.style.opacity = "1")}
+                  onMouseDown={e => { e.currentTarget.style.transform = "scale(0.95)"; }}
+                  onMouseUp={e => { e.currentTarget.style.transform = "scale(1)"; }}
                   style={{ background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)", color: "#fff", borderRadius: "0 7px 7px 0" }}
                 >
                 <SendHorizonal className="w-4 h-4" />
@@ -459,7 +474,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 "text-[11px] tabular-nums",
                 ogInput.length > 1350 ? "text-gold" : ""
               )}
-              style={ogInput.length <= 1350 ? { color: "rgba(120,60,180,0.50)" } : undefined}
+              style={ogInput.length <= 1350 ? { color: "rgba(212,175,55,0.40)" } : undefined}
             >
                 {ogInput.length}/1500
               </span>


### PR DESCRIPTION
MobileMenu: bump ASK THE OG sparkles 24→26px, all cell icons 16→18px, all cell labels 1.0→1.1rem, center-align legal disclaimer.

OgBotSheet: add 32px fab icon to sheet header, remove fab from empty state, bump prompt text 22→24px, chip text 16→17px, add send button press scale, swap F icon for mini fab in answer attribution, change counter color to gold, remove unused filmmakerFIcon import.

https://claude.ai/code/session_01Xu6hKsNhrTHJppNPXi754w