### PR TITLE
Rebuild Stack step: glass hero, purple selection, contrast + CTA upgr…

### DIFF
--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -1,7 +1,7 @@
 import { Check, Receipt, Landmark, Coins, Users2, Clock } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 import { useState } from "react";
-import ChapterCard, { cardH, cardHSub } from "../ChapterCard";
+import ChapterCard from "../ChapterCard";
 import { CapitalSelections } from "@/lib/waterfall";
 
 // Re-export as alias for backward compatibility
@@ -69,13 +69,50 @@ const s: Record<string, React.CSSProperties> = {
   wrapper: {
     animation: "stepEnter 0.4s ease-out forwards",
   },
-  headerPad: {
-    padding: "20px 24px 0",
+  /* ── Glass Hero ── */
+  heroOuter: { position: "relative" as const, marginBottom: 20 },
+  heroCanopy: {
+    position: "absolute" as const, top: 0, left: 0, right: 0, height: "120%",
+    background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.25) 0%, transparent 70%)",
+    pointerEvents: "none" as const,
   },
-  subLine: {
-    marginBottom: "16px",
-    paddingBottom: "16px",
-    borderBottom: "1px solid rgba(255,255,255,0.06)",
+  heroCard: {
+    position: "relative" as const, textAlign: "center" as const,
+    padding: "24px 20px 20px", borderRadius: 12, overflow: "hidden" as const,
+    background: "rgba(6,6,6,0.92)",
+    backdropFilter: "blur(40px)", WebkitBackdropFilter: "blur(40px)",
+    border: "1px solid rgba(212,175,55,0.20)",
+    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
+  },
+  heroGlowBg: {
+    position: "absolute" as const, top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none" as const,
+    background: [
+      "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%)",
+      "radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%)",
+      "radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+    ].join(", "),
+  },
+  heroInner: { position: "relative" as const, zIndex: 1 },
+  heroEyebrow: { display: "flex", alignItems: "center", gap: "10px", marginBottom: "12px", padding: "0 8px" },
+  heroEyebrowLine: { flex: 1, height: "1px", background: "rgba(212,175,55,0.35)" },
+  heroEyebrowLabel: {
+    fontFamily: "'Roboto Mono', monospace", fontSize: "10px",
+    letterSpacing: "0.15em", textTransform: "uppercase" as const,
+    color: "rgba(212,175,55,0.65)", whiteSpace: "nowrap" as const,
+  },
+  heroH1: {
+    fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.8rem",
+    letterSpacing: "0.02em", lineHeight: 0.90, color: "#fff", marginBottom: "8px",
+    textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
+  },
+  heroGoldSpan: {
+    color: "#D4AF37",
+    textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
+  },
+  heroSubtext: {
+    fontFamily: "'Inter', sans-serif", fontSize: "15px",
+    color: "rgba(255,255,255,0.75)", lineHeight: 1.45,
+    textShadow: "0 2px 12px rgba(0,0,0,0.9)",
   },
   stackHdr: {
     padding: "12px 16px",
@@ -89,12 +126,12 @@ const s: Record<string, React.CSSProperties> = {
     fontWeight: 600,
     textTransform: "uppercase" as const,
     letterSpacing: "0.15em",
-    color: "rgba(255,255,255,0.55)",
+    color: "rgba(212,175,55,0.75)",
   },
   stackCnt: {
     fontFamily: "'Roboto Mono', monospace",
     fontSize: "11px",
-    color: "rgba(212,175,55,0.60)",
+    color: "rgba(212,175,55,0.75)",
   },
   si: {
     padding: "16px",
@@ -119,9 +156,9 @@ const s: Record<string, React.CSSProperties> = {
     borderBottom: "1px solid rgba(255,255,255,0.04)",
     cursor: "pointer",
     transition: "all 0.15s",
-    borderLeft: "3px solid #D4AF37",
+    borderLeft: "3px solid rgba(120,60,180,0.60)",
     minHeight: "64px",
-    background: "rgba(212,175,55,0.02)",
+    background: "rgba(120,60,180,0.04)",
     width: "100%",
     border: "none",
     textAlign: "left" as const,
@@ -137,9 +174,9 @@ const s: Record<string, React.CSSProperties> = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    border: "1px solid rgba(212,175,55,0.15)",
+    border: "1px solid rgba(255,255,255,0.12)",
     borderRadius: "4px",
-    color: "rgba(212,175,55,0.30)",
+    color: "rgba(255,255,255,0.30)",
     background: "#000",
     transition: "all 0.15s",
   },
@@ -149,27 +186,27 @@ const s: Record<string, React.CSSProperties> = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    border: "1px solid #D4AF37",
+    border: "1px solid rgba(120,60,180,0.50)",
     borderRadius: "4px",
-    color: "#D4AF37",
-    background: "rgba(212,175,55,0.05)",
+    color: "rgba(190,160,240,1.0)",
+    background: "rgba(120,60,180,0.12)",
     transition: "all 0.15s",
   },
   siTitle: {
     fontSize: "14px",
     fontWeight: 600,
-    color: "rgba(255,255,255,0.70)",
+    color: "rgba(255,255,255,0.80)",
     transition: "color 0.15s",
   },
   siTitleOn: {
     fontSize: "14px",
     fontWeight: 600,
-    color: "#D4AF37",
+    color: "rgba(190,160,240,1.0)",
     transition: "color 0.15s",
   },
   siDesc: {
     fontSize: "11px",
-    color: "rgba(255,255,255,0.35)",
+    color: "rgba(255,255,255,0.40)",
     marginTop: "2px",
   },
   siRight: {
@@ -185,8 +222,8 @@ const s: Record<string, React.CSSProperties> = {
     letterSpacing: "0.08em",
     padding: "4px 8px",
     borderRadius: "4px",
-    background: "rgba(212,175,55,0.04)",
-    color: "rgba(212,175,55,0.40)",
+    background: "rgba(255,255,255,0.04)",
+    color: "rgba(255,255,255,0.45)",
     transition: "all 0.15s",
     whiteSpace: "nowrap" as const,
   },
@@ -198,8 +235,8 @@ const s: Record<string, React.CSSProperties> = {
     letterSpacing: "0.08em",
     padding: "4px 8px",
     borderRadius: "4px",
-    background: "rgba(212,175,55,0.10)",
-    color: "rgba(212,175,55,0.80)",
+    background: "rgba(120,60,180,0.14)",
+    color: "rgba(190,160,240,0.90)",
     transition: "all 0.15s",
     whiteSpace: "nowrap" as const,
   },
@@ -207,7 +244,7 @@ const s: Record<string, React.CSSProperties> = {
     width: "22px",
     height: "22px",
     borderRadius: "4px",
-    border: "1px solid rgba(212,175,55,0.15)",
+    border: "1px solid rgba(255,255,255,0.15)",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
@@ -218,8 +255,8 @@ const s: Record<string, React.CSSProperties> = {
     width: "22px",
     height: "22px",
     borderRadius: "4px",
-    background: "#D4AF37",
-    border: "1px solid #D4AF37",
+    background: "rgba(120,60,180,0.85)",
+    border: "1px solid rgba(120,60,180,0.85)",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
@@ -229,7 +266,7 @@ const s: Record<string, React.CSSProperties> = {
   hint: {
     textAlign: "center" as const,
     fontSize: "11px",
-    color: "rgba(255,255,255,0.35)",
+    color: "rgba(255,255,255,0.40)",
     padding: "16px",
   },
   cta: {
@@ -250,7 +287,7 @@ const s: Record<string, React.CSSProperties> = {
     justifyContent: "center",
     gap: "10px",
     transition: "transform 0.12s",
-    boxShadow: "0 0 20px rgba(249,224,118,0.25), 0 0 60px rgba(249,224,118,0.08)",
+    boxShadow: "0 0 20px rgba(249,224,118,0.25), 0 0 60px rgba(249,224,118,0.15)",
     minHeight: "56px",
   },
 };
@@ -269,13 +306,29 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
 
   return (
     <div style={s.wrapper}>
-      <ChapterCard chapter="02" title="Capital Stack" variant="data" noPad>
-        <div style={s.headerPad}>
-          <div style={cardH}>How's It Funded?</div>
-          <div style={{ ...cardHSub, ...s.subLine }}>
-            Select the capital sources in your deal
+      {/* Glass Hero */}
+      <div style={s.heroOuter}>
+        <div style={s.heroCanopy} />
+        <section style={s.heroCard}>
+          <div style={s.heroGlowBg} />
+          <div style={s.heroInner}>
+            <div style={s.heroEyebrow}>
+              <div style={s.heroEyebrowLine} />
+              <span style={s.heroEyebrowLabel}>Step 02 · Capital Stack</span>
+              <div style={s.heroEyebrowLine} />
+            </div>
+            <h1 style={s.heroH1}>
+              How's It<br />
+              <span style={s.heroGoldSpan}>Funded?</span>
+            </h1>
+            <p style={s.heroSubtext}>
+              Select the capital sources in your deal.
+            </p>
           </div>
-        </div>
+        </section>
+      </div>
+
+      <ChapterCard chapter="02" title="Capital Stack" variant="data" noPad hideEyebrow>
 
         {/* Header */}
         <div style={s.stackHdr}>
@@ -300,7 +353,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
                   ...(isSelected ? s.siOn : s.si),
                   // Re-apply borderBottom separately since si/siOn override border
                   borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.04)",
-                  borderLeft: isSelected ? "3px solid #D4AF37" : "3px solid transparent",
+                  borderLeft: isSelected ? "3px solid rgba(120,60,180,0.60)" : "3px solid transparent",
                   ...(justToggled === option.key ? { transform: "scale(1.01)" } : {}),
                 }}
               >
@@ -329,8 +382,8 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
         <p style={s.hint}>Most indie films use Senior Debt + Equity</p>
       </ChapterCard>
 
-      <button style={s.cta} onClick={onNext}>
-        {selectedCount > 0 ? "Continue" : "Skip — Self-Financed"}
+      <button style={s.cta} onClick={(e) => { haptics.medium(e); onNext(); }}>
+        {selectedCount > 0 ? "Enter Your Stack Details" : "Skip — Self-Financed"}
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <line x1="5" y1="12" x2="19" y2="12" />
           <polyline points="12 5 19 12 12 19" />

--- a/src/components/calculator/stack/StackInputCard.tsx
+++ b/src/components/calculator/stack/StackInputCard.tsx
@@ -119,7 +119,7 @@ const StackInputCard = ({
             style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
           >
             <div className="flex items-center gap-2">
-              <span className="text-xs uppercase tracking-widest font-semibold" style={{ color: "rgba(255,255,255,0.55)" }}>
+              <span className="text-xs uppercase tracking-widest font-semibold" style={{ color: "rgba(212,175,55,0.75)" }}>
                 {amountLabel}
               </span>
               {helpText && (
@@ -194,12 +194,12 @@ const StackInputCard = ({
               <div className="p-5">
                 <div className="space-y-3">
                   <div className="flex items-center justify-between text-sm">
-                    <span style={{ color: "rgba(255,255,255,0.55)" }}>Principal</span>
-                    <span className="font-mono" style={{ color: "rgba(255,255,255,0.70)" }}>{formatCompactCurrency(amount)}</span>
+                    <span style={{ color: "rgba(255,255,255,0.60)" }}>Principal</span>
+                    <span className="font-mono" style={{ color: "rgba(255,255,255,0.85)" }}>{formatCompactCurrency(amount)}</span>
                   </div>
                   <div className="flex items-center justify-between text-sm">
-                    <span style={{ color: "rgba(255,255,255,0.55)" }}>+ {rateConfig.label} ({rateValue}%)</span>
-                    <span className="font-mono" style={{ color: "rgba(255,255,255,0.70)" }}>{formatCompactCurrency(interestAmount)}</span>
+                    <span style={{ color: "rgba(255,255,255,0.60)" }}>+ {rateConfig.label} ({rateValue}%)</span>
+                    <span className="font-mono" style={{ color: "rgba(255,255,255,0.85)" }}>{formatCompactCurrency(interestAmount)}</span>
                   </div>
                   <div style={{ height: "1px", background: "rgba(212,175,55,0.20)" }} />
                   <div className="flex items-center justify-between">
@@ -215,7 +215,7 @@ const StackInputCard = ({
           {typicalRangeLabel && (
             <div className="px-5 py-3" style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
               <div className="flex items-center justify-between">
-                <span className="text-xs" style={{ color: "rgba(255,255,255,0.55)" }}>Typical range</span>
+                <span className="text-xs" style={{ color: "rgba(255,255,255,0.60)" }}>Typical range</span>
                 <span className="text-xs font-mono" style={{ color: "rgba(255,255,255,0.70)" }}>{typicalRangeLabel}</span>
               </div>
             </div>

--- a/src/components/calculator/stack/StackSummary.tsx
+++ b/src/components/calculator/stack/StackSummary.tsx
@@ -2,6 +2,7 @@ import { Receipt, Landmark, CreditCard, Users, Clock, Edit2 } from "lucide-react
 import { WaterfallInputs, formatCompactCurrency } from "@/lib/waterfall";
 import { CapitalSourceSelections } from "./CapitalSelect";
 import StandardStepLayout from "../StandardStepLayout";
+import { useHaptics } from "@/hooks/use-haptics";
 
 interface StackSummaryProps {
   inputs: WaterfallInputs;
@@ -25,6 +26,7 @@ interface StackItem {
  * Shows selected sources with amounts. Edit routes by source key.
  */
 const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryProps) => {
+  const haptics = useHaptics();
   const totalCapital = inputs.credits + inputs.debt + inputs.mezzanineDebt + inputs.equity;
   const gapPercent = inputs.budget > 0 ? (totalCapital / inputs.budget) * 100 : 0;
   const isFullyFunded = gapPercent >= 100;
@@ -50,7 +52,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
       title={title}
       subtitle={subtitle}
       onNext={onComplete}
-      nextLabel="Continue to Deal Terms"
+      nextLabel="Set Your Deal Terms"
       isComplete={true}
     >
       <div className="space-y-6">
@@ -74,7 +76,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
               />
             )}
             <div className="relative flex items-center justify-between mb-2">
-              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "rgba(255,255,255,0.55)" }}>Total Capital</span>
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "rgba(212,175,55,0.75)" }}>Total Capital</span>
               <span
                 className="font-mono text-lg font-medium"
                 style={{
@@ -102,7 +104,10 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
               <span className="text-xs" style={{ color: "rgba(255,255,255,0.55)" }}>Budget: {formatCompactCurrency(inputs.budget)}</span>
               <span
                 className="font-mono text-xs font-medium"
-                style={{ color: gapPercent >= 100 ? "#D4AF37" : "rgba(212,175,55,0.60)" }}
+                style={{
+                  color: gapPercent >= 100 ? "#D4AF37" : "rgba(212,175,55,0.60)",
+                  fontWeight: gapPercent >= 100 ? 600 : 500,
+                }}
               >
                 {gapPercent.toFixed(0)}% Funded
               </span>
@@ -119,7 +124,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
             className="px-5 py-3"
             style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}
           >
-            <span className="text-xs uppercase tracking-widest font-semibold" style={{ color: "rgba(255,255,255,0.55)" }}>
+            <span className="text-xs uppercase tracking-widest font-semibold" style={{ color: "rgba(212,175,55,0.75)" }}>
               Capital Sources
             </span>
           </div>
@@ -148,7 +153,7 @@ const StackSummary = ({ inputs, selections, onEdit, onComplete }: StackSummaryPr
                     <div className="flex items-center gap-3">
                       <span className="font-mono" style={{ color: "#D4AF37" }}>{formatCompactCurrency(item.amount)}</span>
                       <button
-                        onClick={() => onEdit(item.sourceKey)}
+                        onClick={(e) => { haptics.light(e); onEdit(item.sourceKey); }}
                         className="p-1.5 transition-colors"
                         style={{ color: "rgba(255,255,255,0.55)" }}
                       >

--- a/src/components/calculator/tabs/StackTab.tsx
+++ b/src/components/calculator/tabs/StackTab.tsx
@@ -21,46 +21,25 @@ const STEP_LABELS: Record<string, string> = {
   summary: 'Review',
 };
 
-/* ── Wizard progress pip row ───────────────────── */
-const WizardProgress = ({ steps, currentIndex }: { steps: string[]; currentIndex: number }) => (
-  <div className="px-6 pt-4 pb-2">
-    <div className="flex items-center justify-center">
-      {steps.map((step, i) => {
-        const isCompleted = i < currentIndex;
-        const isCurrent = i === currentIndex;
-        return (
-          <div key={step} className="flex items-center">
-            {i > 0 && (
-              <div
-                className="transition-colors duration-300"
-                style={{
-                  height: "1.5px",
-                  width: steps.length <= 4 ? "24px" : "16px",
-                  background: isCompleted ? "rgba(212,175,55,0.60)" : "rgba(255,255,255,0.10)",
-                }}
-              />
-            )}
-            <div
-              className="rounded-full transition-all duration-300"
-              style={
-                isCurrent
-                  ? { width: "10px", height: "10px", background: "#D4AF37", boxShadow: "0 0 6px rgba(212,175,55,0.6)" }
-                  : isCompleted
-                    ? { width: "8px", height: "8px", background: "rgba(212,175,55,0.50)" }
-                    : { width: "8px", height: "8px", background: "rgba(255,255,255,0.15)" }
-              }
-            />
-          </div>
-        );
-      })}
-    </div>
-    <p className="text-center text-[11px] font-mono mt-2 tracking-wider" style={{ color: "rgba(255,255,255,0.55)" }}>
+/* ── Sub-step text indicator ──────────────────── */
+const SubStepIndicator = ({ steps, currentIndex }: { steps: string[]; currentIndex: number }) => {
+  const currentLabel = STEP_LABELS[steps[currentIndex]] ?? steps[currentIndex];
+  return (
+    <div style={{
+      textAlign: "center",
+      padding: "16px 24px 8px",
+      fontFamily: "'Roboto Mono', monospace",
+      fontSize: 10,
+      letterSpacing: "0.12em",
+      textTransform: "uppercase" as const,
+      color: "rgba(212,175,55,0.55)",
+    }}>
       Step {currentIndex + 1} of {steps.length}
       {" — "}
-      <span style={{ color: "rgba(255,255,255,0.70)" }}>{STEP_LABELS[steps[currentIndex]] ?? steps[currentIndex]}</span>
-    </p>
-  </div>
-);
+      <span style={{ color: "rgba(255,255,255,0.70)" }}>{currentLabel}</span>
+    </div>
+  );
+};
 
 interface StackTabProps {
   inputs: WaterfallInputs;
@@ -185,7 +164,7 @@ const StackTab = ({ inputs, onUpdateInput, onAdvance, selections, onToggleSelect
 
   return (
     <div className="pb-8">
-      <WizardProgress steps={steps} currentIndex={safeIndex} />
+      <SubStepIndicator steps={steps} currentIndex={safeIndex} />
       {renderStep()}
     </div>
   );


### PR DESCRIPTION
…ades

- CapitalSelect: Add glass hero with triple glow, convert all selected states from gold to purple, bump contrast values, update CTA label to "Enter Your Stack Details" with haptic feedback, neutralize rest- state pill borders to white
- StackTab: Replace dot-pip WizardProgress with minimal text SubStepIndicator
- StackSummary: CTA label to "Set Your Deal Terms", add haptic to edit buttons, gold contrast on section headers, bold "100% Funded"
- StackInputCard: Gold section headers, contrast bumps on calculation labels (0.60) and values (0.85), typical range label to 0.60

https://claude.ai/code/session_01LeGVoESX6CowmRj8kRDist