### PR TITLE
fix: countdown replaces spinner (no double loading)

### DIFF
--- a/src/components/calculator/WaterfallDeck.tsx
+++ b/src/components/calculator/WaterfallDeck.tsx
@@ -17,7 +17,7 @@ import { supabase } from "@/integrations/supabase/client";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
 import { useHaptics } from "@/hooks/use-haptics";
 import { serializeSnapshot } from "@/lib/serialize-snapshot";
-import FilmLeaderCountdown from "@/components/calculator/FilmLeaderCountdown";
+
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -2063,10 +2063,6 @@ const WaterfallBrief = ({
   project,
   guilds,
 }: WaterfallBriefProps) => {
-  const [showCountdown, setShowCountdown] = useState(
-    () => !sessionStorage.getItem("og-leader-played")
-  );
-
   // Core computations
   const tiers = computeTierPayments(result, inputs);
 
@@ -2076,16 +2072,6 @@ const WaterfallBrief = ({
       maxWidth: "430px",
       margin: "0 auto",
     }}>
-      {showCountdown && (
-        <FilmLeaderCountdown
-          projectTitle={project.title}
-          onComplete={() => {
-            setShowCountdown(false);
-            sessionStorage.setItem("og-leader-played", "1");
-          }}
-        />
-      )}
-
       {/* ═══ 1. TITLE PAGE ═══ */}
       <CoverSection
         project={project}

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -1,6 +1,7 @@
 import { WaterfallResult, WaterfallInputs, GuildState, CapitalSelections, calculateWaterfall } from "@/lib/waterfall";
 import type { ProjectDetails } from "@/pages/Calculator";
 import { Lock, Play, X } from "lucide-react";
+import FilmLeaderCountdown from "@/components/calculator/FilmLeaderCountdown";
 import ChapterCard from "../ChapterCard";
 import StandardStepLayout from "../StandardStepLayout";
 import { useEffect, useState } from "react";
@@ -60,6 +61,10 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
   // State for Demo Mode (if real inputs are empty)
   const isEmpty = initialInputs.budget === 0 || initialInputs.revenue === 0;
   const [isDemoMode, setIsDemoMode] = useState(false);
+  const [shouldPlayCountdown] = useState(
+    () => !sessionStorage.getItem("og-leader-played")
+  );
+  const [countdownPlaying, setCountdownPlaying] = useState(false);
 
   // Use Demo data if active, otherwise real data
   const activeInputs = isDemoMode ? DEMO_INPUTS : initialInputs;
@@ -81,10 +86,19 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
   useEffect(() => {
     if (isLocked) {
       setShowResult(false);
+      setCountdownPlaying(false);
       return;
     }
 
-    // Start Sequence
+    // If countdown should play, skip the spinner — countdown IS the loading animation
+    if (shouldPlayCountdown && !sessionStorage.getItem("og-leader-played")) {
+      setIsCalculating(false);
+      setShowResult(false);
+      setCountdownPlaying(true);
+      return;
+    }
+
+    // Otherwise use the standard spinner
     setIsCalculating(true);
     setShowResult(false);
 
@@ -102,6 +116,13 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
   const handleRunDemo = (e?: React.MouseEvent) => {
     haptics.medium(e);
     setIsDemoMode(true);
+  };
+
+  const handleCountdownComplete = () => {
+    setCountdownPlaying(false);
+    sessionStorage.setItem("og-leader-played", "1");
+    haptics.success();
+    setShowResult(true);
   };
 
   // LOCKED STATE — data card with sell copy
@@ -226,6 +247,14 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
         </div>
       )}
 
+      {/* COUNTDOWN STATE — replaces spinner on first visit */}
+      {countdownPlaying && (
+        <FilmLeaderCountdown
+          projectTitle={activeProject.title}
+          onComplete={handleCountdownComplete}
+        />
+      )}
+
       {/* CALCULATING STATE */}
       {isCalculating && (
         <div
@@ -281,7 +310,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
       )}
 
       {/* RESULT STATE — deck at full width */}
-      {!isCalculating && showResult && (
+      {!isCalculating && !countdownPlaying && showResult && (
         <div className="animate-reveal-up">
           {/* Demo banner */}
           {isDemoMode && (


### PR DESCRIPTION
## Summary
- Moved `FilmLeaderCountdown` from `WaterfallDeck` to `WaterfallTab` so the countdown **replaces** the spinner on first visit instead of stacking two loading animations back-to-back
- On subsequent visits (same session), the existing 1500ms spinner plays as before
- Added `countdownPlaying` guard to prevent result from rendering during countdown

## Flow
- **First visit:** effect detects countdown hasn't played → skips spinner, shows countdown → on complete, result renders immediately
- **Return visit:** sessionStorage flag set → standard spinner → result

## Test plan
- [ ] First visit: countdown plays, NO spinner before or after it
- [ ] Countdown completes → output appears immediately (no second loading)
- [ ] Second visit (same session): spinner plays, no countdown
- [ ] Demo mode first visit: countdown plays with demo project title
- [ ] Demo mode second visit: spinner plays, no countdown
- [ ] Tap to skip works during countdown
- [ ] `npm run build` — no errors

https://claude.ai/code/session_01NSUP2jvxRJ42Z3TohojitV