### PR TITLE
Audit resources page + add glass hero to Store and Resources

### DIFF
--- a/RESOURCES_PAGE_REFERENCE.md
+++ b/RESOURCES_PAGE_REFERENCE.md
@@ -3,6 +3,7 @@
 **Source of truth:** `src/pages/Resources.tsx` (1,256 lines), `src/lib/glossary-rotation.ts`
 **Last extracted:** March 21, 2026 (commit d293e0e)
 **Companion docs:** `LANDING_PAGE_REFERENCE.md`, `UNIVERSAL_PATTERN_LIBRARY.md`
+**Audit shipped:** March 22, 2026 (PR #TBD) — glass hero, pinned cards below command center with purple pins, purple command center, standard footer, atmospheric bumps across all card states. See session brief for full proposal list.
 
 ---
 
@@ -24,14 +25,14 @@
 ### Section Stack (render order)
 
 ```
-HEADER — "Resource Vault" hero headline
+HERO — Glass card: "RESOURCE / VAULT" + subtext (matches Index.tsx hero pattern)
 ── breath line ──
-EDITOR'S CHOICE — 2 pinned cornerstone cards (horizontal scroll on mobile)
-── breath line ──
-COMMAND CENTER — sticky search + filter bar
+COMMAND CENTER — sticky search + filter bar (purple atmospheric + purple search border)
+PINNED CARDS — 2 cornerstone entries, stacked vertically, purple pin indicators
+── purple separator ──
 RESULTS BAR — count + sort toggle
 VAULT GRID — filtered VaultCard list
-FOOTER — branded ruled footer
+FOOTER — standard social + nav + disclaimer (synced with Index.tsx / Store.tsx)
 ```
 
 ### Styling Convention
@@ -125,12 +126,11 @@ Two featured entries in a horizontal scroll container:
 // Content: "Start Here" eyebrow → "What Is a Recoupment Waterfall" title → "Editor's Choice" gold solid badge
 ```
 
-### Secondary Pinned Card (auto width)
+### Secondary Pinned Card (stacked, full width)
 
 ```tsx
 {
-  flex: "0 0 auto",
-  minWidth: "65%",
+  // No flex sizing — stacked vertically below primary
   scrollSnapAlign: "start",
   borderRadius: 12,
   padding: "22px 20px",
@@ -304,17 +304,9 @@ Appears between header and pinned section, and between pinned section and comman
 
 ---
 
-## 10. FOOTER (unique to Resources)
+## 10. FOOTER (synced with Index.tsx / Store.tsx)
 
-NOT the standard landing page/store footer. Resources has its own branded footer:
-
-```tsx
-// Ruled brand mark: gold line + "Filmmaker.og" mono label + gold line
-// Subtitle: "Film finance intelligence" in muted mono
-// Extra generous padding: 80px top/bottom
-```
-
-No social icons, no nav links, no disclaimer. This is a minimal brand-only closer.
+Standard shared footer with social icons (Instagram, TikTok, Facebook), nav links (Home, Shop, Resources), and legal disclaimer. `#0A0A0A` background, gold `0.12` border-top, `32px 24px 40px` padding.
 
 ---
 
@@ -344,13 +336,15 @@ Resources is the only page with explicit responsive CSS. Injected via script blo
 | `4.2rem` | Bebas | Page header "Resource Vault" |
 | `1.9rem` | Bebas | Primary pinned card title |
 | `1.6rem` | Bebas | Secondary pinned card title |
-| `1.5rem` | Bebas | Vault card titles |
+| `1.8rem` | Bebas | Vault card titles (gold/gold-featured) |
+| `1.6rem` | Bebas | Vault card titles (neutral) |
 | `22px` | — | Hover arrow (→ / ↗) |
 | `16px` | Inter | Card excerpt, search input |
 | `14px` | Mono | Card meta (date, read time) |
 | `13px` | Mono | Footer brand label, dropdown items |
 | `12px` | Mono | Badges, pinned labels, "Editor's Choice", filter, results bar |
-| `11px` | Mono | Card eyebrow, dropdown button |
+| `12px` | Mono | Card eyebrow |
+| `11px` | Mono | Badge text, dropdown button |
 | `8px` | — | Meta dot separator |
 
 ---
@@ -361,6 +355,6 @@ Resources is the only page with explicit responsive CSS. Injected via script blo
 - Do NOT remove the responsive CSS injection — it controls mobile behavior
 - Do NOT change glossary rotation to cron-based — deterministic date seeding is by design
 - Do NOT use glass blur on vault cards — they're opaque `#0A0A0A` (consistent with Store)
-- Do NOT add the standard landing page/store footer — Resources has its own minimal footer
+- Do NOT diverge the footer from Store.tsx / Index.tsx — Resources now uses the standard shared footer
 - Do NOT put editorial content href links to "#" in production — they're placeholder
 - Do NOT change card state assignment logic without updating all dependent style functions

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -133,8 +133,8 @@ function getCardBorderStyle(state: CardState, hovered: boolean): React.CSSProper
       return {
         border: hovered ? "1px solid rgba(212,175,55,0.50)" : "1px solid rgba(212,175,55,0.30)",
         boxShadow: hovered
-          ? "0 20px 50px rgba(0,0,0,0.9), 0 0 40px rgba(212,175,55,0.10)"
-          : "0 16px 40px rgba(0,0,0,0.8), 0 0 30px rgba(212,175,55,0.04)",
+          ? "0 20px 50px rgba(0,0,0,0.9), 0 0 40px rgba(212,175,55,0.18)"
+          : "0 16px 40px rgba(0,0,0,0.8), 0 0 30px rgba(212,175,55,0.14)",
       };
     case "neutral":
       return {
@@ -144,7 +144,7 @@ function getCardBorderStyle(state: CardState, hovered: boolean): React.CSSProper
     default: // gold
       return {
         border: hovered ? "1px solid rgba(212,175,55,0.35)" : "1px solid rgba(212,175,55,0.20)",
-        boxShadow: hovered ? "0 20px 50px rgba(0,0,0,0.8), 0 0 20px rgba(212,175,55,0.05)" : "none",
+        boxShadow: hovered ? "0 20px 50px rgba(0,0,0,0.8), 0 0 20px rgba(212,175,55,0.12)" : "0 8px 24px rgba(0,0,0,0.6), 0 0 20px rgba(212,175,55,0.08)",
       };
   }
 }
@@ -171,8 +171,8 @@ function getToplineStyle(state: CardState, hovered: boolean): React.CSSPropertie
         ...base,
         height: 1,
         background: hovered
-          ? "linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)"
-          : "linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)",
+          ? "linear-gradient(90deg, transparent, rgba(255,255,255,0.25), transparent)"
+          : "linear-gradient(90deg, transparent, rgba(255,255,255,0.18), transparent)",
       };
     default:
       return {
@@ -196,11 +196,11 @@ function getHazeStyle(state: CardState): React.CSSProperties {
   };
   switch (state) {
     case "gold-featured":
-      return { ...base, background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.10) 0%, transparent 70%)" };
+      return { ...base, background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.18) 0%, transparent 70%)" };
     case "neutral":
       return { ...base, display: "none" };
     default:
-      return { ...base, background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.05) 0%, transparent 70%)" };
+      return { ...base, background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.14) 0%, transparent 70%)" };
   }
 }
 
@@ -366,7 +366,7 @@ const VaultCard: React.FC<{
         <p style={{
           fontFamily: "'Inter', sans-serif",
           fontSize: isNeutral ? 16 : 17,
-          color: isNeutral ? "rgba(255,255,255,0.60)" : "rgba(255,255,255,0.75)",
+          color: isNeutral ? "rgba(255,255,255,0.60)" : "rgba(255,255,255,0.80)",
           lineHeight: 1.55,
           display: "-webkit-box",
           WebkitLineClamp: isNeutral ? 2 : 3,
@@ -547,256 +547,66 @@ const Resources = () => {
       lineHeight: 1.6,
       minHeight: "100vh",
     }}>
-      {/* ---- HEADER ---- */}
-      <header ref={headerRef} style={{
-        padding: "48px 0 28px",
-        textAlign: "center",
-        position: "relative",
-      }}>
+      {/* ---- HERO (glass card) ---- */}
+      <div ref={headerRef} style={{ padding: "32px 0 0", position: "relative" }}>
+        {/* Page-level canopy behind the card */}
         <div style={{
-          position: "absolute",
-          top: "-10%",
-          left: 0,
-          right: 0,
-          height: "70%",
-          background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.15) 0%, transparent 70%)",
+          position: "absolute", top: 0, left: 0, right: 0, height: "120%",
+          background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.25) 0%, transparent 70%)",
           pointerEvents: "none",
         }} />
-        <h1 style={{
-          fontFamily: "'Bebas Neue', sans-serif",
-          fontSize: "4.2rem",
-          letterSpacing: "0.04em",
-          textTransform: "uppercase",
-          lineHeight: 1,
-          color: "#fff",
-          position: "relative",
-          zIndex: 1,
-          margin: 0,
+        {/* Glass hero card */}
+        <section style={{
+          position: "relative", textAlign: "center",
+          padding: "28px 24px 24px",
+          margin: "0 24px",
+          borderRadius: 12,
+          overflow: "hidden",
+          background: "rgba(6,6,6,0.92)",
+          backdropFilter: "blur(40px)",
+          WebkitBackdropFilter: "blur(40px)",
+          border: "1px solid rgba(212,175,55,0.20)",
+          boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
           ...reveal(headerVisible),
         }}>
-          Resource <span style={{ color: "#D4AF37" }}>Vault</span>
-        </h1>
-      </header>
-
-      {/* ---- BREATH LINE ---- */}
-      <div style={{
-        height: 1,
-        background: "linear-gradient(90deg, transparent 5%, rgba(212,175,55,0.35) 50%, transparent 95%)",
-        boxShadow: "0 0 12px rgba(212,175,55,0.2)",
-        margin: "0 24px",
-      }} />
-
-      {/* ---- EDITOR'S CHOICE (PINNED) ---- */}
-      <section ref={pinnedRef} className="pinned-section" style={{ padding: "28px 24px 16px", maxWidth: 1000, margin: "0 auto" }}>
-        <div className="pinned-label" style={{
-          fontFamily: "'Roboto Mono', monospace",
-          fontSize: 12,
-          letterSpacing: "0.15em",
-          textTransform: "uppercase",
-          color: "rgba(255,255,255,0.95)",
-          marginBottom: 20,
-        }}>
-          Editor&apos;s Choice
-        </div>
-        <div className="vault-pinned-grid" style={{
-          display: "flex",
-          gap: 16,
-          overflowX: "auto",
-          scrollSnapType: "x mandatory",
-          WebkitOverflowScrolling: "touch",
-          scrollbarWidth: "none",
-          margin: "0 -24px",
-          padding: "0 24px 8px",
-        }}>
-          {/* Primary pinned */}
-          <a
-            href="#"
-            style={{
-              flex: "0 0 78%",
-              minWidth: 0,
-              scrollSnapAlign: "start",
-              borderRadius: 12,
-              position: "relative",
-              overflow: "hidden",
-              padding: "22px 20px",
-              background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.08) 0%, #0A0A0A 70%)",
-              cursor: "pointer",
-              textDecoration: "none",
-              color: "inherit",
-              display: "block",
-              transition: "all 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
-              transform: pinnedPrimaryHover ? "translateY(-3px)" : "translateY(0)",
-              boxShadow: pinnedPrimaryHover
-                ? "0 20px 50px rgba(0,0,0,0.9), 0 0 50px rgba(212,175,55,0.12)"
-                : "none",
-              ...reveal(pinnedVisible),
-            }}
-            onMouseEnter={() => setPinnedPrimaryHover(true)}
-            onMouseLeave={() => setPinnedPrimaryHover(false)}
-          >
-            {/* Gold gradient border via pseudo — simulated with box-shadow + border since inline styles can't do mask */}
-            <div style={{
-              position: "absolute",
-              inset: 0,
-              borderRadius: 12,
-              border: "1px solid rgba(212,175,55,0.40)",
-              pointerEvents: "none",
-            }} />
-            {/* Topline */}
-            <div style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              height: 2,
-              background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.6), transparent)",
-              zIndex: 1,
-            }} />
-            <span style={{
-              fontFamily: "'Roboto Mono', monospace",
-              fontSize: 12,
-              letterSpacing: "0.15em",
-              textTransform: "uppercase",
-              color: "#D4AF37",
-              marginBottom: 8,
-              display: "block",
-            }}>
-              Start Here
-            </span>
-            <h2 style={{
+          {/* Triple radial glow */}
+          <div style={{
+            position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
+            background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+          }} />
+          <div style={{ position: "relative", zIndex: 1 }}>
+            <h1 style={{
               fontFamily: "'Bebas Neue', sans-serif",
-              fontSize: "1.9rem",
-              color: "#fff",
-              lineHeight: 1,
-              letterSpacing: "0.03em",
-              marginBottom: 14,
-              marginTop: 0,
-            }}>
-              What Is a Recoupment Waterfall
-            </h2>
-            <div style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              paddingTop: 12,
-              borderTop: "1px solid rgba(255,255,255,0.08)",
-            }}>
-              <span style={{
-                fontFamily: "'Roboto Mono', monospace",
-                fontSize: 11,
-                textTransform: "uppercase",
-                letterSpacing: "0.15em",
-                color: "#000",
-                background: "#D4AF37",
-                padding: "6px 14px",
-                borderRadius: 4,
-                fontWeight: 600,
-                boxShadow: "0 0 12px rgba(212,175,55,0.4)",
-              }}>
-                Editor&apos;s Choice
-              </span>
-              <span style={{
-                color: pinnedPrimaryHover ? "#D4AF37" : "rgba(255,255,255,0.35)",
-                fontSize: 18,
-                transition: "all 0.3s",
-                transform: pinnedPrimaryHover ? "translateX(6px)" : "translateX(0)",
-                display: "inline-block",
-              }}>
-                {"\u2192"}
-              </span>
-            </div>
-          </a>
-
-          {/* Secondary pinned */}
-          <a
-            href="#"
-            style={{
-              flex: "0 0 78%",
-              minWidth: 0,
-              scrollSnapAlign: "start",
-              borderRadius: 12,
-              position: "relative",
-              overflow: "hidden",
-              padding: "22px 18px",
-              background: "#0A0A0A",
-              border: "1px solid rgba(212,175,55,0.20)",
-              boxShadow: pinnedSecondaryHover
-                ? "0 20px 50px rgba(0,0,0,0.8), 0 0 20px rgba(212,175,55,0.05)"
-                : "0 16px 40px rgba(0,0,0,0.6)",
-              cursor: "pointer",
-              textDecoration: "none",
-              color: "inherit",
-              display: "flex",
-              flexDirection: "column",
-              transition: "all 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
-              transform: pinnedSecondaryHover ? "translateY(-3px)" : "translateY(0)",
-              borderColor: pinnedSecondaryHover ? "rgba(212,175,55,0.35)" : "rgba(212,175,55,0.20)",
-              ...reveal(pinnedVisible, 1),
-            }}
-            onMouseEnter={() => setPinnedSecondaryHover(true)}
-            onMouseLeave={() => setPinnedSecondaryHover(false)}
-          >
-            {/* Topline */}
-            <div style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              height: 1,
-              background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.5), transparent)",
-            }} />
-            <span style={{
-              fontFamily: "'Roboto Mono', monospace",
-              fontSize: 12,
-              letterSpacing: "0.15em",
+              fontSize: "4.2rem",
+              letterSpacing: "0.01em",
               textTransform: "uppercase",
-              color: "#D4AF37",
-              marginBottom: 8,
-              display: "block",
-            }}>
-              Reference
-            </span>
-            <h2 style={{
-              fontFamily: "'Bebas Neue', sans-serif",
-              fontSize: "1.6rem",
+              lineHeight: 0.86,
               color: "#fff",
-              lineHeight: 1,
-              letterSpacing: "0.03em",
-              marginBottom: 10,
-              marginTop: 0,
+              marginBottom: 4,
+              textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
             }}>
-              15 Terms Your Investors Expect You to Know
-            </h2>
-            <div style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              marginTop: "auto",
-              paddingTop: 12,
-              borderTop: "1px solid rgba(255,255,255,0.08)",
+              Resource<br />
+              <span style={{
+                color: "#D4AF37",
+                fontStyle: "normal",
+                textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
+              }}>Vault</span>
+            </h1>
+            <p style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: "1.5rem",
+              lineHeight: 1.1,
+              color: "#fff",
+              textAlign: "center",
+              marginTop: 8,
+              textShadow: "0 2px 12px rgba(0,0,0,0.9)",
             }}>
-              <span style={{
-                fontFamily: "'Roboto Mono', monospace",
-                fontSize: 12,
-                letterSpacing: "0.1em",
-                textTransform: "uppercase",
-                color: "rgba(212,175,55,0.55)",
-              }}>
-                Glossary
-              </span>
-              <span style={{
-                color: pinnedSecondaryHover ? "#D4AF37" : "rgba(255,255,255,0.35)",
-                fontSize: 18,
-                transition: "all 0.3s",
-                transform: pinnedSecondaryHover ? "translateX(6px)" : "translateX(0)",
-                display: "inline-block",
-              }}>
-                {"\u2192"}
-              </span>
-            </div>
-          </a>
-        </div>
-      </section>
+              Deal Structures. Waterfall Mechanics.<br />
+              The Intelligence Behind Films That Close.
+            </p>
+          </div>
+        </section>
+      </div>
 
       {/* ---- BREATH LINE ---- */}
       <div style={{
@@ -811,7 +621,7 @@ const Resources = () => {
         position: "sticky",
         top: 0,
         zIndex: 50,
-        background: "rgba(0,0,0,0.88)",
+        background: "linear-gradient(180deg, rgba(120,60,180,0.08) 0%, rgba(0,0,0,0.88) 100%)",
         backdropFilter: "blur(24px)",
         WebkitBackdropFilter: "blur(24px)",
         borderTop: "1px solid rgba(212,175,55,0.10)",
@@ -868,7 +678,7 @@ const Resources = () => {
               style={{
                 width: "100%",
                 background: searchInputFocused ? "rgba(212,175,55,0.06)" : "rgba(212,175,55,0.04)",
-                border: searchInputFocused ? "1px solid rgba(212,175,55,0.40)" : "1px solid rgba(212,175,55,0.25)",
+                border: searchInputFocused ? "1px solid rgba(120,60,180,0.50)" : "1px solid rgba(120,60,180,0.30)",
                 borderRadius: 12,
                 color: "rgba(255,255,255,0.95)",
                 fontFamily: "'Inter', sans-serif",
@@ -878,7 +688,7 @@ const Resources = () => {
                 outline: "none",
                 transition: "all 0.3s",
                 boxSizing: "border-box",
-                boxShadow: searchInputFocused ? "0 0 20px rgba(212,175,55,0.08)" : "0 0 12px rgba(212,175,55,0.04)",
+                boxShadow: searchInputFocused ? "0 0 20px rgba(120,60,180,0.15)" : "0 0 12px rgba(120,60,180,0.06)",
               }}
               autoComplete="off"
             />
@@ -1060,6 +870,246 @@ const Resources = () => {
         </div>
       </div>
 
+      {/* ---- EDITOR'S CHOICE (PINNED) ---- */}
+      <section ref={pinnedRef} className="pinned-section" style={{ padding: "28px 24px 16px", maxWidth: 1000, margin: "0 auto" }}>
+        <div className="pinned-label" style={{
+          fontFamily: "'Roboto Mono', monospace",
+          fontSize: 12,
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+          color: "rgba(255,255,255,0.95)",
+          marginBottom: 20,
+        }}>
+          Editor&apos;s Choice
+        </div>
+        <div style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}>
+          {/* Primary pinned */}
+          <a
+            href="#"
+            style={{
+              borderRadius: 12,
+              position: "relative",
+              overflow: "hidden",
+              padding: "22px 20px",
+              background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.08) 0%, #0A0A0A 70%)",
+              cursor: "pointer",
+              textDecoration: "none",
+              color: "inherit",
+              display: "block",
+              transition: "all 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
+              transform: pinnedPrimaryHover ? "translateY(-3px)" : "translateY(0)",
+              boxShadow: pinnedPrimaryHover
+                ? "0 20px 50px rgba(0,0,0,0.9), 0 0 50px rgba(212,175,55,0.12)"
+                : "none",
+              ...reveal(pinnedVisible),
+            }}
+            onMouseEnter={() => setPinnedPrimaryHover(true)}
+            onMouseLeave={() => setPinnedPrimaryHover(false)}
+          >
+            {/* Gold gradient border */}
+            <div style={{
+              position: "absolute",
+              inset: 0,
+              borderRadius: 12,
+              border: "1px solid rgba(212,175,55,0.40)",
+              pointerEvents: "none",
+            }} />
+            {/* Topline */}
+            <div style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 2,
+              background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.6), transparent)",
+              zIndex: 1,
+            }} />
+            {/* Purple pin */}
+            <div style={{
+              position: "absolute", top: 12, right: 14,
+              display: "flex", alignItems: "center", gap: 6, zIndex: 2,
+            }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgba(120,60,180,0.85)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 17v5" />
+                <path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z" />
+              </svg>
+              <span style={{
+                fontFamily: "'Roboto Mono', monospace", fontSize: 10,
+                letterSpacing: "0.12em", textTransform: "uppercase",
+                color: "rgba(120,60,180,0.75)", fontWeight: 600,
+              }}>Pinned</span>
+            </div>
+            <span style={{
+              fontFamily: "'Roboto Mono', monospace",
+              fontSize: 12,
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "#D4AF37",
+              marginBottom: 8,
+              display: "block",
+            }}>
+              Start Here
+            </span>
+            <h2 style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: "1.9rem",
+              color: "#fff",
+              lineHeight: 1,
+              letterSpacing: "0.03em",
+              marginBottom: 14,
+              marginTop: 0,
+              paddingRight: 80,
+            }}>
+              What Is a Recoupment Waterfall
+            </h2>
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              paddingTop: 12,
+              borderTop: "1px solid rgba(255,255,255,0.08)",
+            }}>
+              <span style={{
+                fontFamily: "'Roboto Mono', monospace",
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.15em",
+                color: "#000",
+                background: "#D4AF37",
+                padding: "6px 14px",
+                borderRadius: 4,
+                fontWeight: 600,
+                boxShadow: "0 0 12px rgba(212,175,55,0.4)",
+              }}>
+                Editor&apos;s Choice
+              </span>
+              <span style={{
+                color: pinnedPrimaryHover ? "#D4AF37" : "rgba(255,255,255,0.35)",
+                fontSize: 18,
+                transition: "all 0.3s",
+                transform: pinnedPrimaryHover ? "translateX(6px)" : "translateX(0)",
+                display: "inline-block",
+              }}>
+                {"\u2192"}
+              </span>
+            </div>
+          </a>
+
+          {/* Secondary pinned */}
+          <a
+            href="#"
+            style={{
+              borderRadius: 12,
+              position: "relative",
+              overflow: "hidden",
+              padding: "22px 18px",
+              background: "#0A0A0A",
+              border: "1px solid rgba(212,175,55,0.20)",
+              boxShadow: pinnedSecondaryHover
+                ? "0 20px 50px rgba(0,0,0,0.8), 0 0 20px rgba(212,175,55,0.05)"
+                : "0 16px 40px rgba(0,0,0,0.6)",
+              cursor: "pointer",
+              textDecoration: "none",
+              color: "inherit",
+              display: "flex",
+              flexDirection: "column",
+              transition: "all 0.4s cubic-bezier(0.16, 1, 0.3, 1)",
+              transform: pinnedSecondaryHover ? "translateY(-3px)" : "translateY(0)",
+              borderColor: pinnedSecondaryHover ? "rgba(212,175,55,0.35)" : "rgba(212,175,55,0.20)",
+              ...reveal(pinnedVisible, 1),
+            }}
+            onMouseEnter={() => setPinnedSecondaryHover(true)}
+            onMouseLeave={() => setPinnedSecondaryHover(false)}
+          >
+            {/* Topline */}
+            <div style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 1,
+              background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.5), transparent)",
+            }} />
+            {/* Purple pin */}
+            <div style={{
+              position: "absolute", top: 12, right: 14,
+              display: "flex", alignItems: "center", gap: 6, zIndex: 2,
+            }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgba(120,60,180,0.85)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 17v5" />
+                <path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z" />
+              </svg>
+              <span style={{
+                fontFamily: "'Roboto Mono', monospace", fontSize: 10,
+                letterSpacing: "0.12em", textTransform: "uppercase",
+                color: "rgba(120,60,180,0.75)", fontWeight: 600,
+              }}>Pinned</span>
+            </div>
+            <span style={{
+              fontFamily: "'Roboto Mono', monospace",
+              fontSize: 12,
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "#D4AF37",
+              marginBottom: 8,
+              display: "block",
+            }}>
+              Reference
+            </span>
+            <h2 style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: "1.6rem",
+              color: "#fff",
+              lineHeight: 1,
+              letterSpacing: "0.03em",
+              marginBottom: 10,
+              marginTop: 0,
+              paddingRight: 80,
+            }}>
+              15 Terms Your Investors Expect You to Know
+            </h2>
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginTop: "auto",
+              paddingTop: 12,
+              borderTop: "1px solid rgba(255,255,255,0.08)",
+            }}>
+              <span style={{
+                fontFamily: "'Roboto Mono', monospace",
+                fontSize: 12,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: "rgba(212,175,55,0.55)",
+              }}>
+                Glossary
+              </span>
+              <span style={{
+                color: pinnedSecondaryHover ? "#D4AF37" : "rgba(255,255,255,0.35)",
+                fontSize: 18,
+                transition: "all 0.3s",
+                transform: pinnedSecondaryHover ? "translateX(6px)" : "translateX(0)",
+                display: "inline-block",
+              }}>
+                {"\u2192"}
+              </span>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      {/* Purple separator — pinned → grid */}
+      <div style={{
+        height: 1,
+        background: "linear-gradient(90deg, transparent 10%, rgba(120,60,180,0.20) 50%, transparent 90%)",
+        margin: "12px 24px 0",
+      }} />
+
       {/* ---- RESULTS BAR ---- */}
       <div style={{ padding: "20px 24px 0", maxWidth: 1000, margin: "0 auto" }}>
         <div style={{
@@ -1131,48 +1181,43 @@ const Resources = () => {
         )}
       </div>
 
-      {/* ---- FOOTER ---- */}
+      {/* ---- FOOTER (synced with Index.tsx / Store.tsx) ---- */}
       <footer ref={footerRef} style={{
-        textAlign: "center",
-        padding: "80px 20px",
+        background: "#0A0A0A",
+        borderTop: "1px solid rgba(212,175,55,0.12)",
+        padding: "32px 24px 40px",
+        maxWidth: 1000,
+        margin: "0 auto",
         ...reveal(footerVisible),
       }}>
-        <div style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 12,
-          marginBottom: 16,
-        }}>
-          <span style={{
-            flex: 1,
-            height: 1,
-            background: "rgba(212,175,55,0.25)",
-            boxShadow: "0 0 8px rgba(212,175,55,0.10)",
-          }} />
-          <span style={{
-            fontFamily: "'Roboto Mono', monospace",
-            fontSize: 13,
-            letterSpacing: "0.15em",
-            textTransform: "uppercase",
-            color: "rgba(212,175,55,0.55)",
-          }}>
-            Filmmaker.og
-          </span>
-          <span style={{
-            flex: 1,
-            height: 1,
-            background: "rgba(212,175,55,0.25)",
-            boxShadow: "0 0 8px rgba(212,175,55,0.10)",
-          }} />
+        <div style={{ display: "flex", justifyContent: "center", gap: 20, marginBottom: 16 }}>
+          <a href="https://www.instagram.com/filmmaker.og" target="_blank" rel="noopener noreferrer" style={{ color: "rgba(212,175,55,0.50)", textDecoration: "none", display: "flex", alignItems: "center", justifyContent: "center", width: 36, height: 36, borderRadius: 8, border: "1px solid rgba(212,175,55,0.15)", transition: "color 0.2s ease, border-color 0.2s ease" }} aria-label="Instagram">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="20" height="20" x="2" y="2" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" x2="17.51" y1="6.5" y2="6.5"/></svg>
+          </a>
+          <a href="https://www.tiktok.com/@filmmaker.og" target="_blank" rel="noopener noreferrer" style={{ color: "rgba(212,175,55,0.50)", textDecoration: "none", display: "flex", alignItems: "center", justifyContent: "center", width: 36, height: 36, borderRadius: 8, border: "1px solid rgba(212,175,55,0.15)", transition: "color 0.2s ease, border-color 0.2s ease" }} aria-label="TikTok">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 0 0-.79-.05A6.34 6.34 0 0 0 3.15 15a6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.34-6.34V8.71a8.2 8.2 0 0 0 4.76 1.52v-3.4a4.85 4.85 0 0 1-1-.14z"/></svg>
+          </a>
+          <a href="https://www.facebook.com/filmmaker.og" target="_blank" rel="noopener noreferrer" style={{ color: "rgba(212,175,55,0.50)", textDecoration: "none", display: "flex", alignItems: "center", justifyContent: "center", width: 36, height: 36, borderRadius: 8, border: "1px solid rgba(212,175,55,0.15)", transition: "color 0.2s ease, border-color 0.2s ease" }} aria-label="Facebook">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+          </a>
         </div>
-        <span style={{
-          fontFamily: "'Roboto Mono', monospace",
-          fontSize: 12,
-          color: "rgba(255,255,255,0.25)",
-          letterSpacing: "0.08em",
+        <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 10, marginBottom: 16 }}>
+          <span onClick={() => window.location.href = "/"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Home</span>
+          <span style={{ color: "rgba(212,175,55,0.20)", fontSize: 12 }}>&middot;</span>
+          <span onClick={() => window.location.href = "/store"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Shop</span>
+          <span style={{ color: "rgba(212,175,55,0.20)", fontSize: 12 }}>&middot;</span>
+          <span onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Resources</span>
+        </div>
+        <p style={{
+          fontFamily: "'Inter', sans-serif",
+          fontSize: 14,
+          color: "rgba(255,255,255,0.48)",
+          textAlign: "center",
+          lineHeight: 1.55,
+          margin: 0,
         }}>
-          Film finance intelligence
-        </span>
+          Filmmaker.og provides financial modeling tools for educational purposes. This is not legal or financial advice. Consult qualified counsel before executing any investment structure.
+        </p>
       </footer>
     </div>
   );
@@ -1186,33 +1231,7 @@ if (typeof document !== "undefined" && !document.getElementById(RESPONSIVE_STYLE
   style.textContent = `
     a, button { -webkit-tap-highlight-color: transparent; }
     .vault-search-input::placeholder { color: rgba(255,255,255,0.35) !important; }
-    .vault-pinned-grid::-webkit-scrollbar { display: none !important; }
     @media (max-width: 767px) {
-      .vault-pinned-grid {
-        display: flex !important;
-        overflow-x: auto !important;
-        scroll-snap-type: x mandatory !important;
-        scroll-padding-left: 24px !important;
-        -webkit-overflow-scrolling: touch !important;
-        gap: 16px !important;
-        margin: 0 -24px 0 -24px !important;
-        padding: 0 24px 8px !important;
-        scrollbar-width: none !important;
-      }
-      .vault-pinned-grid > a {
-        flex: 0 0 78% !important;
-        scroll-snap-align: start !important;
-        min-width: 0 !important;
-      }
-      .pinned-section .wrap { position: relative !important; }
-      .pinned-section .wrap::after {
-        content: '';
-        position: absolute;
-        top: 0; right: 0; bottom: 0; width: 40px;
-        background: linear-gradient(to left, #000 0%, transparent 100%);
-        pointer-events: none;
-        z-index: 10;
-      }
       .vault-command-inner { gap: 8px !important; }
       .vault-search-wrap { flex: 1 !important; min-width: 0 !important; }
       .vault-search-input { font-size: 16px !important; height: 48px !important; padding: 0 40px 0 48px !important; }

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1168,39 +1168,62 @@ const Store = () => {
       {/* ═══════════════════════════════════════
            § 1 — ON DEMAND
          ═══════════════════════════════════════ */}
-      <section
-        ref={heroRef}
-        style={{ padding: "40px 24px 32px", textAlign: "center", position: "relative" }}
-      >
+      {/* Glass hero card */}
+      <div ref={heroRef} style={{ padding: "32px 0 0", position: "relative" }}>
+        {/* Page-level canopy */}
         <div style={{
-          position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+          position: "absolute", top: 0, left: 0, right: 0, height: "120%",
           background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.25) 0%, transparent 70%)",
           pointerEvents: "none",
         }} />
-        <div style={{ position: "relative", ...reveal(heroVisible) }}>
-          <EyebrowRuled text="On Demand" />
-          <h1 style={{
-            fontFamily: "'Bebas Neue', sans-serif",
-            fontSize: "3.8rem",
-            lineHeight: 0.95,
-            margin: "0 0 16px 0",
-            letterSpacing: "0.04em",
-            color: "#fff",
-          }}>
-            Your Numbers.<br />
-            <span style={{ color: "#D4AF37" }}>Investor-Ready.</span>
-          </h1>
-          <p style={{
-            fontFamily: "'Inter', sans-serif",
-            fontSize: "19px",
-            color: "rgba(255,255,255,0.88)",
-            lineHeight: 1.55,
-            margin: 0,
-          }}>
-            Professional financial documents. Investor-grade. Yours.
-          </p>
-        </div>
-      </section>
+        <section style={{
+          position: "relative", textAlign: "center",
+          padding: "28px 24px 24px",
+          margin: "0 24px",
+          borderRadius: 12,
+          overflow: "hidden",
+          background: "rgba(6,6,6,0.92)",
+          backdropFilter: "blur(40px)",
+          WebkitBackdropFilter: "blur(40px)",
+          border: "1px solid rgba(212,175,55,0.20)",
+          boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
+          ...reveal(heroVisible),
+        }}>
+          {/* Triple radial glow */}
+          <div style={{
+            position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
+            background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+          }} />
+          <div style={{ position: "relative", zIndex: 1 }}>
+            <EyebrowRuled text="On Demand" />
+            <h1 style={{
+              fontFamily: "'Bebas Neue', sans-serif",
+              fontSize: "3.8rem",
+              lineHeight: 0.95,
+              margin: "0 0 16px 0",
+              letterSpacing: "0.04em",
+              color: "#fff",
+              textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
+            }}>
+              Your Numbers.<br />
+              <span style={{
+                color: "#D4AF37",
+                textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
+              }}>Investor-Ready.</span>
+            </h1>
+            <p style={{
+              fontFamily: "'Inter', sans-serif",
+              fontSize: "19px",
+              color: "rgba(255,255,255,0.88)",
+              lineHeight: 1.55,
+              margin: 0,
+              textShadow: "0 2px 12px rgba(0,0,0,0.9)",
+            }}>
+              Professional financial documents. Investor-grade. Yours.
+            </p>
+          </div>
+        </section>
+      </div>
 
       {/* § 1 — On Demand Card (Full Analysis only) */}
       <div


### PR DESCRIPTION
Serving 1: Opacity bumps — card haze (0.18/0.14), card glow (0.18/0.14/0.12/0.08), neutral topline (0.25/0.18), featured excerpt (0.80).

Serving 2: Replace Resources header with glass card hero — two-line title ("RESOURCE" / "VAULT"), subtext, triple radial glow (gold + purple), backdrop blur, matching Index.tsx hero pattern.

Serving 3: Move pinned cards below command center (vertical stack), add purple thumbtack pin indicators, purple atmospheric on command center, purple search input borders, purple separator before results bar, replace footer with standard shared footer (social icons + nav + disclaimer).

Serving 4: Wrap Store hero in glass card with triple glow, backdrop blur, gold border, and text shadows — all three pages now share the glass hero pattern.

Serving 5: Update RESOURCES_PAGE_REFERENCE.md — fix typography table (P8), update section stack, document audit changes, sync footer docs.

https://claude.ai/code/session_01MnV8AyFqwGsHZqeMGRoNyB