### PR TITLE
fix: reset stale countdown flag for Chrome Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.next
+next-env.d.ts
 *.local
 
 # Environment variables

--- a/src/components/calculator/tabs/WaterfallTab.tsx
+++ b/src/components/calculator/tabs/WaterfallTab.tsx
@@ -62,7 +62,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
   const isEmpty = initialInputs.budget === 0 || initialInputs.revenue === 0;
   const [isDemoMode, setIsDemoMode] = useState(false);
   const [shouldPlayCountdown] = useState(
-    () => !sessionStorage.getItem("og-leader-played")
+    () => !sessionStorage.getItem("og-leader-v2")
   );
   const [countdownPlaying, setCountdownPlaying] = useState(false);
 
@@ -91,7 +91,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
     }
 
     // If countdown should play, skip the spinner — countdown IS the loading animation
-    if (shouldPlayCountdown && !sessionStorage.getItem("og-leader-played")) {
+    if (shouldPlayCountdown && !sessionStorage.getItem("og-leader-v2")) {
       setIsCalculating(false);
       setShowResult(false);
       setCountdownPlaying(true);
@@ -120,7 +120,7 @@ const WaterfallTab = ({ result: initialResult, inputs: initialInputs, project, g
 
   const handleCountdownComplete = () => {
     setCountdownPlaying(false);
-    sessionStorage.setItem("og-leader-played", "1");
+    sessionStorage.setItem("og-leader-v2", "1");
     haptics.success();
     setShowResult(true);
   };


### PR DESCRIPTION
## Summary

- Renames sessionStorage key from `og-leader-played` to `og-leader-v2` in WaterfallTab.tsx (3 instances)
- Chrome Android doesn't clear sessionStorage when browsing data is cleared if the tab is still alive in background, so the stale flag from the first broken deploy (PR #528) was preventing the countdown from ever playing again
- This makes the old stuck key irrelevant so the film leader countdown plays on next visit

## Test plan

- [ ] Open filmmakerog.com on the Pixel WITHOUT clearing anything
- [ ] Navigate to calculator output (demo mode or real inputs)
- [ ] Film leader countdown should play — 3, 2, 1, reveal
- [ ] Second visit in same session: spinner, no countdown
- [ ] `npm run build` — no errors

https://claude.ai/code/session_0122ADtj4TbK4kpYuTEezquc