### PR TITLE
Fix tax credit tier inconsistency and add profit split control

### DIFF
--- a/src/components/calculator/deal/DealInput.tsx
+++ b/src/components/calculator/deal/DealInput.tsx
@@ -739,6 +739,59 @@ const DealInput = ({ inputs, guilds, selections, onUpdateInput, onNext, genre }:
         </div>
       </div>
 
+      {/* Backend Profit Split */}
+      <div style={{ marginTop: 24, paddingTop: 20, borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+        <div style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          marginBottom: 12,
+        }}>
+          <span style={{
+            fontFamily: "'Inter', sans-serif", fontSize: 11, fontWeight: 600,
+            textTransform: "uppercase", letterSpacing: "0.15em",
+            color: "rgba(212,175,55,0.50)",
+          }}>Backend Split</span>
+          <span style={{
+            fontFamily: "'Roboto Mono', monospace", fontSize: 14,
+            color: "rgba(255,255,255,0.70)",
+          }}>
+            {inputs.profitSplit ?? 50} / {100 - (inputs.profitSplit ?? 50)}
+          </span>
+        </div>
+        <div style={{
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <span style={{
+            fontFamily: "'Roboto Mono', monospace", fontSize: 10,
+            textTransform: "uppercase", letterSpacing: "0.1em",
+            color: "rgba(212,175,55,0.40)", whiteSpace: "nowrap",
+          }}>Investor</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={inputs.profitSplit ?? 50}
+            onChange={(e) => onUpdateInput("profitSplit", Number(e.target.value))}
+            style={{
+              flex: 1, height: 2, appearance: "none", WebkitAppearance: "none",
+              background: `linear-gradient(to right, rgba(212,175,55,0.40) 0%, rgba(212,175,55,0.40) ${inputs.profitSplit ?? 50}%, rgba(255,255,255,0.10) ${inputs.profitSplit ?? 50}%, rgba(255,255,255,0.10) 100%)`,
+              borderRadius: 1, outline: "none", cursor: "pointer",
+            }}
+          />
+          <span style={{
+            fontFamily: "'Roboto Mono', monospace", fontSize: 10,
+            textTransform: "uppercase", letterSpacing: "0.1em",
+            color: "rgba(255,255,255,0.40)", whiteSpace: "nowrap",
+          }}>Producer</span>
+        </div>
+        <p style={{
+          fontFamily: "'Inter', sans-serif", fontSize: 11,
+          color: "rgba(255,255,255,0.40)", marginTop: 8, lineHeight: 1.4,
+        }}>
+          How the backend pool splits after all tiers are paid. Standard is 50/50 — leverage and risk allocation determine the actual number.
+        </p>
+      </div>
+
       {/* CTA */}
       <div style={hasRevenue ? s.revealVis : s.reveal}>
         <button style={s.cta} onClick={(e) => { haptics.medium(e); onNext(); }}>

--- a/src/lib/waterfall.ts
+++ b/src/lib/waterfall.ts
@@ -20,6 +20,7 @@ export interface WaterfallInputs {
   salesFee: number;
   salesExp: number;  // Sales & Marketing expenses cap (AFM, markets, deliverables)
   deferments: number; // Deferred compensation (producer fees, talent, etc.)
+  profitSplit: number; // Investor share of backend pool (0-100, default 50)
 }
 
 export interface GuildState {
@@ -43,6 +44,7 @@ export interface WaterfallResult {
   marketing: number;
   deferments: number;
   credits: number;
+  creditsApplied: number; // Actual credits used (capped at max deductible)
   recouped: number;
   recoupPct: number;
   investor: number;
@@ -55,6 +57,7 @@ export interface WaterfallResult {
   seniorDebtHurdle: number;
   mezzDebtHurdle: number;
   equityHurdle: number;
+  profitSplit: number; // Investor % of backend (for display)
 }
 
 // Calculate the algebraic breakeven point
@@ -162,8 +165,9 @@ export function calculateWaterfall(inputs: WaterfallInputs, guilds: GuildState):
   const recoupPct = totalHurdle > 0 ? Math.min(100, (revenue / totalHurdle) * 100) : 0;
 
   const investorRecoup = Math.min(equityHurdle, Math.max(0, revenue - offTop - totalDebtHurdle));
-  const investorTotal = investorRecoup + (profitPool * 0.5);
-  const producerShare = profitPool * 0.5;
+  const splitPct = Math.max(0, Math.min(100, inputs.profitSplit ?? 50)) / 100;
+  const investorTotal = investorRecoup + (profitPool * splitPct);
+  const producerShare = profitPool * (1 - splitPct);
   const multiple = equity > 0 ? investorTotal / equity : 0;
 
   // 6. Ledger Construction
@@ -188,6 +192,8 @@ export function calculateWaterfall(inputs: WaterfallInputs, guilds: GuildState):
     marketing,
     deferments,
     credits,
+    creditsApplied,
+    profitSplit: Math.max(0, Math.min(100, inputs.profitSplit ?? 50)),
     recouped,
     recoupPct,
     investor: investorTotal,
@@ -206,7 +212,8 @@ export function calculateWaterfall(inputs: WaterfallInputs, guilds: GuildState):
 import type { TierPayment, WaterfallState } from "./waterfall-types";
 
 export function computeTierPayments(result: WaterfallResult, inputs: WaterfallInputs): TierPayment[] {
-  let remaining = inputs.revenue - result.offTopTotal;
+  // Start with revenue after off-the-tops, then add back credits
+  let remaining = inputs.revenue - result.offTopTotal + result.creditsApplied;
   const tiers: TierPayment[] = [];
   let phase = 1;
 

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -48,6 +48,7 @@ const defaultInputs: WaterfallInputs = {
   salesFee: 15,
   salesExp: 75000,
   deferments: 0,
+  profitSplit: 50,
 };
 
 const defaultGuilds: GuildState = {


### PR DESCRIPTION
- Fix computeTierPayments to inject creditsApplied after off-tops, resolving the discrepancy where profitPool included credits but the tier cascade did not
- Add profitSplit field (0-100, default 50) to WaterfallInputs, replacing hardcoded 50/50 investor/producer split
- Add creditsApplied and profitSplit to WaterfallResult for display
- Add Backend Split slider to DealInput with 5% increments
- Default profitSplit: 50 in Calculator.tsx for backward compatibility

https://claude.ai/code/session_01JLXCXGNknFfFyyZjFstuDw