### PR TITLE
Fix TabBar icon visibility, add purple atmospheric pass, collapse CTA…

### DIFF
--- a/src/components/calculator/ChapterCard.tsx
+++ b/src/components/calculator/ChapterCard.tsx
@@ -93,8 +93,11 @@ const warmGlow: React.CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  height: "220px",
-  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.18) 0%, transparent 70%)",
+  height: "280px",
+  background: [
+    "radial-gradient(ellipse 80% 50% at 50% 0%, rgba(212,175,55,0.18) 0%, transparent 70%)",
+    "radial-gradient(ellipse 60% 40% at 50% 100%, rgba(120,60,180,0.08) 0%, transparent 60%)",
+  ].join(", "),
   pointerEvents: "none",
 };
 
@@ -103,8 +106,11 @@ const featureGlow: React.CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  height: "180px",
-  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.14) 0%, transparent 70%)",
+  height: "220px",
+  background: [
+    "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.14) 0%, transparent 70%)",
+    "radial-gradient(ellipse 60% 40% at 50% 100%, rgba(120,60,180,0.06) 0%, transparent 60%)",
+  ].join(", "),
   pointerEvents: "none",
 };
 
@@ -113,8 +119,11 @@ const dataGlow: React.CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  height: "140px",
-  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.10) 0%, transparent 70%)",
+  height: "180px",
+  background: [
+    "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.10) 0%, transparent 70%)",
+    "radial-gradient(ellipse 60% 40% at 50% 100%, rgba(120,60,180,0.06) 0%, transparent 60%)",
+  ].join(", "),
   pointerEvents: "none",
 };
 
@@ -123,8 +132,11 @@ const neutralGlow: React.CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  height: "100px",
-  background: "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.08) 0%, transparent 70%)",
+  height: "140px",
+  background: [
+    "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(212,175,55,0.08) 0%, transparent 70%)",
+    "radial-gradient(ellipse 60% 40% at 50% 100%, rgba(120,60,180,0.04) 0%, transparent 60%)",
+  ].join(", "),
   pointerEvents: "none",
 };
 

--- a/src/components/calculator/TabBar.tsx
+++ b/src/components/calculator/TabBar.tsx
@@ -53,7 +53,7 @@ const s: Record<string, React.CSSProperties> = {
     fontWeight: 600,
     textTransform: "uppercase" as const,
     letterSpacing: "0.05em",
-    color: "rgba(255,255,255,0.40)",
+    color: "rgba(255,255,255,0.45)",
     cursor: "pointer",
     transition: "all 0.2s",
     border: "none",
@@ -68,7 +68,7 @@ const s: Record<string, React.CSSProperties> = {
     color: "rgba(255,255,255,0.65)",
   },
   iconInactive: {
-    opacity: 0.4,
+    opacity: 1,
     transition: "all 0.2s",
   },
   iconActive: {

--- a/src/components/calculator/stack/CapitalSelect.tsx
+++ b/src/components/calculator/stack/CapitalSelect.tsx
@@ -31,7 +31,7 @@ const options: {
   {
     key: 'taxCredits',
     title: 'Tax Credits',
-    description: 'Louisiana, Georgia, New York, etc.',
+    description: 'LA, Georgia, New York, etc.',
     icon: Receipt,
     priorityLabel: 'Off-waterfall',
   },
@@ -165,8 +165,9 @@ const s: Record<string, React.CSSProperties> = {
   },
   siLeft: {
     display: "flex",
-    alignItems: "center",
+    alignItems: "flex-start",
     gap: "12px",
+    paddingTop: "2px",
   },
   siIcon: {
     width: "40px",
@@ -359,7 +360,7 @@ const CapitalSelect = ({ selections, onToggle, onNext }: CapitalSelectProps) => 
               >
                 <div style={s.siLeft}>
                   <div style={isSelected ? s.siIconOn : s.siIcon}>
-                    <Icon style={{ width: "20px", height: "20px" }} />
+                    <Icon style={{ width: "24px", height: "24px" }} />
                   </div>
                   <div>
                     <div style={isSelected ? s.siTitleOn : s.siTitle}>{option.title}</div>

--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -266,20 +266,24 @@ const s: Record<string, React.CSSProperties> = {
   // CTA
   reveal: {
     opacity: 0,
+    maxHeight: 0,
+    overflow: "hidden" as const,
     transform: "translateY(12px)",
-    transition: "opacity 0.4s ease 0.15s, transform 0.4s ease 0.15s",
+    transition: "opacity 0.4s ease 0.15s, transform 0.4s ease 0.15s, max-height 0.35s ease",
     pointerEvents: "none" as const,
   },
   revealVis: {
     opacity: 1,
+    maxHeight: 120,
+    overflow: "hidden" as const,
     transform: "translateY(0)",
-    transition: "opacity 0.4s ease 0.15s, transform 0.4s ease 0.15s",
+    transition: "opacity 0.4s ease 0.15s, transform 0.4s ease 0.15s, max-height 0.35s ease",
     pointerEvents: "auto" as const,
   },
   cta: {
     width: "100%",
     padding: 16,
-    marginTop: 24,
+    marginTop: 16,
     background: "#F9E076",
     border: "none",
     borderRadius: 8,


### PR DESCRIPTION
… dead space, fix CapitalSelect alignment

- S1: TabBar — Remove double-dimming on inactive icons (0.16 → 0.45 effective opacity)
- S2: ChapterCard — Add bottom-anchored purple radial to all 4 glow variants
- S3: ProjectTab — CTA collapses with maxHeight:0 when hidden, tighter marginTop
- S4: CapitalSelect — Icons 20→24px, flex-start alignment, shorten Tax Credits desc

https://claude.ai/code/session_019ExhJEY5DX1nkyXNS8sum6