### PR TITLE
fix: portal countdown to document.body to escape transform containing…

### DIFF
--- a/src/components/calculator/FilmLeaderCountdown.tsx
+++ b/src/components/calculator/FilmLeaderCountdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface FilmLeaderCountdownProps {
   projectTitle: string;
@@ -133,7 +134,7 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
     }} />
   ));
 
-  return (
+  return createPortal(
     <div
       onClick={handleSkip}
       style={{
@@ -320,7 +321,8 @@ const FilmLeaderCountdown = ({ projectTitle, onComplete }: FilmLeaderCountdownPr
           100% { transform: translateY(100vh); }
         }
       `}</style>
-    </div>
+    </div>,
+    document.body
   );
 };
 


### PR DESCRIPTION
… block

CSS transforms on the tab animation wrapper create a new containing block, causing position:fixed on the countdown to be relative to the wrapper instead of the viewport. Using createPortal renders it at document.body.

https://claude.ai/code/session_01NSUP2jvxRJ42Z3TohojitV