### PR TITLE
Fix double countdown replay and square edges on mobile

### DIFF
--- a/src/components/calculator/FilmLeaderCountdown.tsx
+++ b/src/components/calculator/FilmLeaderCountdown.tsx
@@ -11,7 +11,11 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
   const flashRef = useRef<HTMLDivElement>(null);
   const cueDotRef = useRef<HTMLDivElement>(null);
   const grainRef = useRef<HTMLDivElement>(null);
+  const onCompleteRef = useRef(onComplete);
   const [isPlaying, setIsPlaying] = useState(true);
+
+  // Keep ref current without retriggering effects
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
 
   const displayTitle = projectTitle.trim() || "WATERFALL SNAPSHOT";
 
@@ -30,8 +34,8 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
   const handleSkip = useCallback(() => {
     if (!isPlaying) return;
     setIsPlaying(false);
-    onComplete();
-  }, [isPlaying, onComplete]);
+    onCompleteRef.current();
+  }, [isPlaying]);
 
   // Run countdown
   useEffect(() => {
@@ -57,7 +61,7 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
           "radial-gradient(circle at 50% 50%, rgba(249,224,118,0.15) 0%, rgba(212,175,55,0.06) 50%, transparent 70%)";
         flash.style.opacity = "1";
         setTimeout(() => { if (!cancelled) flash.style.opacity = "0"; }, 200);
-        setTimeout(() => { if (!cancelled) onComplete(); }, 600);
+        setTimeout(() => { if (!cancelled) onCompleteRef.current(); }, 600);
         return;
       }
 
@@ -118,7 +122,7 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
       clearTimeout(kickoff);
       clearTimeout(beatTimeout);
     };
-  }, [isPlaying, onComplete]);
+  }, [isPlaying]);
 
   // Sprocket holes
   const sprockets = Array.from({ length: 28 }, (_, i) => (

--- a/src/components/calculator/WaterfallDeck.tsx
+++ b/src/components/calculator/WaterfallDeck.tsx
@@ -348,7 +348,7 @@ const CoverSection = ({
           gap: "2px",
           marginBottom: "20px",
           border: "1px solid rgba(255,255,255,0.06)",
-          borderRadius: "4px",
+          borderRadius: "12px",
           overflow: "hidden",
           background: "rgba(255,255,255,0.06)",
         }}>
@@ -380,7 +380,7 @@ const CoverSection = ({
         gap: "2px",
         marginBottom: "2px",
         background: "rgba(255,255,255,0.06)",
-        borderRadius: "4px",
+        borderRadius: "12px",
         overflow: "hidden",
       }}>
         <div style={{ flex: 1, background: "#0A0A0A", padding: "14px" }}>
@@ -413,7 +413,7 @@ const CoverSection = ({
         gap: "2px",
         marginBottom: "2px",
         background: "rgba(255,255,255,0.06)",
-        borderRadius: "4px",
+        borderRadius: "12px",
         overflow: "hidden",
       }}>
         <div style={{ flex: 1, background: "#0A0A0A", padding: "14px" }}>
@@ -448,7 +448,7 @@ const CoverSection = ({
         gap: "2px",
         marginBottom: "24px",
         background: "rgba(255,255,255,0.06)",
-        borderRadius: "4px",
+        borderRadius: "12px",
         overflow: "hidden",
       }}>
         <div style={{
@@ -537,7 +537,7 @@ const CoverSection = ({
         padding: "14px 16px",
         background: "rgba(255,255,255,0.03)",
         border: "1px solid rgba(255,255,255,0.06)",
-        borderRadius: "4px",
+        borderRadius: "12px",
       }}>
         <div style={{
           ...FONT.fine,
@@ -823,7 +823,7 @@ const VisualCluster1 = ({
           <div style={{
             padding: "20px",
             border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: "4px",
+            borderRadius: "12px",
             marginBottom: "20px",
           }}>
             {/* Hero row */}
@@ -834,7 +834,7 @@ const VisualCluster1 = ({
               </span>
             </div>
             {/* Stacked bar */}
-            <div style={{ height: "28px", background: "rgba(255,255,255,0.04)", borderRadius: "4px", display: "flex", overflow: "hidden", marginBottom: "16px" }}>
+            <div style={{ height: "28px", background: "rgba(255,255,255,0.04)", borderRadius: "12px", display: "flex", overflow: "hidden", marginBottom: "16px" }}>
               {erosionItems.map((item) => {
                 const widthPct = erosionTotal > 0 ? (item.amount / erosionTotal) * 100 : 0;
                 return (
@@ -871,7 +871,7 @@ const VisualCluster1 = ({
       <div style={{
         display: "flex", justifyContent: "space-between", alignItems: "center",
         padding: "14px 20px", background: netBg, border: `1px solid ${netBorder}`,
-        borderRadius: "4px", marginBottom: "28px",
+        borderRadius: "12px", marginBottom: "28px",
       }}>
         <span style={{ fontSize: "16px", color: W.tertiary }}>Net to Investors</span>
         <span style={{ ...FONT.data, fontSize: "26px", color: netColor }}>
@@ -886,7 +886,7 @@ const VisualCluster1 = ({
           <div style={{
             display: "flex", flexDirection: "column", gap: "2px",
             marginBottom: "16px", border: "1px solid rgba(255,255,255,0.06)",
-            borderRadius: "4px", overflow: "hidden", background: "rgba(255,255,255,0.06)",
+            borderRadius: "12px", overflow: "hidden", background: "rgba(255,255,255,0.06)",
           }}>
             {sources.map((s) => (
               <div key={s.label} style={{ background: "#0A0A0A", padding: "16px" }}>
@@ -905,7 +905,7 @@ const VisualCluster1 = ({
             ))}
           </div>
           {/* Stacked bar */}
-          <div style={{ height: "24px", borderRadius: "4px", display: "flex", overflow: "hidden", marginBottom: "28px" }}>
+          <div style={{ height: "24px", borderRadius: "12px", display: "flex", overflow: "hidden", marginBottom: "28px" }}>
             {sources.map((s) => {
               const widthPct = inputs.budget > 0 ? (s.amount / inputs.budget) * 100 : 0;
               return (
@@ -931,7 +931,7 @@ const VisualCluster1 = ({
           <div style={{ ...FONT.fine, color: W.tertiary, marginBottom: "12px" }}>SCENARIO STRESS TEST</div>
           <div style={{
             border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: "4px", overflow: "hidden", marginBottom: "20px",
+            borderRadius: "12px", overflow: "hidden", marginBottom: "20px",
           }}>
             <div style={{
               padding: "12px 20px", background: "rgba(255,255,255,0.04)",
@@ -991,7 +991,7 @@ const LockedSensitivitySection = () => (
     <div style={{
       position: "relative",
       border: "1px solid rgba(212,175,55,0.15)",
-      borderRadius: "4px",
+      borderRadius: "12px",
       overflow: "hidden",
     }}>
       {/* Blurred content — reduced blur, higher opacity */}
@@ -1096,7 +1096,7 @@ const LockedSnapshotPlusSection = ({ onUnlock }: { onUnlock: () => void }) => (
       gridTemplateColumns: "1fr 1fr",
       gap: "2px",
       background: "rgba(255,255,255,0.06)",
-      borderRadius: "4px",
+      borderRadius: "12px",
       overflow: "hidden",
       position: "relative",
     }}>
@@ -1139,7 +1139,7 @@ const LockedSnapshotPlusSection = ({ onUnlock }: { onUnlock: () => void }) => (
         alignItems: "center",
         justifyContent: "center",
         background: "radial-gradient(ellipse at center, rgba(212,175,55,0.03) 0%, rgba(0,0,0,0.45) 70%)",
-        borderRadius: "4px",
+        borderRadius: "12px",
       }}>
         <div style={{
           width: "38px",
@@ -1340,7 +1340,7 @@ const VisualCluster2 = ({
       {/* ── DEDUCTIONS LEDGER ── */}
       <div style={{ ...FONT.fine, color: W.tertiary, marginBottom: "12px" }}>GROSS TO NET</div>
       <div style={{
-        border: "1px solid rgba(255,255,255,0.08)", borderRadius: "4px",
+        border: "1px solid rgba(255,255,255,0.08)", borderRadius: "12px",
         overflow: "hidden", marginBottom: "28px",
       }}>
         {/* Header */}
@@ -1433,8 +1433,8 @@ const VisualCluster2 = ({
                   </div>
                   <span style={{ fontSize: "11px", fontWeight: 700, letterSpacing: "0.10em", textTransform: "uppercase" as const, padding: "3px 8px", borderRadius: "3px", ...badgeStyle }}>{badgeText}</span>
                 </div>
-                <div style={{ height: "8px", background: "rgba(255,255,255,0.04)", borderRadius: "4px", overflow: "hidden", marginBottom: "8px" }}>
-                  {fillPct > 0 && <div style={{ height: "100%", width: `${Math.min(100, fillPct)}%`, borderRadius: "4px", background: barGradient }} />}
+                <div style={{ height: "8px", background: "rgba(255,255,255,0.04)", borderRadius: "12px", overflow: "hidden", marginBottom: "8px" }}>
+                  {fillPct > 0 && <div style={{ height: "100%", width: `${Math.min(100, fillPct)}%`, borderRadius: "12px", background: barGradient }} />}
                 </div>
                 <div style={{ display: "flex", justifyContent: "space-between" }}>
                   <span style={{ ...FONT.data, fontSize: "15px", color: W.secondary }}>
@@ -1481,7 +1481,7 @@ const LockedComparableSection = () => (
     <div style={{
       position: "relative",
       border: "1px solid rgba(212,175,55,0.22)",
-      borderRadius: "4px",
+      borderRadius: "12px",
       overflow: "hidden",
     }}>
       {/* Blurred content — fake comp table */}
@@ -1529,7 +1529,7 @@ const LockedComparableSection = () => (
         {/* Fake valuation range bar */}
         <div style={{ marginTop: "16px", marginBottom: "12px" }}>
           <div style={{ height: "6px", width: "50px", background: "rgba(212,175,55,0.18)", borderRadius: "2px", marginBottom: "8px" }} />
-          <div style={{ height: "20px", borderRadius: "4px", display: "flex", overflow: "hidden" }}>
+          <div style={{ height: "20px", borderRadius: "12px", display: "flex", overflow: "hidden" }}>
             <div style={{ width: "25%", height: "100%", background: "rgba(220,38,38,0.20)" }} />
             <div style={{ width: "35%", height: "100%", background: "rgba(240,168,48,0.22)" }} />
             <div style={{ width: "25%", height: "100%", background: "rgba(60,179,113,0.25)" }} />
@@ -1591,7 +1591,7 @@ const LockedInvestorMemoSection = () => (
     <div style={{
       position: "relative",
       border: "1px solid rgba(212,175,55,0.30)",
-      borderRadius: "4px",
+      borderRadius: "12px",
       overflow: "hidden",
       boxShadow: "0 0 30px rgba(212,175,55,0.08), 0 0 60px rgba(120,60,180,0.06)",
     }}>


### PR DESCRIPTION
## Summary

- **Fix double countdown**: Store `onComplete` in a ref so the countdown effect doesn't tear down and restart when the parent re-renders with a new inline callback. Removes `onComplete` from the effect and `useCallback` dependency arrays.
- **Fix square edges**: Replace all `borderRadius: "4px"` → `"12px"` in WaterfallDeck.tsx (20 instances) for visual consistency with the landing page's 12px standard radius. Preserves `2px` (inline elements), `3px 3px 0 0` (bar tops), `50%` (circles), and `6px` (buttons).

## Test plan

- [ ] Run calculator → countdown plays exactly ONCE (3, 2, 1, done)
- [ ] No stutter, restart, or double play on parent re-renders
- [ ] Tap during countdown skips immediately to Cover
- [ ] Navigate away and back — countdown does NOT replay (sessionStorage)
- [ ] KPI rows, assumptions grid, erosion cards, scenario table, locked gate cards all show visible rounded corners
- [ ] Small elements (skeleton loaders, pips) still have tight 2px radius
- [ ] Bar chart tops still have 3px top-only radius
- [ ] Circles (lock icons) still round
- [ ] `npm run build` — no errors
- [ ] Mobile 430px — rounded corners visible on OLED

https://claude.ai/code/session_01Hm244xXDfG7YczcjSUDf8v