### PR TITLE
Landing page polish: badge sizing, tier nums purple, spacing reductio…

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -129,27 +129,27 @@ const Index = () => {
     {
       title: "Enter Your Budget",
       body: "Total budget, cash basis after deferments and tax credits, investor equity.",
-      icon: <svg viewBox="0 0 24 24" fill="#fff" width="18" height="18"><path d="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"/></svg>,
+      icon: <svg viewBox="0 0 24 24" fill="#fff" width="22" height="22"><path d="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"/></svg>,
     },
     {
       title: "Build Your Capital Stack",
       body: "Equity, debt, tax credits, deferments. Structure your financing the way real deals close.",
-      icon: <svg viewBox="0 0 24 24" fill="#fff" width="18" height="18"><path d="M5 9.2h3V19H5V9.2zM10.6 5h2.8v14h-2.8V5zm5.6 8H19v6h-2.8v-6z"/></svg>,
+      icon: <svg viewBox="0 0 24 24" fill="#fff" width="22" height="22"><path d="M5 9.2h3V19H5V9.2zM10.6 5h2.8v14h-2.8V5zm5.6 8H19v6h-2.8v-6z"/></svg>,
     },
     {
       title: "Set Your Deal Terms",
       body: "Fees, guild rates, distribution costs. Every line between revenue and profit.",
-      icon: <svg viewBox="0 0 24 24" fill="#fff" width="18" height="18"><rect x="3" y="4" width="18" height="3" rx="1"/><rect x="5" y="9" width="14" height="3" rx="1"/><rect x="7" y="14" width="10" height="3" rx="1"/><rect x="9" y="19" width="6" height="3" rx="1"/></svg>,
+      icon: <svg viewBox="0 0 24 24" fill="#fff" width="22" height="22"><rect x="3" y="4" width="18" height="3" rx="1"/><rect x="5" y="9" width="14" height="3" rx="1"/><rect x="7" y="14" width="10" height="3" rx="1"/><rect x="9" y="19" width="6" height="3" rx="1"/></svg>,
     },
     {
       title: "See the Full Waterfall",
       body: "Every tier with accurate rates — off-the-tops through net backend profit. Adjust and stress-test until you know what you can't give up.",
-      icon: <svg viewBox="0 0 24 24" fill="#fff" width="18" height="18"><path d="M12 2L3 7v5c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5zm-1 14l-3.5-3.5 1.41-1.41L11 13.17l5.09-5.09 1.41 1.41L11 16z"/></svg>,
+      icon: <svg viewBox="0 0 24 24" fill="#fff" width="22" height="22"><path d="M12 2L3 7v5c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5zm-1 14l-3.5-3.5 1.41-1.41L11 13.17l5.09-5.09 1.41 1.41L11 16z"/></svg>,
     },
     {
       title: "Export & Share",
       body: "Download a formatted PDF. Share directly with investors, financiers, and co-producers.",
-      icon: <svg viewBox="0 0 24 24" fill="#fff" width="18" height="18"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></svg>,
+      icon: <svg viewBox="0 0 24 24" fill="#fff" width="22" height="22"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/></svg>,
     },
   ];
 
@@ -311,7 +311,7 @@ const Index = () => {
           <div style={{ ...styles.whyHeader, ...reveal(whyVisible) }}>
             <EyebrowRuled text="Why This Matters" />
             <h2 style={styles.whyH2}><span style={{ color: "#D4AF37" }}>(4) Four</span> Reasons<br />You Can't Skip This</h2>
-            <p style={styles.sectionSub}>The math behind every deal you'll ever make.</p>
+            <p style={styles.sectionSub}>The math behind every deal you'll make.</p>
           </div>
 
           <div style={{ ...styles.badgeGridWrapper, ...reveal(whyVisible, 1) }}>
@@ -468,9 +468,12 @@ const Index = () => {
         {/* ═══ § 6 REALITY ═══ */}
         <section style={styles.realitySection}>
           <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.20) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
-          <blockquote ref={realityQuoteRef} style={{ ...styles.blockquote, ...reveal(realityQuoteVisible) }}>
+          <div style={{ position: "relative" }}>
+            <div style={{ position: "absolute", top: "-20px", left: "-20px", right: "-20px", bottom: "-20px", background: "radial-gradient(ellipse 100% 80% at 20% 50%, rgba(120,60,180,0.12) 0%, transparent 60%)", pointerEvents: "none", zIndex: 0 }} />
+            <blockquote ref={realityQuoteRef} style={{ ...styles.blockquote, position: "relative", zIndex: 1, ...reveal(realityQuoteVisible) }}>
             The waterfall either costs you now — or costs you everything <span style={{ color: "#D4AF37" }}>later</span>.
           </blockquote>
+          </div>
 
           <div ref={realityGridRef} style={{ ...styles.checkGrid, ...reveal(realityGridVisible) }}>
             <div style={{ position: "absolute", top: 0, left: 0, right: "50%", height: "1px", background: "linear-gradient(90deg, transparent, rgba(60,179,113,0.5), transparent)", zIndex: 1 }} />
@@ -583,7 +586,7 @@ const styles: Record<string, React.CSSProperties> = {
   /* ── § 1 HERO ── */
   hero: {
     position: "relative", textAlign: "center",
-    padding: "24px 24px 0",
+    padding: "24px 24px 12px",
     margin: "0 24px",
     borderRadius: "12px",
     overflow: "hidden",
@@ -605,12 +608,12 @@ const styles: Record<string, React.CSSProperties> = {
   heroMid: { display: "block", color: "#fff", fontStyle: "normal", textShadow: "0 2px 16px rgba(0,0,0,0.9)" },
   heroSub: {
     fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.5rem", textAlign: "center",
-    marginBottom: "28px", lineHeight: 1.1, color: "#fff",
+    marginBottom: "16px", lineHeight: 1.1, color: "#fff",
     marginTop: "8px", textShadow: "0 2px 12px rgba(0,0,0,0.9)",
   },
 
   /* ── § 2 HOW IT WORKS ── */
-  howSection: { position: "relative", background: "#000", padding: "64px 0 0" },
+  howSection: { position: "relative", background: "#000", padding: "48px 0 0" },
   howHeader: { textAlign: "center", padding: "16px 24px 24px", background: "radial-gradient(ellipse 80% 50% at 50% 60%, rgba(120,60,180,0.18) 0%, transparent 70%)" },
   howH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   stepsContainer: { position: "relative", display: "flex", flexDirection: "column", gap: "1px", background: "rgba(120,60,180,0.10)", borderRadius: "12px", overflow: "hidden", margin: "0 24px", border: "1px solid rgba(120,60,180,0.25)", boxShadow: "0 16px 40px rgba(0,0,0,0.5), 0 0 20px rgba(120,60,180,0.15)" },
@@ -627,7 +630,7 @@ const styles: Record<string, React.CSSProperties> = {
     background: "linear-gradient(180deg, rgba(120,60,180,0.6) 0%, rgba(120,60,180,0.1) 100%)", zIndex: 0,
   },
   stepNumBadge: {
-    position: "relative", zIndex: 1, width: "40px", height: "40px", borderRadius: "50%",
+    position: "relative", zIndex: 1, width: "48px", height: "48px", borderRadius: "50%",
     background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)", display: "flex", alignItems: "center", justifyContent: "center",
     boxShadow: "0 0 20px rgba(120,60,180,0.50), 0 0 40px rgba(120,60,180,0.25)",
   },
@@ -636,7 +639,7 @@ const styles: Record<string, React.CSSProperties> = {
   stepBody: { fontFamily: "'Inter', sans-serif", fontSize: "19px", color: "rgba(255,255,255,0.88)", lineHeight: 1.55 },
 
   /* ── § 3 WATERFALL ── */
-  waterfallSection: { position: "relative", background: "#000", padding: "64px 0 0" },
+  waterfallSection: { position: "relative", background: "#000", padding: "48px 0 0" },
   waterfallHeader: { textAlign: "center", padding: "0 24px 24px" },
   waterfallH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   waterfallExplainer: {
@@ -646,7 +649,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   acquisitionCallout: {
     position: "relative", overflow: "hidden", textAlign: "center", margin: "0 24px 10px",
-    background: "radial-gradient(circle at 50% 70%, rgba(212,175,55,0.20) 0%, rgba(6,6,6,0.92) 75%)", border: "1px solid rgba(212,175,55,0.25)", borderRadius: "12px", padding: "24px 20px",
+    background: "radial-gradient(circle at 50% 70%, rgba(212,175,55,0.20) 0%, rgba(6,6,6,0.92) 75%), radial-gradient(circle at 50% 50%, rgba(120,60,180,0.10) 0%, transparent 60%)", border: "1px solid rgba(212,175,55,0.25)", borderRadius: "12px", padding: "24px 20px",
     boxShadow: "0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
   },
   acqLabel: { fontFamily: "'Roboto Mono', monospace", fontSize: "16px", textTransform: "uppercase", letterSpacing: "0.15em", color: "#D4AF37", marginBottom: "4px" },
@@ -665,11 +668,11 @@ const styles: Record<string, React.CSSProperties> = {
     borderLeft: "2px solid rgba(220,38,38,0.15)",
   },
   tierNum: {
-    fontFamily: "'Roboto Mono', monospace", fontSize: "11px", color: "#D4AF37",
-    background: "rgba(212,175,55,0.18)", border: "1px solid rgba(212,175,55,0.35)",
+    fontFamily: "'Roboto Mono', monospace", fontSize: "11px", color: "rgb(180,140,255)",
+    background: "rgba(120,60,180,0.18)", border: "1px solid rgba(120,60,180,0.35)",
     width: "28px", height: "28px", display: "flex", alignItems: "center", justifyContent: "center",
     borderRadius: "6px", fontWeight: 600,
-    boxShadow: "0 0 16px rgba(212,175,55,0.3), 0 0 32px rgba(120,60,180,0.25)",
+    boxShadow: "0 0 16px rgba(120,60,180,0.3), 0 0 32px rgba(120,60,180,0.25)",
   },
   tierName: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem", color: "#fff", lineHeight: 1.3, textTransform: "uppercase", letterSpacing: "0.02em" },
   tierAmt: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "rgba(220,38,38,0.85)", textAlign: "right", whiteSpace: "nowrap", letterSpacing: "0.02em" },
@@ -679,12 +682,12 @@ const styles: Record<string, React.CSSProperties> = {
   flowDiagram: { margin: "16px 24px 0" },
   netBackend: {
     position: "relative", textAlign: "center", background: "rgba(6,6,6,0.92)", border: "1px solid rgba(60,179,113,0.35)",
-    borderRadius: "12px", padding: "24px 20px", zIndex: 2, boxShadow: "0 8px 24px rgba(0,0,0,0.5), 0 0 30px rgba(60,179,113,0.15)",
+    borderRadius: "12px", padding: "24px 20px", zIndex: 2, boxShadow: "0 8px 24px rgba(0,0,0,0.5), 0 0 30px rgba(60,179,113,0.15), 0 0 20px rgba(120,60,180,0.12)",
   },
   netLabel: { fontFamily: "'Roboto Mono', monospace", fontSize: "11px", textTransform: "uppercase", letterSpacing: "0.15em", color: colors.textPrimary, marginBottom: "8px" },
   netAmount: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#3CB371", lineHeight: 0.9, letterSpacing: "0.02em", textShadow: "0 0 24px rgba(60,179,113,0.35)" },
   pipeNetwork: { display: "flex", flexDirection: "column", alignItems: "center", marginTop: "-1px", position: "relative", zIndex: 1 },
-  pipeVertical: { width: "2px", height: "18px", background: "rgba(60,179,113,0.50)" },
+  pipeVertical: { width: "2px", height: "18px", background: "rgba(60,179,113,0.50)", boxShadow: "0 0 8px rgba(120,60,180,0.10)" },
   pipeFork: { display: "flex", width: "calc(50% + 10px)" },
   pipeLeft: { flex: 1, height: "18px", borderTop: "2px solid rgba(60,179,113,0.50)", borderLeft: "2px solid rgba(60,179,113,0.50)", borderRadius: "6px 0 0 0" },
   pipeRight: { flex: 1, height: "18px", borderTop: "2px solid rgba(60,179,113,0.50)", borderRight: "2px solid rgba(60,179,113,0.50)", borderRadius: "0 6px 0 0" },
@@ -699,7 +702,7 @@ const styles: Record<string, React.CSSProperties> = {
   waterfallNote: { fontFamily: "'Roboto Mono', monospace", fontSize: "11px", textTransform: "uppercase", textAlign: "center", color: "rgba(255,255,255,0.45)", letterSpacing: "0.06em", padding: "16px 24px 0" },
 
   /* ── § 4 WHY THIS MATTERS ── */
-  whySection: { position: "relative", background: "#000", textAlign: "center", padding: "64px 0 0" },
+  whySection: { position: "relative", background: "#000", textAlign: "center", padding: "48px 0 0" },
   whyHeader: { padding: "20px 24px 24px" },
   whyH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", textAlign: "center", lineHeight: 0.95 },
   badgeGridWrapper: {
@@ -709,15 +712,15 @@ const styles: Record<string, React.CSSProperties> = {
   badgeGrid: { display: "grid", gridTemplateColumns: "1fr", gap: "1px", background: "rgba(120,60,180,0.15)" },
   badgeCard: { background: "radial-gradient(circle at 45px 57px, rgba(120,60,180,0.15) 0%, rgba(6,6,6,0.92) 65%)", padding: "36px 24px", textAlign: "left" },
   badgeNum: {
-    width: "40px", height: "40px", borderRadius: "50%", background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)", color: "#fff",
-    display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.5rem",
+    width: "48px", height: "48px", borderRadius: "50%", background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)", color: "#fff",
+    display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.7rem",
     marginBottom: "16px", paddingTop: "2px", boxShadow: "0 0 24px rgba(120,60,180,0.55), 0 0 48px rgba(120,60,180,0.25)",
   },
   badgeTitle: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#fff", marginBottom: "8px", lineHeight: 1.05, letterSpacing: "0.02em" },
   badgeBody: { fontFamily: "'Inter', sans-serif", fontSize: "19px", color: "rgba(255,255,255,0.85)", lineHeight: 1.55 },
 
   /* ── § 5 ARSENAL ── */
-  arsenalSection: { position: "relative", background: "#000", textAlign: "center", padding: "64px 0 0" },
+  arsenalSection: { position: "relative", background: "#000", textAlign: "center", padding: "48px 0 0" },
   arsenalHeader: { padding: "0 24px 24px" },
   arsenalH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   arsenalSub: { fontFamily: "'Inter', sans-serif", fontSize: "18px", marginTop: "10px", color: "rgba(255,255,255,0.88)", lineHeight: 1.6 },
@@ -854,7 +857,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
 
   /* ── § 6 REALITY ── */
-  realitySection: { position: "relative", background: "#000", textAlign: "left", padding: "64px 24px 32px" },
+  realitySection: { position: "relative", background: "#000", textAlign: "left", padding: "40px 24px 32px" },
   blockquote: {
     fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.4rem", lineHeight: 0.95, color: "#fff",
     borderLeft: "3px solid #D4AF37", paddingLeft: "20px", marginBottom: "24px",
@@ -897,7 +900,7 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: "12px",
     backgroundImage: "linear-gradient(to bottom, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.35) 50%, rgba(0,0,0,0.60) 100%), url('/closer-bg.jpg')",
     backgroundSize: "cover",
-    backgroundPosition: "center top",
+    backgroundPosition: "center 30%",
   },
   closerGlowBottom: {
     position: "absolute", bottom: 0, left: 0, right: 0, height: "80%", pointerEvents: "none",


### PR DESCRIPTION
…n, purple glows

- Badges: 40px → 48px, font 1.5rem → 1.7rem, step icons 18px → 22px
- Waterfall tier numbers: gold → purple (rgb(180,140,255))
- Hero CTA spacing: marginBottom 28px → 16px, bottom padding 0 → 12px
- Orphan fix: "every deal you'll ever make" → "every deal you'll make"
- Purple glows: blockquote wrapper, acquisition callout layer, net backend shadow, pipe vertical
- Section top padding: 64px → 48px (how/waterfall/why/arsenal), 64px → 40px (reality)
- Closer image: backgroundPosition center top → center 30%

https://claude.ai/code/session_016DX8Sg4JcK4onc9ERWtzkY