### PR TITLE
Fix menu footer orphan word, brighten bot input resting state

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -479,8 +479,8 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           <div className="pt-3" style={{ borderTop: "1px solid rgba(212,175,55,0.20)" }}>
             <p style={{
               fontFamily: "'Inter', sans-serif",
-              fontSize: "12px",
-              letterSpacing: "0.05em",
+              fontSize: "11px",
+              letterSpacing: "0.02em",
               lineHeight: 1.6,
               color: "rgba(255,255,255,0.40)",
               textAlign: "center",

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -245,7 +245,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
 
         <style>{`
           .og-input::placeholder {
-            color: rgba(255,255,255,0.40) !important;
+            color: rgba(255,255,255,0.55) !important;
           }
         `}</style>
 
@@ -436,10 +436,10 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
               className="flex gap-0 transition-colors"
               style={{
                 borderRadius: "8px",
-                border: "1px solid rgba(120,60,180,0.30)",
+                border: "1px solid rgba(120,60,180,0.40)",
               }}
-              onFocus={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.50)")}
-              onBlur={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.30)")}
+              onFocus={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.60)")}
+              onBlur={e => (e.currentTarget.style.borderColor = "rgba(120,60,180,0.40)")}
             >
               <textarea
                 ref={inputRef}


### PR DESCRIPTION
- Legal disclaimer: 12px → 11px, letter-spacing 0.05em → 0.02em to eliminate orphaned "decisions." on line 4
- Bot input border: rest 0.30 → 0.40, focus 0.50 → 0.60 so input looks ready-to-type on OLED
- Placeholder text: 0.40 → 0.55 for clearer invitation to type

https://claude.ai/code/session_017Tkxd7m695rRwfwVS67F5g