### PR TITLE
Fix store product copy: replace "white-labeled" with "branded" in Pro…

### DIFF
--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -164,7 +164,7 @@ export const products: Product[] = [
       "Individual Investor Return Profiles",
       "One-Page Executive Summary",
       "Deal Terms Summary",
-      "Everything white-labeled to your project",
+      "Everything branded to your project",
     ],
     whatsIncluded: [
       {


### PR DESCRIPTION
…ducer's Package

The Producer's Package features list incorrectly used "white-labeled" instead of "branded" for the project branding description.

https://claude.ai/code/session_01TPf8t4BuCGHB3RvDwxvniq