### PR TITLE
Fix PWA cache staleness with cache-control headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,24 @@
 {
+  "headers": [
+    {
+      "source": "/(.*).html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/" }


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: no-cache, must-revalidate` headers for `/`, `/*.html`, and `/manifest.json` in `vercel.json`
- Forces browsers to revalidate the HTML document on every visit, so users always get the latest deploy without manually clearing cache
- Vite's hashed assets (`/assets/index-abc123.js`) are unaffected — they continue to cache normally since filenames change on each build

## Test plan
- [ ] Deploy ships successfully
- [ ] On mobile: close all tabs, reopen filmmakerog.com — should show latest deploy
- [ ] `curl -I https://filmmakerog.com` shows `Cache-Control: no-cache, must-revalidate`
- [ ] Response headers on `/assets/*.js` do NOT show `no-cache` (still cached normally)

https://claude.ai/code/session_01GA2MW3bo8YfVqNT5nf7GWo