### PR TITLE
Calculator visual rebuild: ProgressBar, CalcHero, ProjectTab two-zone…

### DIFF
--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 import type { ProjectDetails } from "@/pages/Calculator";
-import ChapterCard, { cardH, cardHSub } from "../ChapterCard";
 
 interface ProjectTabProps {
   project: ProjectDetails;
@@ -12,141 +11,259 @@ interface ProjectTabProps {
 
 const GENRES = [
   "Action", "Thriller", "Comedy", "Drama", "Horror",
-  "Romance", "Sci-Fi / Fantasy", "Documentary", "Animation", "Other",
+  "Romance", "Sci-Fi", "Doc", "Animation", "Other",
 ];
 
-const STATUSES = ["Development", "Pre-Production", "Production", "Post-Production"];
+const STATUSES = ["Development", "Pre-Prod", "Production", "Post"];
+
+/* ═══ Style constants ═══ */
+
+const warmCard: React.CSSProperties = {
+  position: "relative",
+  background: "#0A0A0A",
+  border: "1px solid rgba(212,175,55,0.35)",
+  borderRadius: 12,
+  overflow: "hidden",
+  boxShadow: "0 24px 50px rgba(0,0,0,0.8), inset 0 1px 0 rgba(212,175,55,0.10)",
+  marginBottom: 16,
+};
+
+const warmGlow: React.CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 220,
+  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.18) 0%, transparent 70%)",
+  pointerEvents: "none",
+};
+
+const warmTopline: React.CSSProperties = {
+  height: 2,
+  background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.60), transparent)",
+  position: "relative",
+  overflow: "hidden",
+};
+
+const warmToplineShimmer: React.CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: "-100%",
+  width: "60%",
+  height: "100%",
+  background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.30), transparent)",
+  animation: "toplineShimmer 8s ease-in-out infinite",
+};
+
+const dataCard: React.CSSProperties = {
+  position: "relative",
+  background: "#0A0A0A",
+  border: "1px solid rgba(212,175,55,0.20)",
+  borderRadius: 12,
+  overflow: "hidden",
+  marginBottom: 16,
+};
+
+const dataGlow: React.CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 140,
+  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.10) 0%, transparent 70%)",
+  pointerEvents: "none",
+};
+
+const dataTopline: React.CSSProperties = {
+  height: 1,
+  background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.40), transparent)",
+};
+
+const separator: React.CSSProperties = {
+  height: 1,
+  background: "rgba(255,255,255,0.06)",
+  margin: "20px -24px",
+};
 
 const s: Record<string, React.CSSProperties> = {
   wrapper: {
     animation: "stepEnter 0.4s ease-out forwards",
   },
+  pad: {
+    position: "relative",
+    padding: "24px 24px",
+  },
   fg: {
-    marginBottom: "20px",
+    marginBottom: 20,
   },
   fl: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "11px",
+    fontSize: 11,
     fontWeight: 600,
-    textTransform: "uppercase" as const,
+    textTransform: "uppercase",
     letterSpacing: "0.15em",
-    color: "rgba(212,175,55,0.50)",
-    marginBottom: "8px",
+    color: "rgba(212,175,55,0.75)",
+    marginBottom: 8,
     display: "block",
   },
   flOpt: {
     fontWeight: 400,
     letterSpacing: "0.06em",
-    textTransform: "none" as const,
+    textTransform: "none",
     color: "rgba(255,255,255,0.40)",
-    marginLeft: "6px",
-    fontSize: "10px",
+    marginLeft: 6,
+    fontSize: 10,
   },
   fi: {
     width: "100%",
     background: "rgba(255,255,255,0.04)",
-    border: "1px solid rgba(212,175,55,0.20)",
-    borderRadius: "8px",
+    border: "1px solid rgba(212,175,55,0.25)",
+    borderRadius: 8,
     padding: "14px 16px",
     fontFamily: "'Inter', sans-serif",
-    fontSize: "16px",
-    color: "rgba(255,255,255,0.85)",
+    fontSize: 16,
+    color: "rgba(255,255,255,0.95)",
     outline: "none",
     transition: "border-color 0.2s, box-shadow 0.2s",
     WebkitAppearance: "none" as const,
-    minHeight: "48px",
+    minHeight: 48,
   },
-  pills: {
-    display: "flex",
-    flexWrap: "wrap" as const,
-    gap: "8px",
+  genreGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, 1fr)",
+    gap: 8,
   },
   pill: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "13px",
+    fontSize: 13,
     fontWeight: 500,
-    padding: "9px 16px",
-    minHeight: "48px",
+    padding: "9px 8px",
+    minHeight: 48,
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    borderRadius: "8px",
-    border: "1px solid rgba(212,175,55,0.20)",
-    background: "rgba(255,255,255,0.04)",
-    color: "rgba(255,255,255,0.65)",
+    borderRadius: 8,
+    border: "1px solid rgba(255,255,255,0.12)",
+    background: "rgba(255,255,255,0.03)",
+    color: "rgba(255,255,255,0.60)",
     cursor: "pointer",
     transition: "all 0.15s",
-    whiteSpace: "nowrap" as const,
+    whiteSpace: "nowrap",
   },
   pillOn: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "13px",
-    fontWeight: 500,
-    padding: "9px 16px",
-    minHeight: "48px",
+    fontSize: 13,
+    fontWeight: 600,
+    padding: "9px 8px",
+    minHeight: 48,
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    borderRadius: "8px",
-    border: "1px solid rgba(120,60,180,0.40)",
-    background: "rgba(120,60,180,0.08)",
-    color: "rgba(120,60,180,0.85)",
+    borderRadius: 8,
+    border: "1px solid rgba(120,60,180,0.50)",
+    background: "rgba(120,60,180,0.14)",
+    color: "rgba(190,160,240,1.0)",
     cursor: "pointer",
     transition: "all 0.15s",
-    whiteSpace: "nowrap" as const,
-    boxShadow: "0 0 12px rgba(120,60,180,0.15)",
+    whiteSpace: "nowrap",
+    boxShadow: "0 0 14px rgba(120,60,180,0.20)",
   },
-  expTrigger: {
+  statusPills: {
     display: "flex",
-    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  hint: {
+    fontFamily: "'Inter', sans-serif",
+    fontSize: 11,
+    color: "rgba(255,255,255,0.40)",
+    marginTop: 6,
+    lineHeight: 1.4,
+  },
+  // Team card
+  teamTrigger: {
+    padding: "16px 24px",
+    display: "flex",
     justifyContent: "space-between",
-    width: "100%",
-    padding: "14px 0",
-    border: "none",
-    background: "transparent",
+    alignItems: "center",
     cursor: "pointer",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
-    marginTop: "20px",
+    position: "relative",
   },
-  expLeft: {
+  teamHeaderLeft: {
     display: "flex",
     alignItems: "center",
-    gap: "8px",
+    gap: 8,
   },
-  expTitle: {
+  teamTitle: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "13px",
-    fontWeight: 500,
-    color: "rgba(255,255,255,0.65)",
+    fontSize: 13,
+    fontWeight: 600,
+    color: "rgba(212,175,55,0.70)",
   },
-  expHint: {
+  teamOptional: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "11px",
+    fontSize: 10,
     color: "rgba(255,255,255,0.40)",
   },
-  expBody: {
+  teamRight: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  teamFieldCount: {
+    fontFamily: "'Inter', sans-serif",
+    fontSize: 11,
+    color: "rgba(255,255,255,0.35)",
+  },
+  teamBody: {
     maxHeight: 0,
     overflow: "hidden",
     transition: "max-height 0.35s ease, opacity 0.25s ease",
     opacity: 0,
   },
-  expBodyOpen: {
-    maxHeight: "700px",
+  teamBodyOpen: {
+    maxHeight: 700,
     overflow: "hidden",
     transition: "max-height 0.35s ease, opacity 0.25s ease",
     opacity: 1,
   },
-  expInner: {
-    paddingTop: "16px",
+  teamGrid: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gap: 12,
+    padding: "0 24px 20px",
   },
-  hint: {
+  teamFg: {
+    marginBottom: 0,
+  },
+  teamFl: {
     fontFamily: "'Inter', sans-serif",
-    fontSize: "11px",
-    color: "rgba(255,255,255,0.40)",
-    marginTop: "6px",
-    lineHeight: 1.4,
+    fontSize: 10,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: "0.12em",
+    color: "rgba(212,175,55,0.60)",
+    marginBottom: 6,
+    display: "block",
   },
-  // CTA reveal
+  teamFi: {
+    width: "100%",
+    background: "rgba(255,255,255,0.03)",
+    border: "1px solid rgba(255,255,255,0.10)",
+    borderRadius: 8,
+    padding: "12px 14px",
+    fontFamily: "'Inter', sans-serif",
+    fontSize: 14,
+    color: "rgba(255,255,255,0.95)",
+    outline: "none",
+    transition: "border-color 0.2s, box-shadow 0.2s",
+    WebkitAppearance: "none" as const,
+    minHeight: 44,
+  },
+  teamFiFullWidth: {
+    gridColumn: "1 / -1",
+  },
+  // CTA
   reveal: {
     opacity: 0,
     transform: "translateY(12px)",
@@ -161,34 +278,34 @@ const s: Record<string, React.CSSProperties> = {
   },
   cta: {
     width: "100%",
-    padding: "16px",
-    marginTop: "24px",
+    padding: 16,
+    marginTop: 24,
     background: "#F9E076",
     border: "none",
-    borderRadius: "8px",
+    borderRadius: 8,
     fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: "20px",
+    fontSize: 20,
     letterSpacing: "0.18em",
-    textTransform: "uppercase" as const,
+    textTransform: "uppercase",
     color: "#000",
     cursor: "pointer",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    gap: "10px",
+    gap: 10,
     transition: "transform 0.12s ease, opacity 0.15s, box-shadow 0.2s ease",
     boxShadow: "0 0 20px rgba(249,224,118,0.25), 0 0 60px rgba(249,224,118,0.15)",
-    minHeight: "56px",
+    minHeight: 56,
   },
   skip: {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    gap: "4px",
-    minHeight: "48px",
-    marginTop: "14px",
+    gap: 4,
+    minHeight: 48,
+    marginTop: 14,
     fontFamily: "'Inter', sans-serif",
-    fontSize: "13px",
+    fontSize: 13,
     color: "rgba(255,255,255,0.40)",
     cursor: "pointer",
     background: "none",
@@ -196,13 +313,13 @@ const s: Record<string, React.CSSProperties> = {
     width: "100%",
   },
   autosave: {
-    textAlign: "center" as const,
+    textAlign: "right",
     fontFamily: "'Roboto Mono', monospace",
-    fontSize: "10px",
+    fontSize: 9,
     letterSpacing: "0.1em",
-    textTransform: "uppercase" as const,
-    color: "rgba(255,255,255,0.40)",
-    marginTop: "16px",
+    textTransform: "uppercase",
+    color: "rgba(255,255,255,0.30)",
+    marginTop: 16,
   },
 };
 
@@ -231,7 +348,17 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
   };
 
   const handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.style.borderColor = "rgba(212,175,55,0.20)";
+    e.target.style.borderColor = "rgba(212,175,55,0.25)";
+    e.target.style.boxShadow = "none";
+  };
+
+  const handleTeamInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.style.borderColor = "rgba(212,175,55,0.35)";
+    e.target.style.boxShadow = "0 0 12px rgba(212,175,55,0.08)";
+  };
+
+  const handleTeamInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.style.borderColor = "rgba(255,255,255,0.10)";
     e.target.style.boxShadow = "none";
   };
 
@@ -247,245 +374,262 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
 
   return (
     <div style={s.wrapper}>
-      <ChapterCard chapter="00" title="Project Details" isActive={true} variant="neutral">
-        <div style={cardH}>What Are You Building?</div>
-        <div style={cardHSub}>Tell us about the project — or jump straight to the numbers</div>
-
-        {/* Project Title */}
-        <div style={s.fg}>
-          <label style={s.fl}>Project Title</label>
-          <input
-            style={s.fi}
-            type="text"
-            placeholder="Untitled Feature"
-            value={project.title}
-            onChange={(e) => update("title", e.target.value)}
-            onFocus={handleInputFocus}
-            onBlur={handleInputBlur}
-            onKeyDown={handleTitleKeyDown}
-            enterKeyHint="next"
-          />
+      {/* ═══ Warm Card — Title + Logline + Genre + Status ═══ */}
+      <div style={warmCard}>
+        <div style={warmGlow} />
+        <div style={warmTopline}>
+          <div style={warmToplineShimmer} />
         </div>
-
-        {/* Logline */}
-        <div style={s.fg}>
-          <label style={s.fl}>
-            Logline <span style={s.flOpt}>optional</span>
-          </label>
-          <input
-            style={s.fi}
-            type="text"
-            placeholder="One sentence — what's the movie about?"
-            value={project.logline}
-            onChange={(e) => update("logline", e.target.value)}
-            onFocus={handleInputFocus}
-            onBlur={handleInputBlur}
-            enterKeyHint="next"
-          />
-        </div>
-
-        {/* Genre */}
-        <div style={s.fg}>
-          <label style={s.fl}>Genre</label>
-          <div style={s.pills}>
-            {GENRES.map((genre) => {
-              const isSelected = project.genre === genre;
-              const isPressed = pressedPill === genre;
-              return (
-                <button
-                  key={genre}
-                  style={{
-                    ...(isSelected ? s.pillOn : s.pill),
-                    ...(isPressed ? { transform: "scale(0.96)" } : {}),
-                  }}
-                  onClick={(e) => { haptics.light(e); handleGenreSelect(genre); }}
-                  onPointerDown={() => setPressedPill(genre)}
-                  onPointerUp={() => setPressedPill(null)}
-                  onPointerLeave={() => setPressedPill(null)}
-                >
-                  {genre}
-                </button>
-              );
-            })}
+        <div style={s.pad}>
+          {/* Project Title */}
+          <div style={s.fg}>
+            <label style={s.fl}>Project Title</label>
+            <input
+              style={s.fi}
+              type="text"
+              placeholder="Untitled Feature"
+              value={project.title}
+              onChange={(e) => update("title", e.target.value)}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
+              onKeyDown={handleTitleKeyDown}
+              enterKeyHint="next"
+            />
           </div>
-          {project.genre === "Other" && (
-            <div style={{ marginTop: "10px" }}>
-              <input
-                style={s.fi}
-                type="text"
-                placeholder="e.g. Western, Musical, Mockumentary"
-                value={project.customGenre}
-                onChange={(e) => update("customGenre", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-                autoFocus
-              />
+
+          {/* Logline */}
+          <div style={s.fg}>
+            <label style={s.fl}>
+              Logline <span style={s.flOpt}>optional</span>
+            </label>
+            <input
+              style={s.fi}
+              type="text"
+              placeholder="One sentence — what's the movie about?"
+              value={project.logline}
+              onChange={(e) => update("logline", e.target.value)}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
+              enterKeyHint="next"
+            />
+          </div>
+
+          <div style={separator} />
+
+          {/* Genre — 3-column grid */}
+          <div style={s.fg}>
+            <label style={s.fl}>Genre</label>
+            <div style={s.genreGrid}>
+              {GENRES.map((genre) => {
+                const isSelected = project.genre === genre;
+                const isPressed = pressedPill === genre;
+                return (
+                  <button
+                    key={genre}
+                    style={{
+                      ...(isSelected ? s.pillOn : s.pill),
+                      ...(isPressed ? { transform: "scale(0.96)" } : {}),
+                    }}
+                    onClick={(e) => { haptics.light(e); handleGenreSelect(genre); }}
+                    onPointerDown={() => setPressedPill(genre)}
+                    onPointerUp={() => setPressedPill(null)}
+                    onPointerLeave={() => setPressedPill(null)}
+                  >
+                    {genre}
+                  </button>
+                );
+              })}
             </div>
-          )}
-        </div>
+            {project.genre === "Other" && (
+              <div style={{ marginTop: 10 }}>
+                <input
+                  style={s.fi}
+                  type="text"
+                  placeholder="e.g. Western, Musical, Mockumentary"
+                  value={project.customGenre}
+                  onChange={(e) => update("customGenre", e.target.value)}
+                  onFocus={handleInputFocus}
+                  onBlur={handleInputBlur}
+                  autoFocus
+                />
+              </div>
+            )}
+          </div>
 
-        {/* Project Status */}
-        <div style={s.fg}>
-          <label style={s.fl}>Project Status</label>
-          <div style={s.pills}>
-            {STATUSES.map((status) => {
-              const isSelected = project.status === status;
-              const isPressed = pressedPill === `status-${status}`;
-              return (
-                <button
-                  key={status}
-                  style={{
-                    ...(isSelected ? s.pillOn : s.pill),
-                    ...(isPressed ? { transform: "scale(0.96)" } : {}),
-                  }}
-                  onClick={(e) => { haptics.light(e); update("status", status); }}
-                  onPointerDown={() => setPressedPill(`status-${status}`)}
-                  onPointerUp={() => setPressedPill(null)}
-                  onPointerLeave={() => setPressedPill(null)}
-                >
-                  {status}
-                </button>
-              );
-            })}
+          <div style={separator} />
+
+          {/* Project Status */}
+          <div style={{ ...s.fg, marginBottom: 0 }}>
+            <label style={s.fl}>Project Status</label>
+            <div style={s.statusPills}>
+              {STATUSES.map((status) => {
+                const isSelected = project.status === status;
+                const isPressed = pressedPill === `status-${status}`;
+                return (
+                  <button
+                    key={status}
+                    style={{
+                      ...(isSelected ? s.pillOn : s.pill),
+                      ...(isPressed ? { transform: "scale(0.96)" } : {}),
+                    }}
+                    onClick={(e) => { haptics.light(e); update("status", status); }}
+                    onPointerDown={() => setPressedPill(`status-${status}`)}
+                    onPointerUp={() => setPressedPill(null)}
+                    onPointerLeave={() => setPressedPill(null)}
+                  >
+                    {status}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
+      </div>
 
-        {/* Team Details — collapsible */}
-        <button
-          style={s.expTrigger}
+      {/* ═══ Data Card — Team Details (collapsed) ═══ */}
+      <div style={dataCard}>
+        <div style={dataGlow} />
+        <div style={dataTopline} />
+        <div
+          style={s.teamTrigger}
           onClick={(e) => { haptics.light(e); setTeamOpen(!teamOpen); }}
         >
-          <div style={s.expLeft}>
-            <span style={s.expTitle}>Team Details</span>
-            <span style={s.expHint}>producer, director, writer, cast</span>
+          <div style={s.teamHeaderLeft}>
+            <span style={s.teamTitle}>Team Details</span>
+            <span style={s.teamOptional}>optional</span>
           </div>
-          <ChevronDown
-            style={{
-              width: "16px",
-              height: "16px",
-              color: "rgba(212,175,55,0.40)",
-              transition: "transform 0.25s",
-              transform: teamOpen ? "rotate(180deg)" : "rotate(0deg)",
-            }}
-          />
-        </button>
+          <div style={s.teamRight}>
+            <span style={s.teamFieldCount}>6 fields</span>
+            <ChevronDown
+              style={{
+                width: 16,
+                height: 16,
+                color: "rgba(212,175,55,0.45)",
+                transition: "transform 0.25s",
+                transform: teamOpen ? "rotate(180deg)" : "rotate(0deg)",
+              }}
+            />
+          </div>
+        </div>
 
-        <div style={teamOpen ? s.expBodyOpen : s.expBody}>
-          <div style={s.expInner}>
-            <div style={s.fg}>
-              <label style={s.fl}>Producer(s) <span style={s.flOpt}>optional</span></label>
+        <div style={teamOpen ? s.teamBodyOpen : s.teamBody}>
+          <div style={s.teamGrid}>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Producer(s)</label>
               <input
-                style={s.fi}
+                style={s.teamFi}
                 type="text"
                 placeholder="Producer name(s)"
                 value={project.producers}
                 onChange={(e) => update("producers", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
                 enterKeyHint="next"
               />
             </div>
-            <div style={s.fg}>
-              <label style={s.fl}>Director <span style={s.flOpt}>optional</span></label>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Director</label>
               <input
-                style={s.fi}
+                style={s.teamFi}
                 type="text"
                 placeholder="Director name"
                 value={project.director}
                 onChange={(e) => update("director", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
                 enterKeyHint="next"
               />
             </div>
-            <div style={s.fg}>
-              <label style={s.fl}>Writer(s) <span style={s.flOpt}>optional</span></label>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Writer(s)</label>
               <input
-                style={s.fi}
+                style={s.teamFi}
                 type="text"
                 placeholder="Writer name(s)"
                 value={project.writers}
                 onChange={(e) => update("writers", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
                 enterKeyHint="next"
               />
             </div>
-            <div style={s.fg}>
-              <label style={s.fl}>Attached / Wishlist Cast <span style={s.flOpt}>optional</span></label>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Cast</label>
               <input
-                style={s.fi}
+                style={s.teamFi}
                 type="text"
                 placeholder="Lead cast names"
                 value={project.cast}
                 onChange={(e) => update("cast", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
                 enterKeyHint="next"
               />
+            </div>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Company / SPV</label>
+              <input
+                style={s.teamFi}
+                type="text"
+                placeholder="Entity name"
+                value={project.company}
+                onChange={(e) => update("company", e.target.value)}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
+                enterKeyHint="next"
+              />
+            </div>
+            <div style={s.teamFg}>
+              <label style={s.teamFl}>Location</label>
+              <input
+                style={s.teamFi}
+                type="text"
+                placeholder="City, State"
+                value={project.location}
+                onChange={(e) => update("location", e.target.value)}
+                onFocus={handleTeamInputFocus}
+                onBlur={handleTeamInputBlur}
+                enterKeyHint="done"
+              />
+            </div>
+            <div style={{ ...s.teamFg, ...s.teamFiFullWidth }}>
               <p style={s.hint}>
                 "Attached" = signed LOI. "Wishlist" = targeting. Be honest — investors will verify.
               </p>
             </div>
-            <div style={s.fg}>
-              <label style={s.fl}>Production Company / SPV <span style={s.flOpt}>optional</span></label>
-              <input
-                style={s.fi}
-                type="text"
-                placeholder="Entity name (LLC, Inc, etc.)"
-                value={project.company}
-                onChange={(e) => update("company", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-                enterKeyHint="next"
-              />
-            </div>
-            <div style={{ ...s.fg, marginBottom: 0 }}>
-              <label style={s.fl}>Primary Shooting Location <span style={s.flOpt}>optional</span></label>
-              <input
-                style={s.fi}
-                type="text"
-                placeholder="City, State / Country"
-                value={project.location}
-                onChange={(e) => update("location", e.target.value)}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-                enterKeyHint="done"
-              />
-            </div>
           </div>
         </div>
+      </div>
 
-        {/* CTA — reveals when title has text */}
-        <div style={canProceed ? s.revealVis : s.reveal}>
-          <button
-            style={{
-              ...s.cta,
-              ...(ctaHovered ? { boxShadow: "0 0 30px rgba(249,224,118,0.35), 0 0 80px rgba(249,224,118,0.20)" } : {}),
-              ...(ctaPressed ? { transform: "scale(0.98)" } : {}),
-            }}
-            onClick={(e) => { haptics.medium(e); onAdvance(); }}
-            onPointerDown={() => setCtaPressed(true)}
-            onPointerUp={() => setCtaPressed(false)}
-            onPointerLeave={() => { setCtaPressed(false); setCtaHovered(false); }}
-            onMouseEnter={() => setCtaHovered(true)}
-          >
-            Continue to Budget
-            <ArrowRight style={{ width: "18px", height: "18px" }} />
-          </button>
-        </div>
-
-        {/* Skip link */}
-        <button style={s.skip} onClick={onAdvance}>
-          Jump to Budget
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ opacity: 0.5 }}>
-            <line x1="5" y1="12" x2="19" y2="12" />
-            <polyline points="12 5 19 12 12 19" />
-          </svg>
+      {/* ═══ CTA — reveals when title has text ═══ */}
+      <div style={canProceed ? s.revealVis : s.reveal}>
+        <button
+          style={{
+            ...s.cta,
+            ...(ctaHovered ? { boxShadow: "0 0 30px rgba(249,224,118,0.35), 0 0 80px rgba(249,224,118,0.20)" } : {}),
+            ...(ctaPressed ? { transform: "scale(0.98)" } : {}),
+          }}
+          onClick={(e) => { haptics.medium(e); onAdvance(); }}
+          onPointerDown={() => setCtaPressed(true)}
+          onPointerUp={() => setCtaPressed(false)}
+          onPointerLeave={() => { setCtaPressed(false); setCtaHovered(false); }}
+          onMouseEnter={() => setCtaHovered(true)}
+        >
+          Set Your Budget
+          <ArrowRight style={{ width: 18, height: 18 }} />
         </button>
-      </ChapterCard>
+      </div>
 
-      {/* Autosave indicator */}
+      {/* Skip link */}
+      <button style={s.skip} onClick={onAdvance}>
+        Skip project details
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ opacity: 0.5 }}>
+          <line x1="5" y1="12" x2="19" y2="12" />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+      </button>
+
+      {/* Autosave */}
       <p style={s.autosave}>Session data — stays in your browser</p>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -913,6 +913,12 @@
     50% { opacity: 0.08; }
   }
 
+  /* Progress bar segment pulse */
+  @keyframes segPulse {
+    0%, 100% { opacity: 0.60; }
+    50% { opacity: 1.0; }
+  }
+
   /* ═══════════════════════════════════════════════════════════════════
      CALCULATOR V6 — Mobile-optimized slider thumbs (22px minimum)
      ═══════════════════════════════════════════════════════════════════ */

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -97,47 +97,100 @@ const s: Record<string, React.CSSProperties> = {
     borderRadius: "50%",
     animation: "spin 1s linear infinite",
   },
-  glassHero: {
-    position: "relative" as const,
-    background: "rgba(6,6,6,0.92)",
-    backdropFilter: "blur(40px)",
-    WebkitBackdropFilter: "blur(40px)",
-    border: "1px solid rgba(212,175,55,0.20)",
-    borderRadius: "12px",
-    overflow: "hidden",
-    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
-    padding: "40px 24px 36px",
-    marginBottom: "24px",
-    textAlign: "center" as const,
-  },
-  glassHeroGlow: {
-    position: "absolute" as const,
-    inset: 0,
-    background: [
-      "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%)",
-      "radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%)",
-      "radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
-    ].join(", "),
-    pointerEvents: "none" as const,
-  },
-  glassHeroH1: {
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: "4.2rem",
-    lineHeight: 0.86,
-    letterSpacing: "0.04em",
-    color: "#F9E076",
-    position: "relative" as const,
-    zIndex: 1,
-    marginBottom: "16px",
-  },
-  glassHeroSub: {
-    fontFamily: "'Bebas Neue', sans-serif",
-    fontSize: "1.5rem",
-    letterSpacing: "0.06em",
-    color: "rgba(255,255,255,0.55)",
-    position: "relative" as const,
-    zIndex: 1,
-  },
+};
+
+/* ═══ Progress micro-bar — 5 segments ═══ */
+const ProgressBar = ({ activeTab }: { activeTab: TabId }) => {
+  const steps: TabId[] = ['project', 'budget', 'stack', 'deal', 'waterfall'];
+  const activeIdx = steps.indexOf(activeTab);
+  return (
+    <div style={{ display: "flex", gap: 3, marginBottom: 20, height: 3 }}>
+      {steps.map((step, i) => (
+        <div
+          key={step}
+          style={{
+            flex: 1,
+            borderRadius: 2,
+            background: i < activeIdx
+              ? "rgba(212,175,55,0.50)"
+              : i === activeIdx
+                ? "rgba(212,175,55,0.60)"
+                : "rgba(255,255,255,0.08)",
+            transition: "background 0.4s",
+            ...(i === activeIdx ? { animation: "segPulse 2s ease-in-out infinite" } : {}),
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+/* ═══ Glass hero — per-step welcome surface ═══ */
+const CalcHero = ({ stepLabel, title, titleGold, subtitle, visible }: {
+  stepLabel: string;
+  title: string;
+  titleGold: string;
+  subtitle: string;
+  visible: boolean;
+}) => {
+  const prefersReducedMotion = typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const heroReveal: React.CSSProperties = {
+    opacity: prefersReducedMotion || visible ? 1 : 0,
+    transform: prefersReducedMotion || visible ? "translateY(0)" : "translateY(20px)",
+    transition: prefersReducedMotion ? "none" : "opacity 0.6s cubic-bezier(0.16,1,0.3,1), transform 0.6s cubic-bezier(0.16,1,0.3,1)",
+  };
+  return (
+    <div style={{ position: "relative", marginBottom: 20, ...heroReveal }}>
+      <div style={{
+        position: "absolute", top: 0, left: 0, right: 0, height: "120%",
+        background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.25) 0%, transparent 70%)",
+        pointerEvents: "none",
+      }} />
+      <section style={{
+        position: "relative", textAlign: "center",
+        padding: "24px 20px 20px",
+        borderRadius: 12, overflow: "hidden",
+        background: "rgba(6,6,6,0.92)",
+        backdropFilter: "blur(40px)",
+        WebkitBackdropFilter: "blur(40px)",
+        border: "1px solid rgba(212,175,55,0.20)",
+        boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
+      }}>
+        <div style={{
+          position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
+          background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+        }} />
+        <div style={{ position: "relative", zIndex: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, padding: "0 8px" }}>
+            <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
+            <span style={{
+              fontFamily: "'Roboto Mono', monospace", fontSize: 10,
+              letterSpacing: "0.15em", textTransform: "uppercase",
+              color: "rgba(212,175,55,0.65)", whiteSpace: "nowrap",
+            }}>{stepLabel}</span>
+            <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
+          </div>
+          <h1 style={{
+            fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.8rem",
+            letterSpacing: "0.02em", lineHeight: 0.90, color: "#fff",
+            marginBottom: 8,
+            textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
+          }}>
+            {title}<br />
+            <span style={{
+              color: "#D4AF37",
+              textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
+            }}>{titleGold}</span>
+          </h1>
+          <p style={{
+            fontFamily: "'Inter', sans-serif", fontSize: 15,
+            color: "rgba(255,255,255,0.75)", lineHeight: 1.45,
+            textShadow: "0 2px 12px rgba(0,0,0,0.9)",
+          }}>{subtitle}</p>
+        </div>
+      </section>
+    </div>
+  );
 };
 
 const Calculator = () => {
@@ -340,15 +393,33 @@ const Calculator = () => {
     switch (activeTab) {
       case 'project':
         return (
-          <ProjectTab
-            project={project}
-            onUpdateProject={setProject}
-            onAdvance={() => handleTabChange('budget')}
-          />
+          <>
+            <ProgressBar activeTab={activeTab} />
+            <CalcHero
+              stepLabel="Step 00 · Project"
+              title="What Are You"
+              titleGold="Building?"
+              subtitle="Tell us about the project — or jump straight to the numbers."
+              visible={true}
+            />
+            <ProjectTab
+              project={project}
+              onUpdateProject={setProject}
+              onAdvance={() => handleTabChange('budget')}
+            />
+          </>
         );
       case 'budget':
         return (
           <>
+            <ProgressBar activeTab={activeTab} />
+            <CalcHero
+              stepLabel="Step 01 · Budget"
+              title="What Does It"
+              titleGold="Cost?"
+              subtitle="Total negative cost — everything to deliver the film."
+              visible={true}
+            />
             {renderContextBar()}
             <BudgetTab
               inputs={inputs}
@@ -362,6 +433,14 @@ const Calculator = () => {
       case 'stack':
         return (
           <>
+            <ProgressBar activeTab={activeTab} />
+            <CalcHero
+              stepLabel="Step 02 · Capital Stack"
+              title="How's It"
+              titleGold="Funded?"
+              subtitle="Select the capital sources in your deal."
+              visible={true}
+            />
             {renderContextBar()}
             <StackTab
               inputs={inputs}
@@ -375,6 +454,14 @@ const Calculator = () => {
       case 'deal':
         return (
           <>
+            <ProgressBar activeTab={activeTab} />
+            <CalcHero
+              stepLabel="Step 03 · Deal Terms"
+              title="What's The"
+              titleGold="Deal?"
+              subtitle="Acquisition price and distribution assumptions."
+              visible={true}
+            />
             {renderContextBar()}
             <DealTab
               inputs={inputs}
@@ -389,6 +476,7 @@ const Calculator = () => {
       case 'waterfall':
         return (
           <>
+            <ProgressBar activeTab={activeTab} />
             {renderContextBar()}
             <WaterfallTab
               result={result}
@@ -418,18 +506,6 @@ const Calculator = () => {
     <div style={s.page}>
       <main ref={mainRef} style={s.main}>
         <div style={s.col}>
-          {/* Glass Hero — welcome surface on Project tab */}
-          {activeTab === 'project' && (
-            <div style={s.glassHero}>
-              <div style={s.glassHeroGlow} />
-              <div style={s.glassHeroH1}>
-                MODEL YOUR<br />NUMBERS
-              </div>
-              <div style={s.glassHeroSub}>
-                Five Steps. One Waterfall. Investor-Ready.
-              </div>
-            </div>
-          )}
           <div
             key={activeTab}
             style={{


### PR DESCRIPTION
… architecture

- Add 5-segment ProgressBar component with active pulse animation
- Add CalcHero glass hero component wired per-step (Project/Budget/Stack/Deal)
- Waterfall step gets progress bar only (no hero)
- Remove old single glass hero from Calculator render
- Rebuild ProjectTab with two-zone architecture:
  - Warm card: title, logline, 3-col genre grid, status pills with inner separators
  - Data card: collapsed team details with 2-col grid, 6-field layout
- Purple active state on genre/status pills (border + bg + text + glow)
- Gold focus glow on all text inputs
- Contrast hierarchy: labels 0.75, values 0.95, team labels 0.60
- Shortened genre labels (Sci-Fi, Doc) and status labels (Pre-Prod, Post)
- CTA: "Set Your Budget →", skip: "Skip project details →"
- Autosave right-aligned, 9px, white 0.30
- segPulse keyframe added to index.css

https://claude.ai/code/session_019S1tnYcGb8g77uTxqoFKhN