### PR TITLE
Visual fixes: hero borders, subtitle cleanup, search bar, menu width,…

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -88,7 +88,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
       {/* Bottom Sheet */}
       <div
         className={cn(
-          "fixed bottom-0 left-2 right-2 z-[201] max-h-[85vh] overflow-y-auto",
+          "fixed bottom-0 left-0 right-0 z-[201] max-h-[85vh] overflow-y-auto",
           "transition-transform duration-300 ease-out",
           isOpen ? "translate-y-0" : "translate-y-full"
         )}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -339,7 +339,7 @@ const Index = () => {
               <span style={styles.heroMid}>Recoupment</span>
               <em style={styles.heroEm}>Waterfall</em>
             </h1>
-            <p style={styles.heroSub}>Your Deal Structure Begins Here.</p>
+            {/* subtitle killed — h1 + CTA is sufficient, subtitle was redundant with button copy */}
             <div style={{ margin: "8px 0 0" }}>
               <button onClick={handleCTA} style={styles.ctaBtn} aria-label="Run my waterfall" onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.98)"; }} onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}>
                 <span style={{ position: "relative", zIndex: 1 }}>RUN MY WATERFALL</span>
@@ -890,12 +890,12 @@ const styles: Record<string, React.CSSProperties> = {
     background: "rgba(6,6,6,0.92)",
     backdropFilter: "blur(40px)",
     WebkitBackdropFilter: "blur(40px)",
-    border: "1px solid rgba(212,175,55,0.20)",
+    border: "1px solid rgba(212,175,55,0.12)",
     boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
   },
   heroGlow: {
     position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
-    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
   },
   heroInner: { position: "relative", zIndex: 1 },
   heroH1: {

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -559,7 +559,7 @@ const Resources = () => {
           background: "rgba(6,6,6,0.92)",
           backdropFilter: "blur(40px)",
           WebkitBackdropFilter: "blur(40px)",
-          border: "1px solid rgba(212,175,55,0.20)",
+          border: "1px solid rgba(212,175,55,0.12)",
           boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
           ...reveal(headerVisible),
         }}>
@@ -588,14 +588,13 @@ const Resources = () => {
             </h1>
             <p style={{
               fontFamily: "'Bebas Neue', sans-serif",
-              fontSize: "1.5rem",
+              fontSize: "1.25rem",
               lineHeight: 1.1,
               color: "#fff",
               textAlign: "center",
               marginTop: 8,
               textShadow: "0 2px 12px rgba(0,0,0,0.9)",
             }}>
-              Deal Structures. Waterfall Mechanics.<br />
               The Intelligence Behind Films That Close.
             </p>
           </div>
@@ -671,8 +670,8 @@ const Resources = () => {
               }}
               style={{
                 width: "100%",
-                background: searchInputFocused ? "rgba(212,175,55,0.06)" : "rgba(212,175,55,0.04)",
-                border: searchInputFocused ? "1px solid rgba(120,60,180,0.50)" : "1px solid rgba(120,60,180,0.30)",
+                background: searchInputFocused ? "rgba(212,175,55,0.08)" : "rgba(212,175,55,0.06)",
+                border: searchInputFocused ? "1px solid rgba(212,175,55,0.40)" : "1px solid rgba(212,175,55,0.25)",
                 borderRadius: 12,
                 color: "rgba(255,255,255,0.95)",
                 fontFamily: "'Inter', sans-serif",

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1179,7 +1179,7 @@ const Store = () => {
           background: "rgba(6,6,6,0.92)",
           backdropFilter: "blur(40px)",
           WebkitBackdropFilter: "blur(40px)",
-          border: "1px solid rgba(212,175,55,0.20)",
+          border: "1px solid rgba(212,175,55,0.12)",
           boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
           ...reveal(heroVisible),
         }}>


### PR DESCRIPTION
… purple haze

- Remove landing page hero subtitle (redundant with CTA copy)
- Boost purple center haze opacity 0.16 → 0.22 on landing hero
- Reduce hero border opacity 0.20 → 0.12 across all 3 pages (Index, Store, Resources)
- Consolidate Resources subtitle to single line at 1.25rem
- Boost search bar resting border/background for OLED readability, switch to gold border
- Make MobileMenu full-width (left-0 right-0 instead of left-2 right-2)

https://claude.ai/code/session_016xtmX7KLUJwMkLEM2eDCyu