### PR TITLE
Fix menu styling, bot sheet readability, and landing page polish

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -233,12 +233,12 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 70%)",
+                  background: "radial-gradient(ellipse 80% 60% at 50% 30%, rgba(212,175,55,0.12) 0%, transparent 70%)",
                   border: "1px solid rgba(212,175,55,0.25)",
                   borderRadius: "6px",
                   cursor: "pointer",
                   transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
-                  boxShadow: "0 0 16px rgba(212,175,55,0.04)",
+                  boxShadow: "0 0 16px rgba(212,175,55,0.10)",
                 }}
               >
                 {item.icon}
@@ -247,8 +247,6 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
                   color: "rgba(255,255,255,0.88)",
-                  borderBottom: "1px solid rgba(212,175,55,0.20)",
-                  paddingBottom: "2px",
                 }}>
                   {item.label}
                 </span>

--- a/src/components/OgBotSheet.tsx
+++ b/src/components/OgBotSheet.tsx
@@ -118,8 +118,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       })();
 
       const greeting = hasProjectData
-        ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
-        : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
+        ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
+        : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
 
       setOgMessages([{
         id: "greeting",
@@ -297,8 +297,8 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
       } catch { return false; }
     })();
     const greeting = hasProjectData
-      ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
-      : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nYour deal analyst on call.\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
+      ? "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nI can see you\u2019ve been running numbers \u2014 want me to help interpret your model?\n\nOr ask me anything about deals, waterfalls, packaging, or how to get your film financed."
+      : "Hey \u{1F44B}, I\u2019m your film-finance OG!\n\nAsk me anything about waterfalls, deal structures, packaging, or how to get your film financed.\n\nNeed help picking the right package? Just tell me what\u2019s on your mind below \u{1F447}";
     setOgMessages([{
       id: "greeting",
       question: "",
@@ -338,7 +338,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
             borderRadius: "6px",
             borderColor: "rgba(120,60,180,0.35)",
             background: "rgba(120,60,180,0.10)",
-            color: "rgba(255,255,255,0.75)",
+            color: "rgba(255,255,255,0.85)",
           }}
         >
           {chip}
@@ -432,10 +432,10 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 <button
                   onClick={handleReset}
                   aria-label="Clear chat history"
-                  className="flex items-center gap-1.5 font-bebas text-[12px] uppercase tracking-[0.15em] transition-colors tabular-nums"
-                  style={{ color: "rgba(180,140,255,0.50)" }}
-                  onMouseEnter={e => (e.currentTarget.style.color = "rgba(180,140,255,0.80)")}
-                  onMouseLeave={e => (e.currentTarget.style.color = "rgba(180,140,255,0.50)")}
+                  className="flex items-center gap-1.5 font-bebas text-[13px] uppercase tracking-[0.15em] transition-colors tabular-nums"
+                  style={{ color: "rgba(180,140,255,0.65)" }}
+                  onMouseEnter={e => (e.currentTarget.style.color = "rgba(180,140,255,0.90)")}
+                  onMouseLeave={e => (e.currentTarget.style.color = "rgba(180,140,255,0.65)")}
                   onMouseDown={e => (e.currentTarget.style.transform = "scale(0.90)")}
                   onMouseUp={e => (e.currentTarget.style.transform = "scale(1)")}
                 >
@@ -447,9 +447,9 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                 onClick={() => { haptics.light(); setIsOpen(false); }}
                 aria-label="Close chat"
                 className="transition-colors p-1"
-                style={{ color: "rgba(255,255,255,0.50)" }}
-                onMouseEnter={e => (e.currentTarget.style.color = "rgba(255,255,255,0.70)")}
-                onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.50)")}
+                style={{ color: "rgba(255,255,255,0.60)" }}
+                onMouseEnter={e => (e.currentTarget.style.color = "rgba(255,255,255,0.80)")}
+                onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.60)")}
                 onMouseDown={e => (e.currentTarget.style.transform = "scale(0.90)")}
                 onMouseUp={e => (e.currentTarget.style.transform = "scale(1)")}
               >
@@ -519,7 +519,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                     {msg.error ? (
                       <p className="text-[16px] leading-relaxed" style={{ color: "rgba(255,255,255,0.50)" }}>{msg.error}</p>
                     ) : (
-                      <p className="text-[18px] text-white leading-[1.75] whitespace-pre-wrap">
+                      <p className="text-[18px] text-white leading-[1.6] whitespace-pre-wrap">
                         {(() => {
                           const displayText = !msg.streaming ? extractSuggestedChips(msg.answer).cleanedAnswer : msg.answer;
                           return displayText.split(/(https?:\/\/[^\s]+)/g).map((part, i) =>
@@ -530,7 +530,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                           );
                         })()}
                         {msg.streaming && !msg.answer && (
-                          <span style={{ color: "rgba(255,255,255,0.40)" }}>Thinking…</span>
+                          <span style={{ color: "rgba(255,255,255,0.55)" }}>Thinking…</span>
                         )}
                       </p>
                     )}
@@ -550,7 +550,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                         {copiedId === msg.id ? (
                           <span className="text-[13px]" style={{ color: "rgba(255,255,255,0.70)" }}>Copied ✅</span>
                         ) : (
-                          <Share2 style={{ width: "15px", height: "15px", color: "rgba(255,255,255,0.30)" }} />
+                          <Share2 style={{ width: "15px", height: "15px", color: "rgba(255,255,255,0.45)" }} />
                         )}
                       </button>
                     </div>
@@ -620,7 +620,7 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
                   onMouseLeave={e => (e.currentTarget.style.opacity = "1")}
                   onMouseDown={e => { e.currentTarget.style.transform = "scale(0.95)"; }}
                   onMouseUp={e => { e.currentTarget.style.transform = "scale(1)"; }}
-                  style={{ background: "linear-gradient(135deg, rgb(75,30,130) 0%, rgb(110,50,170) 100%)", color: "#fff", borderRadius: "0 7px 7px 0" }}
+                  style={{ background: "linear-gradient(180deg, rgb(110,50,170) 0%, rgb(75,30,130) 100%)", color: "#fff", borderRadius: "0 7px 7px 0", boxShadow: "inset 0 1px 1px rgba(255,255,255,0.20), inset 0 -2px 4px rgba(0,0,0,0.3)" }}
                 >
                 <SendHorizonal className="w-5 h-5" />
               </button>
@@ -644,15 +644,15 @@ const OgBotSheet = ({ isOpen: controlledOpen, onOpenChange }: OgBotSheetProps) =
             paddingTop: "4px",
           }}>
             <a href="https://instagram.com/filmmaker.og" target="_blank" rel="noopener noreferrer"
-               style={{ color: "rgba(255,255,255,0.35)", fontSize: "11px", textDecoration: "none" }}>
+               style={{ color: "rgba(255,255,255,0.45)", fontSize: "11px", textDecoration: "none" }}>
               IG
             </a>
             <a href="https://tiktok.com/@filmmaker.og" target="_blank" rel="noopener noreferrer"
-               style={{ color: "rgba(255,255,255,0.35)", fontSize: "11px", textDecoration: "none" }}>
+               style={{ color: "rgba(255,255,255,0.45)", fontSize: "11px", textDecoration: "none" }}>
               TikTok
             </a>
             <a href="https://facebook.com/filmmaker.og" target="_blank" rel="noopener noreferrer"
-               style={{ color: "rgba(255,255,255,0.35)", fontSize: "11px", textDecoration: "none" }}>
+               style={{ color: "rgba(255,255,255,0.45)", fontSize: "11px", textDecoration: "none" }}>
               FB
             </a>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -512,7 +512,7 @@ const Index = () => {
                           <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, rgba(220,38,38,0.35), transparent)", zIndex: 1 }} />
                           <div style={wfBadgeGlow()} />
                           <div style={wfBadge()}>{groupCards[0].tier}</div>
-                          <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "#fff", textTransform: "uppercase", marginBottom: "3px", textAlign: "center" }}>{groupCards[0].name}</div>
+                          <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem", color: "#fff", textTransform: "uppercase", marginBottom: "3px", textAlign: "center" }}>{groupCards[0].name}</div>
                           <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.5rem", color: "rgba(220,38,38,0.88)", textAlign: "center", textShadow: "0 0 16px rgba(220,38,38,0.20)" }}>–${groupCards[0].amount.toLocaleString()}</div>
                         </div>
                         <div
@@ -527,7 +527,7 @@ const Index = () => {
                           <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, rgba(220,38,38,0.35), transparent)", zIndex: 1 }} />
                           <div style={wfBadgeGlow()} />
                           <div style={wfBadge()}>{groupCards[1].tier}</div>
-                          <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "#fff", textTransform: "uppercase", marginBottom: "3px", textAlign: "center" }}>{groupCards[1].name}</div>
+                          <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem", color: "#fff", textTransform: "uppercase", marginBottom: "3px", textAlign: "center" }}>{groupCards[1].name}</div>
                           <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.5rem", color: "rgba(220,38,38,0.88)", textAlign: "center", textShadow: "0 0 16px rgba(220,38,38,0.20)" }}>–${groupCards[1].amount.toLocaleString()}</div>
                         </div>
                       </div>
@@ -547,7 +547,7 @@ const Index = () => {
                           <div style={wfBadge()}>{tier.tier}</div>
                           <div style={{
                             fontFamily: "'Bebas Neue', sans-serif",
-                            fontSize: "1.3rem",
+                            fontSize: "1.4rem",
                             color: "#fff", textTransform: "uppercase", marginBottom: "3px",
                             textAlign: "center",
                           }}>{tier.name}</div>
@@ -632,7 +632,7 @@ const Index = () => {
                 boxShadow: "0 8px 24px rgba(0,0,0,0.4), 0 0 16px rgba(60,179,113,0.10)",
               }}>
                 <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, #3CB371, transparent)" }} />
-                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Investor</div>
+                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Investor</div>
                 <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${splitCountUp.toLocaleString()}</div>
               </div>
               <div style={{
@@ -643,10 +643,31 @@ const Index = () => {
                 boxShadow: "0 8px 24px rgba(0,0,0,0.4), 0 0 16px rgba(60,179,113,0.10)",
               }}>
                 <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg, transparent, #3CB371, transparent)" }} />
-                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.3rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Producer</div>
+                <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem", color: "rgba(255,255,255,0.88)", marginBottom: "6px" }}>Producer</div>
                 <div style={{ fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.8rem", color: "#3CB371", textShadow: "0 0 16px rgba(60,179,113,0.25)" }}>${splitCountUp.toLocaleString()}</div>
               </div>
             </div>
+          </div>
+
+          {/* Micro-CTA — catch engagement at profit reveal */}
+          <div style={{ textAlign: "center", padding: "20px 24px 8px" }}>
+            <span
+              onClick={handleCTA}
+              style={{
+                fontFamily: "'Roboto Mono', monospace",
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "rgba(212,175,55,0.70)",
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+                textShadow: "0 0 12px rgba(212,175,55,0.20)",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.90)"; e.currentTarget.style.textShadow = "0 0 16px rgba(212,175,55,0.35)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.70)"; e.currentTarget.style.textShadow = "0 0 12px rgba(212,175,55,0.20)"; }}
+            >
+              Run your own numbers →
+            </span>
           </div>
 
         </section>
@@ -721,8 +742,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>11-Tier Recoupment Waterfall</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Every deduction from revenue to profit</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>11-Tier Recoupment Waterfall</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Every deduction from revenue to profit</p>
                   </div>
                 </div>
 
@@ -733,8 +754,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Capital Stack Breakdown</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Equity, debt, tax credits, soft money</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Capital Stack Breakdown</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Equity, debt, tax credits, soft money</p>
                   </div>
                 </div>
 
@@ -745,8 +766,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Investor / Producer Profit Split</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>See who gets what after recoupment</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Investor / Producer Profit Split</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>See who gets what after recoupment</p>
                   </div>
                 </div>
 
@@ -763,8 +784,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Off-the-Top Fee Mapping</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Where the money goes before you see a dime</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Off-the-Top Fee Mapping</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Where the money goes before you see a dime</p>
                   </div>
                 </div>
 
@@ -775,8 +796,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Deal Quality Verdict</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Instant read on whether your deal works</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Deal Quality Verdict</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Instant read on whether your deal works</p>
                   </div>
                 </div>
 
@@ -787,8 +808,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Profit & Loss Breakdown</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Total deductions vs. net backend</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Profit & Loss Breakdown</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Total deductions vs. net backend</p>
                   </div>
                 </div>
 
@@ -805,8 +826,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Formatted PDF Export</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Print-ready for meetings and pitches</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Formatted PDF Export</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Print-ready for meetings and pitches</p>
                   </div>
                 </div>
 
@@ -817,8 +838,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Investor-Ready Presentation</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Full waterfall output, presentation-grade</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Investor-Ready Presentation</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Full waterfall output, presentation-grade</p>
                   </div>
                 </div>
 
@@ -829,8 +850,8 @@ const Index = () => {
                     </div>
                   </div>
                   <div style={{ padding: "2px 0 2px 8px", textAlign: "left" }}>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "17px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Deal-Specific Calculations</p>
-                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "14px", color: "rgba(255,255,255,0.50)", lineHeight: 1.4, marginTop: "3px" }}>Every number from your inputs, not templates</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600, color: "rgba(255,255,255,0.92)", lineHeight: 1.35 }}>Deal-Specific Calculations</p>
+                    <p style={{ fontFamily: "'Inter', sans-serif", fontSize: "15px", color: "rgba(255,255,255,0.55)", lineHeight: 1.4, marginTop: "3px" }}>Every number from your inputs, not templates</p>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary

- **MobileMenu.tsx (Serving E):** Kill underlines from nav label text, bump gold atmospheric from 0.06→0.12 and boxShadow from 0.04→0.10 for OLED visibility
- **OgBotSheet.tsx (Serving F):** Remove "deal analyst on call" line from all greeting variants (including reset), bump 8 dim-screen opacity values (share icon, footer links, chips, reset button, close X, thinking text), tighten answer line-height 1.75→1.6, volumetric send button with 180deg gradient + inset shadows
- **Index.tsx (Serving G):** Add gold micro-CTA "Run your own numbers →" after profit split (triggers handleCTA), bump arsenal feature titles 17→18px, descriptors 14px/0.50→15px/0.55, waterfall tier names 1.3→1.4rem

## Test plan

- [ ] No borderBottom on nav label spans, nav cells have visible warm gold tint
- [ ] Gold glow visible around nav cells (boxShadow 0.10)
- [ ] Bot greeting is 3 paragraphs — "deal analyst on call" line gone in all variants
- [ ] Reset produces same 3-paragraph greeting
- [ ] Share icon, footer links, chips, reset button, close X, thinking text all visible at dim brightness
- [ ] Answer text has tighter line spacing (1.6)
- [ ] Send button has volumetric treatment (lighter purple top)
- [ ] Gold "Run your own numbers →" link appears below profit split, triggers auth-gated CTA
- [ ] Arsenal titles 18px, descriptors 15px/0.55, waterfall tier names 1.4rem
- [ ] No 1.3rem instances remain in Index.tsx
- [ ] npm run build passes

https://claude.ai/code/session_01EK57FGxuSkVv7aEVaYnFsr