### PR TITLE
Blind review Phase 2: polish, count-up, menu, greeting

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -211,6 +211,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           )}
 
           {/* Nav — 3-col (matches social row) */}
+          <SectionLabel>Navigate</SectionLabel>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "6px", marginBottom: "10px" }}>
             {([
               { path: "/calculator", label: "Calculator", icon: <Calculator size={18} color="#D4AF37" /> },
@@ -232,11 +233,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: "transparent",
+                  background: "radial-gradient(ellipse 80% 60% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 70%)",
                   border: "1px solid rgba(212,175,55,0.25)",
                   borderRadius: "6px",
                   cursor: "pointer",
                   transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
+                  boxShadow: "0 0 16px rgba(212,175,55,0.04)",
                 }}
               >
                 {item.icon}
@@ -245,6 +247,8 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.88)",
+                  borderBottom: "1px solid rgba(212,175,55,0.20)",
+                  paddingBottom: "2px",
                 }}>
                   {item.label}
                 </span>

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -118,8 +118,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       })();
 
       const greeting = hasProjectData
-        ? "Hey, I\u2019m the OG \u{1F916} Your film finance copilot. I can see you\u2019ve been running numbers \u2014 want me to help interpret your model, or ask me anything about deals, waterfalls, or packaging."
-        : "Hey, I\u2019m the OG \u{1F916} Your film finance copilot. Ask me anything about deals, waterfalls, packaging, or how to get your film financed. What\u2019s on your mind?";
+        ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
+        : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
 
       setOgMessages([{
         id: "greeting",
@@ -297,8 +297,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       } catch { return false; }
     })();
     const greeting = hasProjectData
-      ? "Hey, I\u2019m the OG \u{1F916} Your film finance copilot. I can see you\u2019ve been running numbers \u2014 want me to help interpret your model, or ask me anything about deals, waterfalls, or packaging."
-      : "Hey, I\u2019m the OG \u{1F916} Your film finance copilot. Ask me anything about deals, waterfalls, packaging, or how to get your film financed. What\u2019s on your mind?";
+      ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
+      : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
     setOgMessages([{
       id: "greeting",
       question: "",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -88,6 +88,7 @@ const Index = () => {
   const { ref: realityQuoteRef, inView: realityQuoteVisible } = useInView<HTMLDivElement>({ threshold: 0.3 });
   const { ref: realityGridRef, inView: realityGridVisible } = useInView<HTMLDivElement>({ threshold: 0.15 });
   const { ref: profitCardRef, inView: profitCardVisible } = useInView<HTMLDivElement>({ threshold: 0.1 });
+  const { ref: splitRef, inView: splitVisible } = useInView<HTMLDivElement>({ threshold: 0.3 });
   const { ref: closerRef, inView: closerVisible } = useInView<HTMLDivElement>({ threshold: 0.2 });
   const { ref: footerRef, inView: footerVisible } = useInView<HTMLDivElement>({ threshold: 0.15 });
 
@@ -117,6 +118,10 @@ const Index = () => {
   const [profitCountUp, setProfitCountUp] = useState(0);
   const [profitGlowIntensity, setProfitGlowIntensity] = useState(0.18);
   const profitAnimRef = useRef<number>(0);
+
+  const [splitCelebrated, setSplitCelebrated] = useState(false);
+  const [splitCountUp, setSplitCountUp] = useState(0);
+  const splitAnimRef = useRef<number>(0);
 
 
   const badgeCards = [
@@ -172,8 +177,8 @@ const Index = () => {
       setProfitCelebrated(true);
       haptics.success();
       setProfitGlowIntensity(0.28);
-      setTimeout(() => setProfitGlowIntensity(0.18), 600);
-      const duration = 600;
+      setTimeout(() => setProfitGlowIntensity(0.18), 2000);
+      const duration = 1800;
       const startTime = performance.now();
       const tick = (now: number) => {
         const elapsed = now - startTime;
@@ -187,6 +192,24 @@ const Index = () => {
       profitAnimRef.current = requestAnimationFrame(tick);
     }
   }, [profitCardVisible, profitCelebrated, haptics]);
+
+  useEffect(() => {
+    if (splitVisible && !splitCelebrated) {
+      setSplitCelebrated(true);
+      const duration = 1200;
+      const startTime = performance.now();
+      const tick = (now: number) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        setSplitCountUp(Math.round(SPLIT * eased));
+        if (progress < 1) {
+          splitAnimRef.current = requestAnimationFrame(tick);
+        }
+      };
+      splitAnimRef.current = requestAnimationFrame(tick);
+    }
+  }, [splitVisible, splitCelebrated]);
 
   // Card entrance animation helper
   const [enteredCards, setEnteredCards] = useState<Set<number>>(new Set());
@@ -328,7 +351,7 @@ const Index = () => {
         }
       `}</style>
 
-      <div style={{ minHeight: "100vh", background: "#000", paddingTop: "32px", maxWidth: "430px", margin: "0 auto" }}>
+      <div style={{ minHeight: "100vh", background: "#000", paddingTop: "24px", maxWidth: "430px", margin: "0 auto" }}>
 
         {/* ═══ § 1 HERO ═══ */}
         <section ref={heroRef} style={styles.hero}>
@@ -598,7 +621,7 @@ const Index = () => {
           <WaterfallConnector color="green" />
 
           {/* ── Profit Split ── */}
-          <div style={{ margin: "0 24px" }}>
+          <div ref={splitRef} style={{ margin: "0 24px" }}>
             <WaterfallGroupLabel text="Profit Split" color="neutral" />
             <div style={{ display: "flex", gap: "8px", alignItems: "stretch" }}>
               <div style={{
@@ -610,7 +633,7 @@ const Index = () => {
               }}>
                 <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, #3CB371, transparent)" }} />
                 <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Investor</div>
-                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${SPLIT.toLocaleString()}</div>
+                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${splitCountUp.toLocaleString()}</div>
               </div>
               <div style={{
                 flex: 1, textAlign: "center", borderRadius: "12px", padding: "16px 12px",
@@ -621,7 +644,7 @@ const Index = () => {
               }}>
                 <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, #3CB371, transparent)" }} />
                 <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Producer</div>
-                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${SPLIT.toLocaleString()}</div>
+                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${splitCountUp.toLocaleString()}</div>
               </div>
             </div>
           </div>
@@ -741,7 +764,7 @@ const Index = () => {
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
                     <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Off-the-Top Fee Mapping</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Where the money goes before you touch it</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Where the money goes before you see a dime</p>
                   </div>
                 </div>
 
@@ -988,11 +1011,11 @@ const styles: Record<string, React.CSSProperties> = {
     backdropFilter: "blur(40px)",
     WebkitBackdropFilter: "blur(40px)",
     border: "1px solid rgba(212,175,55,0.20)",
-    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
+    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15), 0 0 60px rgba(120,60,180,0.12)",
   },
   heroGlow: {
     position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
-    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
+    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.28) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.28) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.24) 0%, transparent 60%)",
   },
   heroInner: { position: "relative", zIndex: 1 },
   heroH1: {
@@ -1009,7 +1032,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
 
   /* ── § 2 HOW IT WORKS ── */
-  howSection: { position: "relative", background: "#000", padding: "48px 0 0" },
+  howSection: { position: "relative", background: "#000", padding: "36px 0 0" },
   howHeader: { textAlign: "center", padding: "16px 24px 24px", background: "radial-gradient(ellipse 80% 50% at 50% 60%, rgba(120,60,180,0.18) 0%, transparent 70%)" },
   howH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   stepsContainer: { position: "relative", display: "flex", flexDirection: "column", gap: "1px", background: "rgba(120,60,180,0.10)", borderRadius: "12px", overflow: "hidden", margin: "0 24px", border: "1px solid rgba(120,60,180,0.25)", boxShadow: "0 16px 40px rgba(0,0,0,0.5), 0 0 20px rgba(120,60,180,0.15)" },


### PR DESCRIPTION
## Summary

- **Serving A (Index.tsx):** Fix orphan wrap on Arsenal descriptor, lift hero 8px, tighten hero→how-section gap from 67→55px, warm hero glow (gold 0.22→0.28, purple 0.22→0.28), add 60px purple halo to hero boxShadow, slow profit counter from 0.6s→1.8s with extended 2s glow pulse
- **Serving B (Index.tsx):** Profit split cards now count up from $0→$209,000 over 1.2s with cubic ease-out, triggered on scroll into view. Both Investor and Producer cards animate simultaneously
- **Serving C (MobileMenu.tsx):** Add "NAVIGATE" section label above nav grid (matches Follow/Connect style), add subtle gold radial atmospheric + boxShadow to nav cells, add thin gold underline under nav label text
- **Serving D (OgBotSheet.tsx):** Rewrite greeting to 4-paragraph format with wave emoji, "deal analyst on call" tagline. Context-aware variant references running numbers. Reset handler uses same strings

## Test plan

- [ ] Arsenal "Off-the-Top Fee Mapping" descriptor says "before you see a dime" — no orphan at 430px
- [ ] Hero card sits higher, "THE PROCESS" eyebrow visible closer to fold
- [ ] Hero glow visibly warmer, purple halo around card edges
- [ ] Profit counter takes ~1.8s to reach $418,000
- [ ] Split cards count from $0→$209,000 over ~1.2s on scroll
- [ ] Split animation fires only once (no retrigger on re-scroll)
- [ ] "NAVIGATE" label appears above Calculator/Shop/Resources in menu
- [ ] Nav cells have subtle gold glow, labels have gold underline
- [ ] Hover/press states still work on nav cells
- [ ] Bot greeting shows 4 paragraphs with wave emoji, no robot emoji
- [ ] Reset button restores same greeting format
- [ ] `npm run build` passes

https://claude.ai/code/session_014oycPTamDrXkuFrtCLUcSi