### PR TITLE
Fix ASK THE OG title vertical alignment with icon in OgBotSheet

### DIFF
--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -274,7 +274,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
               }}>
                 <Sparkles style={{ width: "22px", height: "22px", color: "#D4AF37", filter: "drop-shadow(0 0 3px rgba(212,175,55,0.40))" }} />
               </div>
-              <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none" style={{ color: "#D4AF37", textShadow: "0 0 20px rgba(212,175,55,0.25)" }}>
+              <h2 className="font-bebas text-[32px] tracking-[0.12em] leading-none" style={{ color: "#D4AF37", textShadow: "0 0 20px rgba(212,175,55,0.25)", marginTop: "2px" }}>
                 ASK THE OG
               </h2>
             </div>


### PR DESCRIPTION
Add marginTop: 2px to the h2 title to nudge it down, aligning it visually with the 36px purple icon container. Bebas Neue's cap height with leading-none caused the text to sit too high.

https://claude.ai/code/session_01JgKHBdxmakEmVgDkP5LmKg