### PR TITLE
fix: use dynamic imports in generate-pdf to resolve ESM/CJS module er…

### DIFF
--- a/api/generate-pdf.ts
+++ b/api/generate-pdf.ts
@@ -1,50 +1,63 @@
 // api/generate-pdf.ts
 // Vercel Serverless Function: generates a PDF from a waterfall snapshot
-// Called by the frontend: GET /api/generate-pdf?id={snapshotId}
+// GET /api/generate-pdf?id={snapshotId}
+//
+// Uses dynamic imports to avoid ESM/CJS module resolution issues
+// with puppeteer-core and @sparticuz/chromium on Node 24 + "type": "module"
 
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import puppeteer from 'puppeteer-core';
-import chromium from '@sparticuz/chromium';
-import { generatePdfHtml } from './_pdf-template';
-import { createClient } from '@supabase/supabase-js';
+import type { VercelRequest, VercelResponse } from "@vercel/node";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // Only allow GET
-  if (req.method !== 'GET') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
 
   const { id } = req.query;
-  if (!id || typeof id !== 'string') {
-    return res.status(400).json({ error: 'Missing snapshot id' });
+  if (!id || typeof id !== "string") {
+    return res.status(400).json({ error: "Missing snapshot id" });
   }
 
   try {
-    // 1. Fetch snapshot from Supabase
-    const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+    // Dynamic imports — avoids top-level ESM/CJS resolution failures
+    const { createClient } = await import("@supabase/supabase-js");
+    const { generatePdfHtml } = await import("./_pdf-template.js");
+    const chromiumModule = await import("@sparticuz/chromium");
+    const puppeteerModule = await import("puppeteer-core");
+    const chromium = chromiumModule.default;
+    const puppeteer = puppeteerModule.default;
+
+    // 1. Supabase client (server-side — uses process.env)
+    const supabaseUrl =
+      process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
     const supabaseKey =
-      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.VITE_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseKey) {
-      return res.status(500).json({ error: 'Supabase not configured' });
+      console.error("Missing Supabase env vars:", {
+        hasUrl: !!supabaseUrl,
+        hasKey: !!supabaseKey,
+      });
+      return res.status(500).json({ error: "Server misconfigured" });
     }
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    // 2. Fetch snapshot
     const { data: snapshot, error: dbError } = await supabase
-      .from('waterfall_snapshots')
-      .select('*')
-      .eq('id', id)
+      .from("waterfall_snapshots")
+      .select("*")
+      .eq("id", id)
       .single();
 
     if (dbError || !snapshot) {
-      return res.status(404).json({ error: 'Snapshot not found' });
+      return res.status(404).json({ error: "Snapshot not found" });
     }
 
-    // 2. Generate HTML
+    // 3. Generate HTML from snapshot data
     const html = generatePdfHtml(snapshot.snapshot_data);
 
-    // 3. Launch Puppeteer
+    // 4. Launch Puppeteer with serverless Chromium
     const browser = await puppeteer.launch({
       args: chromium.args,
       defaultViewport: { width: 612, height: 792 },
@@ -53,34 +66,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     const page = await browser.newPage();
-    await page.setContent(html, { waitUntil: 'networkidle0' });
+    await page.setContent(html, { waitUntil: "networkidle0" });
 
-    // Wait for fonts to load
-    await page.evaluateHandle('document.fonts.ready');
+    // Wait for Google Fonts to load
+    await page.evaluateHandle("document.fonts.ready");
 
-    // 4. Generate PDF
+    // 5. Render PDF
     const pdfBuffer = await page.pdf({
-      width: '612px',
-      height: '792px',
+      width: "612px",
+      height: "792px",
       printBackground: true,
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
+      margin: { top: "0", right: "0", bottom: "0", left: "0" },
     });
 
     await browser.close();
 
-    // 5. Return PDF
-    const projectName = snapshot.project_name || 'Waterfall_Snapshot';
-    const safeFilename = projectName.replace(/[^a-zA-Z0-9-]/g, '_');
+    // 6. Return PDF as file download
+    const projectName = snapshot.project_name || "Waterfall_Snapshot";
+    const safeFilename = projectName.replace(/[^a-zA-Z0-9_-]/g, "_");
 
-    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="${safeFilename}_Snapshot.pdf"`,
+      "Content-Disposition",
+      `attachment; filename="${safeFilename}_Snapshot.pdf"`
     );
-    res.setHeader('Cache-Control', 'private, max-age=3600');
-    res.send(pdfBuffer);
+    res.setHeader("Cache-Control", "private, max-age=3600");
+    return res.send(pdfBuffer);
   } catch (error) {
-    console.error('PDF generation error:', error);
-    res.status(500).json({ error: 'Failed to generate PDF' });
+    console.error("PDF generation error:", error);
+    return res.status(500).json({
+      error: "Failed to generate PDF",
+      details: error instanceof Error ? error.message : "Unknown error",
+    });
   }
 }


### PR DESCRIPTION
…rors

Top-level CJS imports from puppeteer-core and @sparticuz/chromium fail under Node 24 with "type": "module". Moving all npm imports inside the handler as dynamic await import() calls avoids the resolution clash.

https://claude.ai/code/session_01EWTghvrEoHyp7Euqc1i5Ln