### PR TITLE
Store card redesign: 2-tier collapse + glass + grouped features + volumetric CTAs

### DIFF
--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -31,7 +31,8 @@ export interface Product {
   turnaround?: string;
   shortDescription: string;
   fullDescription: string;
-  features: string[];
+  features: (string | { title: string; subtitle: string; group: string })[];
+  reassurance?: string;
   whatsIncluded: { title: string; body: string }[];
   whoItsFor: string;
   pickThisIf: string | null;
@@ -60,11 +61,13 @@ export const products: Product[] = [
     fullDescription:
       "Your complete financial model — budget, capital stack, waterfall, deal terms, and scenario analysis — presented as a single, designed document that any investor can pick up and understand.\n\nSensitivity modeling across five market conditions shows how your deal performs when the price moves. Not a single scenario — a stress-tested range.\n\nRun your numbers. We make them investor-ready.",
     features: [
-      "Unified Financial Presentation (PDF)",
-      "Budget, capital stack, waterfall, scenarios — one document",
-      "Sensitivity analysis across 5 market conditions",
-      "White-labeled with your company and project",
+      { title: "Complete Financial Model", subtitle: "Every section of your deal in one document", group: "Analyze" },
+      { title: "Sensitivity Modeling", subtitle: "What happens when the acquisition price changes", group: "Analyze" },
+      { title: "Investor Return Profiles", subtitle: "How your investors make money and when", group: "Analyze" },
+      { title: "White-Labeled Branding", subtitle: "Your company name on every page", group: "Present" },
+      { title: "Institutional Design", subtitle: "Hand it to your attorney. Hand it to your investor. It holds up.", group: "Present" },
     ],
+    reassurance: "ONE-TIME PURCHASE · INSTANT DELIVERY",
     whatsIncluded: [
       {
         title: "Unified Financial Presentation (PDF)",
@@ -79,7 +82,7 @@ export const products: Product[] = [
         body: "Your production company name and project title on every page. Your project, your brand.",
       },
     ],
-    pickThisIf: "you need the numbers documented — clean, professional, stress-tested",
+    pickThisIf: "Your numbers documented, stress-tested, investor-ready.",
     whoItsFor:
       "Producers who have their numbers modeled and need a professional document to reference, send, or attach. When someone asks for the numbers, this is what you hand them.",
     upgradePrompt: {
@@ -106,11 +109,12 @@ export const products: Product[] = [
     fullDescription:
       "The question every investor asks: \"Why is this film worth that?\"\n\nWe research 5 comparable acquisition deals in your genre, budget range, and cast tier. Each comp includes the buyer, reported price range, key deal characteristics, and why it's relevant to your project.\n\nYou get a defensible valuation range with methodology your investors can follow — not a number you made up, but a number grounded in transactions that actually happened.\n\nUpgrade to 10 comps for $995 for a deeper dataset and broader market coverage.",
     features: [
-      "Buyer, price range, and deal characteristics per comp",
-      "Defensible valuation range with methodology",
-      "Market positioning analysis",
-      "Revenue scenarios tied to real transactions",
+      { title: "Comparable Acquisition Deals", subtitle: "Buyer, price range, and deal terms per comp", group: "Research" },
+      { title: "Defensible Valuation Range", subtitle: "Methodology your investors can follow, not a number you made up", group: "Research" },
+      { title: "Market Positioning Analysis", subtitle: "Where your project sits in the current landscape", group: "Evidence" },
+      { title: "Revenue Scenarios", subtitle: "Three scenarios mapped to actual transactions", group: "Evidence" },
     ],
+    reassurance: "ONE-TIME PURCHASE · DELIVERED IN 48 HOURS",
     whatsIncluded: [
       {
         title: "Comparable Acquisition Research",
@@ -129,7 +133,7 @@ export const products: Product[] = [
         body: "Where your project sits in the current acquisition landscape — which buyers are active, what the market supports, and what elements of your package strengthen your position.",
       },
     ],
-    pickThisIf: "you need to defend a valuation with real transaction data",
+    pickThisIf: "Defend a valuation with deals that actually closed.",
     whoItsFor:
       "Producers who need evidence behind their asking price. The Comp Report turns your valuation from an assumption into a defensible number backed by deals that actually closed.",
     upgradePrompt: {
@@ -156,16 +160,13 @@ export const products: Product[] = [
     fullDescription:
       "Tell us about your project. We build the full investor package.\n\nCustom lookbook with visual identity tailored to your film — tone boards, cast packaging, genre positioning, the visual narrative that shows investors this project is real. Alongside the complete financial package — every document from The Full Analysis, plus a presentation-ready PowerPoint pitch deck with speaker notes, plus 10 comparable acquisition deals defending your valuation.\n\nWe build it. You walk into the room.\n\n3-5 business day turnaround after intake.",
     features: [
-      "Custom Lookbook — tone, cast, genre, visual identity",
-      "Pitch Deck (PowerPoint) with speaker notes",
-      "Enhanced Financial Presentation (PDF)",
-      "10 Comparable Acquisition Deals",
-      "Market Valuation Range & Methodology",
-      "Individual Investor Return Profiles",
-      "One-Page Executive Summary",
-      "Deal Terms Summary",
-      "Everything branded to your project",
+      { title: "Custom Lookbook", subtitle: "Tone, cast, genre, visual identity for your film", group: "Build" },
+      { title: "Pitch Deck With Speaker Notes", subtitle: "10-12 slides ready for the room", group: "Build" },
+      { title: "Enhanced Financial Presentation", subtitle: "Elevated design beyond the standard PDF", group: "Build" },
+      { title: "10 Comparable Acquisition Deals", subtitle: "Real transactions defending your valuation", group: "Defend" },
+      { title: "Everything Branded to Your Project", subtitle: "Your company and project name throughout", group: "Defend" },
     ],
+    reassurance: "3-5 BUSINESS DAY TURNAROUND",
     whatsIncluded: [
       {
         title: "Custom Lookbook",
@@ -200,7 +201,7 @@ export const products: Product[] = [
         body: "All deal terms structured for attorney review and investor due diligence.",
       },
     ],
-    pickThisIf: "you want the full treatment — turnkey, custom, ready for the room",
+    pickThisIf: "The complete investor package, built for your project.",
     whoItsFor:
       "Producers with an investor meeting on the calendar — or the conviction to go get one. The complete set of materials that institutional capital expects to see, built by someone who knows what belongs in the room.",
     upgradePrompt: {
@@ -228,11 +229,11 @@ export const products: Product[] = [
     fullDescription:
       "For projects that need more than the standard package covers.\n\nBoutique engagements are scoped per project — specialized research, alternative deal structures, extended market analysis, multi-territory distribution strategies, or anything else that requires custom work.\n\nStarts at $2,997. Priced per engagement based on scope.\n\nReach out to discuss your project.",
     features: [
-      "Everything in The Producer's Package",
-      "Custom scope per engagement",
-      "Specialized research and analysis",
-      "Email-based collaboration",
+      { title: "Everything in The Producer's Package", subtitle: "Full baseline included", group: "Includes" },
+      { title: "Custom Scope Per Engagement", subtitle: "Tailored to your project's specific needs", group: "Includes" },
+      { title: "Specialized Research and Analysis", subtitle: "Multi-territory, alternative structures, extended market work", group: "Includes" },
     ],
+    reassurance: "SCOPED PER ENGAGEMENT",
     whatsIncluded: [
       {
         title: "Everything in The Producer's Package",
@@ -243,7 +244,7 @@ export const products: Product[] = [
         body: "Additional deliverables scoped to your project — specialized research, alternative deal structures, extended market analysis, multi-territory strategies, or other custom work.",
       },
     ],
-    pickThisIf: "your deal is complex enough that standard packages don\u2019t fit \u2014 multi-territory, unusual structures, custom research scope",
+    pickThisIf: "Custom scope beyond the standard package.",
     whoItsFor:
       "Producers with complex financing structures, multi-territory deals, or projects that need specialized analysis beyond the standard package.",
     upgradePrompt: null,

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Mail, X as XIcon, Clock, ChevronDown } from "lucide-react";
 
 import { useHaptics } from "@/hooks/use-haptics";
@@ -336,11 +336,16 @@ const s: Record<string, React.CSSProperties> = {
    ═══════════════════════════════════════════════════════════════════ */
 const tierStyles = {
   gold: {
+    id: "gold" as const,
     card: {
       border: "none",
-      background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.16) 0%, #0A0A0A 70%)",
-      boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 40px rgba(212,175,55,0.12)",
+      background: "radial-gradient(ellipse at 50% 0%, rgba(212,175,55,0.16) 0%, rgba(6,6,6,0.92) 70%)",
+      backdropFilter: "blur(40px)",
+      WebkitBackdropFilter: "blur(40px)",
+      boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 30px rgba(212,175,55,0.12), 0 0 20px rgba(120,60,180,0.10), 0 0 60px rgba(212,175,55,0.04)",
     },
+    atmosphericTop: "radial-gradient(ellipse 100% 80% at 50% 0%, rgba(212,175,55,0.12) 0%, transparent 70%)",
+    atmosphericBottom: "radial-gradient(ellipse 100% 80% at 50% 100%, rgba(120,60,180,0.08) 0%, transparent 70%)",
     gradientBorder: "linear-gradient(180deg, rgba(212,175,55,0.55) 0%, rgba(212,175,55,0.20) 50%, rgba(212,175,55,0.40) 100%)",
     topline: {
       height: "1px",
@@ -359,36 +364,17 @@ const tierStyles = {
     btnRest: { boxShadow: "0 0 20px rgba(212,175,55,0.35), 0 0 50px rgba(212,175,55,0.10)" } as Record<string, string>,
     hoverLift: "-2px",
   },
-  green: {
-    card: {
-      border: "none",
-      background: "radial-gradient(ellipse at 50% 0%, rgba(60,179,113,0.15) 0%, #0A0A0A 70%)",
-      boxShadow: "0 16px 40px rgba(0,0,0,0.5), 0 0 40px rgba(60,179,113,0.10)",
-    },
-    gradientBorder: "linear-gradient(180deg, rgba(60,179,113,0.50) 0%, rgba(60,179,113,0.20) 50%, rgba(60,179,113,0.35) 100%)",
-    topline: {
-      height: "1px",
-      background: "linear-gradient(90deg, transparent, rgba(60,179,113,0.50), transparent)",
-      boxShadow: "0 0 12px rgba(60,179,113,0.3)",
-    },
-    headerBorder: "1px solid rgba(60,179,113,0.12)",
-    headerBg: undefined as string | undefined,
-    subdivider: "linear-gradient(90deg, transparent, rgba(60,179,113,0.12), transparent)",
-    featureCheck: { color: "#3CB371", textShadow: "0 0 12px rgba(60,179,113,0.4)" },
-    pickThis: { color: "rgba(60,179,113,0.80)" },
-    price: { color: "#3CB371" },
-    badge: { color: "#3CB371", background: "rgba(60,179,113,0.08)", border: "1px solid rgba(60,179,113,0.30)" },
-    btn: "btnGreenSolid" as const,
-    btnHover: { boxShadow: "0 0 28px rgba(60,179,113,0.50), 0 0 70px rgba(60,179,113,0.15)" } as Record<string, string>,
-    btnRest: { boxShadow: "0 0 20px rgba(60,179,113,0.35), 0 0 50px rgba(60,179,113,0.10)" } as Record<string, string>,
-    hoverLift: "-4px",
-  },
   purple: {
+    id: "purple" as const,
     card: {
       border: "none",
-      background: "radial-gradient(ellipse at 50% 0%, rgba(120,60,180,0.22) 0%, rgba(212,175,55,0.06) 30%, #0A0A0A 70%)",
-      boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 50px rgba(120,60,180,0.18)",
+      background: "radial-gradient(ellipse at 50% 0%, rgba(120,60,180,0.12) 0%, rgba(6,6,6,0.92) 70%)",
+      backdropFilter: "blur(40px)",
+      WebkitBackdropFilter: "blur(40px)",
+      boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 30px rgba(120,60,180,0.12), 0 0 20px rgba(212,175,55,0.06)",
     },
+    atmosphericTop: "radial-gradient(ellipse 100% 80% at 50% 0%, rgba(120,60,180,0.10) 0%, transparent 70%)",
+    atmosphericBottom: "radial-gradient(ellipse 100% 80% at 50% 100%, rgba(212,175,55,0.08) 0%, transparent 70%)",
     gradientBorder: "linear-gradient(180deg, rgba(212,175,55,0.45) 0%, rgba(212,175,55,0.15) 40%, rgba(120,60,180,0.30) 70%, rgba(120,60,180,0.50) 100%)",
     topline: {
       height: "2px",
@@ -406,39 +392,13 @@ const tierStyles = {
     btnRest: { background: "rgba(120,60,180,0.05)", borderColor: "rgba(120,60,180,0.30)" } as Record<string, string>,
     hoverLift: "-2px",
   },
-  purpleTop: {
-    card: {
-      border: "none",
-      background: "radial-gradient(ellipse at 50% 0%, rgba(120,60,180,0.25) 0%, rgba(212,175,55,0.08) 30%, #0A0A0A 70%)",
-      boxShadow: "0 16px 40px rgba(0,0,0,0.8), 0 0 60px rgba(120,60,180,0.25), 0 0 120px rgba(212,175,55,0.10)",
-    },
-    gradientBorder: "linear-gradient(180deg, rgb(110,50,170) 0%, rgba(120,60,180,0.5) 30%, rgba(212,175,55,0.4) 70%, #D4AF37 100%)",
-    topline: {
-      height: "3px",
-      background: "linear-gradient(90deg, transparent, rgb(110,50,170), #D4AF37, transparent)",
-    },
-    headerBorder: "1px solid rgba(120,60,180,0.15)",
-    headerBg: "radial-gradient(ellipse at 50% 100%, rgba(120,60,180,0.06) 0%, transparent 70%)",
-    subdivider: "linear-gradient(90deg, transparent, rgba(120,60,180,0.15), transparent)",
-    featureCheck: { color: "rgb(160,100,255)", textShadow: "0 0 14px rgba(140,80,240,0.5)" },
-    pickThis: { color: "rgba(180,140,255,0.80)" },
-    price: {},
-    badge: { color: "rgb(180,140,255)", background: "rgba(120,60,180,0.10)", border: "1px solid rgba(120,60,180,0.35)", boxShadow: "0 0 12px rgba(120,60,180,0.10)" },
-    btn: "btnPurple" as const,
-    btnHover: { boxShadow: "0 0 32px rgba(120,60,180,0.50), 0 0 80px rgba(212,175,55,0.15)" } as Record<string, string>,
-    btnRest: { boxShadow: "0 0 24px rgba(120,60,180,0.35), 0 0 60px rgba(212,175,55,0.10)" } as Record<string, string>,
-    hoverLift: "-4px",
-  },
 };
 
 const z2: React.CSSProperties = { position: "relative", zIndex: 2 };
 
 const getTier = (product: Product) => {
-  if (product.id === "the-full-analysis") return tierStyles.gold;
-  if (product.id === "comp-report") return tierStyles.green;
-  if (product.id === "boutique") return tierStyles.purpleTop;
   if (product.category === "service") return tierStyles.purple;
-  return tierStyles.gold; // fallback
+  return tierStyles.gold;
 };
 
 
@@ -471,6 +431,10 @@ const shimmerCSS = `
   0% { background-position: -200% center; }
   100% { background-position: 200% center; }
 }
+@keyframes storeShimmer {
+  0% { left: -100%; }
+  100% { left: 200%; }
+}
 @keyframes faqOpen {
   from { opacity: 0; transform: translateY(-5px); }
   to { opacity: 1; transform: translateY(0); }
@@ -500,6 +464,60 @@ const EyebrowRuled = ({ text }: { text: string }) => (
     <span style={s.eyebrowLabel}>{text}</span>
     <div style={s.eyebrowLine} />
   </div>
+);
+
+
+/* ═══════════════════════════════════════════════════════════════════
+   FEATURE GROUP + COMET TAIL
+   ═══════════════════════════════════════════════════════════════════ */
+const FeatureGroup = ({ features, groupName }: { features: { title: string; subtitle: string }[]; groupName: string }) => (
+  <>
+    <p style={{
+      fontFamily: "'Bebas Neue', sans-serif", fontSize: "1.4rem",
+      color: "#D4AF37", letterSpacing: "0.06em",
+      margin: 0, marginBottom: "16px", paddingLeft: "52px", textAlign: "left" as const,
+      textShadow: "0 0 12px rgba(212,175,55,0.15)",
+    }}>{groupName}</p>
+    {features.map((feat, i) => (
+      <div key={feat.title} style={{
+        display: "grid", gridTemplateColumns: "50px 1fr", alignItems: "start",
+        marginBottom: i === features.length - 1 ? "4px" : "14px",
+      }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", paddingTop: "4px" }}>
+          <div style={{
+            width: "34px", height: "34px", borderRadius: "50%",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            background: "radial-gradient(circle at 50% 40%, rgba(60,179,113,0.20) 0%, rgba(60,179,113,0.06) 100%)",
+            border: "1px solid rgba(60,179,113,0.30)",
+            boxShadow: "0 0 12px rgba(60,179,113,0.25), 0 0 24px rgba(60,179,113,0.10)",
+          }}>
+            <span style={{
+              fontSize: "18px", color: "#3CB371",
+              textShadow: "0 0 8px rgba(60,179,113,0.70), 0 0 16px rgba(60,179,113,0.35)",
+            }}>&#10003;</span>
+          </div>
+        </div>
+        <div style={{ padding: "2px 24px 2px 8px", textAlign: "left" as const }}>
+          <p style={{
+            fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 600,
+            color: "rgba(255,255,255,0.92)", lineHeight: 1.35, margin: 0,
+          }}>{feat.title}</p>
+          <p style={{
+            fontFamily: "'Inter', sans-serif", fontSize: "15px",
+            color: "rgba(255,255,255,0.55)", lineHeight: 1.4, margin: "3px 0 0 0",
+          }}>{feat.subtitle}</p>
+        </div>
+      </div>
+    ))}
+  </>
+);
+
+const CometTail = () => (
+  <div style={{
+    height: "1px",
+    background: "linear-gradient(90deg, rgba(212,175,55,0.25) 0%, transparent 100%)",
+    margin: "20px 0 20px 50px",
+  }} />
 );
 
 
@@ -717,6 +735,47 @@ const WorkingModelPopup = ({
 /* ═══════════════════════════════════════════════════════════════════
    PRODUCT CARD — self-serve tiers (1-2)
    ═══════════════════════════════════════════════════════════════════ */
+const btnGoldVol: React.CSSProperties = {
+  position: "relative" as const, overflow: "hidden" as const,
+  width: "100%", padding: "22px 0", borderRadius: "8px",
+  border: "none", cursor: "pointer",
+  fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 700,
+  letterSpacing: "0.08em", textTransform: "uppercase" as const,
+  color: "#000", textAlign: "center" as const, display: "block" as const,
+  background: "linear-gradient(180deg, #D4AF37 0%, #B8962E 100%)",
+  boxShadow: "inset 0 1px 1px rgba(255,255,255,0.30), inset 0 -2px 4px rgba(0,0,0,0.3), 0 0 0 1px rgba(212,175,55,0.60), 0 8px 24px rgba(0,0,0,0.5), 0 0 40px rgba(212,175,55,0.45), 0 0 20px rgba(212,175,55,0.15)",
+  textShadow: "0 1px 0 rgba(255,255,255,0.15)",
+};
+
+const btnGoldVolSecondary: React.CSSProperties = {
+  ...btnGoldVol,
+  padding: "16px 0", fontSize: "16px",
+  background: "linear-gradient(180deg, rgba(212,175,55,0.80) 0%, rgba(184,150,46,0.80) 100%)",
+  boxShadow: "inset 0 1px 1px rgba(255,255,255,0.20), inset 0 -2px 4px rgba(0,0,0,0.2), 0 0 0 1px rgba(212,175,55,0.40), 0 4px 16px rgba(0,0,0,0.4), 0 0 20px rgba(212,175,55,0.15)",
+  marginTop: "10px",
+};
+
+const btnPurpleVol: React.CSSProperties = {
+  position: "relative" as const, overflow: "hidden" as const,
+  width: "100%", padding: "22px 0", borderRadius: "8px",
+  border: "none", cursor: "pointer",
+  fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 700,
+  letterSpacing: "0.08em", textTransform: "uppercase" as const,
+  color: "#fff", textAlign: "center" as const, display: "block" as const,
+  background: "linear-gradient(180deg, rgb(110,50,170) 0%, rgb(75,30,130) 100%)",
+  boxShadow: "inset 0 1px 1px rgba(255,255,255,0.25), inset 0 -2px 4px rgba(0,0,0,0.4), 0 0 0 1px rgba(212,175,55,0.30), 0 8px 24px rgba(0,0,0,0.5), 0 0 40px rgba(120,60,180,0.45), 0 0 20px rgba(212,175,55,0.12)",
+  textShadow: "0 2px 4px rgba(0,0,0,0.5)",
+};
+
+const btnSnapshotOutline: React.CSSProperties = {
+  width: "100%", padding: "22px 0", borderRadius: "8px",
+  border: "1px solid rgba(212,175,55,0.30)", cursor: "pointer",
+  fontFamily: "'Inter', sans-serif", fontSize: "18px", fontWeight: 700,
+  letterSpacing: "0.08em", textTransform: "uppercase" as const,
+  color: "#D4AF37", textAlign: "center" as const, display: "block" as const,
+  background: "rgba(212,175,55,0.05)",
+};
+
 const ProductCard = ({
   product,
   onBuy,
@@ -734,6 +793,9 @@ const ProductCard = ({
   const haptics = useHaptics();
   const isComp = product.id === "comp-report";
   const tier = getTier(product);
+  const isSnapshot = product.id === "snapshot-plus";
+  const tierPriceColor = tier.id === "purple" ? "rgb(180,140,255)" : "#D4AF37";
+  const tierReassuranceColor = tier.id === "purple" ? "rgba(180,140,255,0.50)" : "rgba(212,175,55,0.50)";
 
   const cardStyle: React.CSSProperties = {
     ...s.cardBase,
@@ -758,87 +820,111 @@ const ProductCard = ({
       {/* Topline */}
       <div style={{ ...tier.topline, ...z2 }} />
 
-      {/* Header */}
-      <div style={{ ...s.cardHeader, borderBottom: tier.headerBorder, ...z2 }}>
-        {product.badge && (
-          <div style={{ marginBottom: "12px" }}>
+      {/* Atmospheric canopies */}
+      <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "50%", background: tier.atmosphericTop, pointerEvents: "none" }} />
+      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "50%", background: tier.atmosphericBottom, pointerEvents: "none" }} />
+
+      {/* === FAST TOP === */}
+      <div style={{ ...s.cardHeader, borderBottom: "1px solid rgba(212,175,55,0.20)", ...z2 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "12px" }}>
+          {product.badge && (
             <span style={{ ...s.badgeBase, ...tier.badge }}>{product.badge}</span>
-          </div>
-        )}
+          )}
+          {product.turnaround && (
+            <span style={s.turnaroundBadge}>
+              <Clock style={{ width: "12px", height: "12px", color: "rgba(212,175,55,0.7)" }} />
+              {product.turnaround}
+            </span>
+          )}
+        </div>
         <h3 style={s.cardName}>{product.name.toUpperCase()}</h3>
         {product.pickThisIf && (
-          <p style={{ ...s.pickThisIf, ...tier.pickThis }}>Pick this one if {product.pickThisIf}</p>
+          <p style={{ ...s.pickThisIf, ...tier.pickThis, fontSize: "18px" }}>{product.pickThisIf}</p>
         )}
       </div>
 
-      {/* Price block */}
-      <div style={{ ...s.priceBlock, ...z2 }}>
-        {isComp ? (
-          <CompPricingBlock />
+      {/* === EDITORIAL MIDDLE — Features === */}
+      <div style={{ ...s.featuresBlock, padding: "24px 0 0 0", ...z2 }}>
+        {(() => {
+          const structured = product.features.filter(
+            (f): f is { title: string; subtitle: string; group: string } => typeof f !== "string"
+          );
+          if (structured.length === 0) {
+            return (product.features as string[]).map((feature) => (
+              <div key={feature} style={s.featureRow}>
+                <span style={{ ...s.featureCheck, ...tier.featureCheck }}>&#10003;</span>
+                <span style={s.featureText}>{feature}</span>
+              </div>
+            ));
+          }
+          const groups = [...new Set(structured.map(f => f.group))];
+          return groups.map((group, gi) => (
+            <React.Fragment key={group}>
+              {gi > 0 && <CometTail />}
+              <FeatureGroup
+                groupName={group}
+                features={structured.filter(f => f.group === group)}
+              />
+            </React.Fragment>
+          ));
+        })()}
+      </div>
+
+      {/* === COMMERCE BOTTOM === */}
+      <div style={{ ...s.actionBlock, padding: "24px 24px 36px", ...z2 }}>
+        {/* Price */}
+        <div style={{ textAlign: "center", marginBottom: "20px" }}>
+          <span style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "3rem", fontWeight: 700, color: tierPriceColor, letterSpacing: "0.02em" }}>
+            ${product.price.toLocaleString()}
+          </span>
+        </div>
+
+        {/* CTA */}
+        {isSnapshot ? (
+          <button
+            onClick={(e) => { haptics.medium(e); onBuy(); }}
+            style={btnSnapshotOutline}
+            onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
+            onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
+          >
+            {product.ctaLabel}
+          </button>
         ) : (
-          <>
-            <span style={{ ...s.priceStandard, ...tier.price }}>
-              ${product.price.toLocaleString()}
-            </span>
-            {product.priceNote && (
-              <span style={s.priceNote}>
-                {product.priceNote}
-              </span>
-            )}
-          </>
+          <button
+            onClick={(e) => { haptics.medium(e); onBuy(); }}
+            style={btnGoldVol}
+            onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
+            onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
+          >
+            <span style={{ position: "relative", zIndex: 1 }}>{product.ctaLabel}</span>
+            <div style={{
+              position: "absolute", top: 0, left: "-100%", width: "55%", height: "100%",
+              pointerEvents: "none",
+              background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.20), transparent)",
+              transform: "skewX(-20deg)",
+              animation: "storeShimmer 2.5s cubic-bezier(0.4, 0, 0.2, 1) infinite",
+            }} />
+          </button>
         )}
-        <p style={s.shortDesc}>{product.shortDescription}</p>
-      </div>
-
-      {/* Subdivider */}
-      <div style={{ ...s.subdivider, background: tier.subdivider, ...z2 }} />
-
-      {/* Features */}
-      <div style={{ ...s.featuresBlock, ...z2 }}>
-        {product.features.map((feature) => (
-          <div key={feature} style={s.featureRow}>
-            <span style={{ ...s.featureCheck, ...tier.featureCheck }}>✓</span>
-            <span style={s.featureText}>{feature}</span>
-          </div>
-        ))}
-      </div>
-
-      {/* Action */}
-      <div style={{ ...s.actionBlock, ...z2 }}>
-        <button
-          onClick={(e) => { haptics.medium(e); onBuy(); }}
-          style={s[tier.btn]}
-          onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
-          onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
-          onMouseEnter={(e) => { if (tier.btnHover.background) e.currentTarget.style.background = tier.btnHover.background; if (tier.btnHover.borderColor) e.currentTarget.style.borderColor = tier.btnHover.borderColor; if (tier.btnHover.boxShadow) e.currentTarget.style.boxShadow = tier.btnHover.boxShadow; }}
-          onMouseLeave={(e) => { if (tier.btnRest.background) e.currentTarget.style.background = tier.btnRest.background; if (tier.btnRest.borderColor) e.currentTarget.style.borderColor = tier.btnRest.borderColor; if (tier.btnRest.boxShadow) e.currentTarget.style.boxShadow = tier.btnRest.boxShadow; }}
-        >
-          {product.ctaLabel}
-        </button>
         {onBuySecondary && (
           <button
             onClick={(e) => { haptics.medium(e); onBuySecondary(); }}
-            style={s.btnGreenSecondary}
+            style={btnGoldVolSecondary}
             onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
             onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(60,179,113,0.08)"; e.currentTarget.style.borderColor = "rgba(60,179,113,0.25)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(60,179,113,0.03)"; e.currentTarget.style.borderColor = "rgba(60,179,113,0.15)"; }}
           >
-            OR GET 5 COMPS — $595
+            <span style={{ position: "relative", zIndex: 1 }}>GET 5 COMPS &middot; $595</span>
           </button>
         )}
-        <button
-          onClick={(e) => {
-            haptics.light(e);
-            e.stopPropagation();
-            window.location.href = `/store/${product.slug}`;
-          }}
-          style={s.detailsLink}
-          onMouseEnter={(e) => { (e.currentTarget.style.color = "#fff"); }}
-          onMouseLeave={(e) => { (e.currentTarget.style.color = "rgba(255,255,255,0.85)"); }}
-        >
-          See full details →
-        </button>
+
+        {/* Reassurance */}
+        {product.reassurance && (
+          <p style={{
+            fontFamily: "'Roboto Mono', monospace", fontSize: "13px",
+            color: tierReassuranceColor, letterSpacing: "0.12em",
+            textTransform: "uppercase", textAlign: "center", margin: "14px 0 0 0",
+          }}>{product.reassurance}</p>
+        )}
       </div>
     </div>
   );
@@ -862,6 +948,9 @@ const ServiceCard = ({
   const [hovered, setHovered] = useState(false);
   const haptics = useHaptics();
   const tier = getTier(product);
+  const isBoutique = product.id === "boutique";
+  const tierPriceColor = "rgb(180,140,255)";
+  const tierReassuranceColor = "rgba(180,140,255,0.50)";
 
   const cardStyle: React.CSSProperties = {
     ...s.cardBase,
@@ -886,82 +975,92 @@ const ServiceCard = ({
       {/* Topline */}
       <div style={{ ...tier.topline, ...z2 }} />
 
-      {/* Header */}
-      <div style={{
-        ...s.cardHeader,
-        borderBottom: tier.headerBorder,
-        ...(tier.headerBg ? { background: tier.headerBg } : {}),
-        ...z2,
-      }}>
-        {product.badge && (
-          <div style={{ marginBottom: "12px" }}>
-            <span style={{ ...s.badgeBase, ...tier.badge }}>{product.badge}</span>
-          </div>
-        )}
-        <h3 style={s.cardName}>{product.name.toUpperCase()}</h3>
-        {product.pickThisIf && (
-          <p style={{ ...s.pickThisIf, ...tier.pickThis }}>Pick this one if {product.pickThisIf}</p>
-        )}
-      </div>
+      {/* Atmospheric canopies */}
+      <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "50%", background: tier.atmosphericTop, pointerEvents: "none" }} />
+      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "50%", background: tier.atmosphericBottom, pointerEvents: "none" }} />
 
-      {/* Price block + turnaround */}
-      <div style={{ ...s.priceBlock, ...z2 }}>
-        <span style={{ ...s.priceStandard, ...tier.price }}>
-          ${product.price.toLocaleString()}
-        </span>
-        {product.priceNote && (
-          <span style={s.priceNote}>
-            {product.priceNote}
-          </span>
-        )}
-        {product.turnaround && (
-          <div style={{ marginTop: "8px" }}>
+      {/* === FAST TOP === */}
+      <div style={{ ...s.cardHeader, borderBottom: "1px solid rgba(120,60,180,0.20)", ...z2 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "12px" }}>
+          {product.badge && (
+            <span style={{ ...s.badgeBase, ...tier.badge }}>{product.badge}</span>
+          )}
+          {product.turnaround && (
             <span style={s.turnaroundBadge}>
               <Clock style={{ width: "12px", height: "12px", color: "rgba(212,175,55,0.7)" }} />
               {product.turnaround}
             </span>
-          </div>
+          )}
+        </div>
+        <h3 style={s.cardName}>{product.name.toUpperCase()}</h3>
+        {product.pickThisIf && (
+          <p style={{ ...s.pickThisIf, ...tier.pickThis, fontSize: "18px" }}>{product.pickThisIf}</p>
         )}
-        <p style={s.shortDesc}>{product.shortDescription}</p>
       </div>
 
-      {/* Subdivider */}
-      <div style={{ ...s.subdivider, background: tier.subdivider, ...z2 }} />
-
-      {/* Features */}
-      <div style={{ ...s.featuresBlock, ...z2 }}>
-        {product.features.map((feature) => (
-          <div key={feature} style={s.featureRow}>
-            <span style={{ ...s.featureCheck, ...tier.featureCheck }}>✓</span>
-            <span style={s.featureText}>{feature}</span>
-          </div>
-        ))}
+      {/* === EDITORIAL MIDDLE — Features === */}
+      <div style={{ ...s.featuresBlock, padding: "24px 0 0 0", ...z2 }}>
+        {(() => {
+          const structured = product.features.filter(
+            (f): f is { title: string; subtitle: string; group: string } => typeof f !== "string"
+          );
+          if (structured.length === 0) {
+            return (product.features as string[]).map((feature) => (
+              <div key={feature} style={s.featureRow}>
+                <span style={{ ...s.featureCheck, ...tier.featureCheck }}>&#10003;</span>
+                <span style={s.featureText}>{feature}</span>
+              </div>
+            ));
+          }
+          const groups = [...new Set(structured.map(f => f.group))];
+          return groups.map((group, gi) => (
+            <React.Fragment key={group}>
+              {gi > 0 && <CometTail />}
+              <FeatureGroup
+                groupName={group}
+                features={structured.filter(f => f.group === group)}
+              />
+            </React.Fragment>
+          ));
+        })()}
       </div>
 
-      {/* Action */}
-      <div style={{ ...s.actionBlock, ...z2 }}>
+      {/* === COMMERCE BOTTOM === */}
+      <div style={{ ...s.actionBlock, padding: "24px 24px 36px", ...z2 }}>
+        {/* Price */}
+        <div style={{ textAlign: "center", marginBottom: "20px" }}>
+          <span style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "3rem", fontWeight: 700, color: tierPriceColor, letterSpacing: "0.02em" }}>
+            ${product.price.toLocaleString()}+
+          </span>
+        </div>
+
+        {/* CTA */}
         <button
           onClick={(e) => { haptics.medium(e); onBuy(); }}
-          style={s[tier.btn]}
+          style={btnPurpleVol}
           onMouseDown={(e) => { (e.currentTarget.style.transform = "scale(0.98)"); }}
           onMouseUp={(e) => { (e.currentTarget.style.transform = "scale(1)"); }}
-          onMouseEnter={(e) => { if (tier.btnHover.background) e.currentTarget.style.background = tier.btnHover.background; if (tier.btnHover.borderColor) e.currentTarget.style.borderColor = tier.btnHover.borderColor; if (tier.btnHover.boxShadow) e.currentTarget.style.boxShadow = tier.btnHover.boxShadow; }}
-          onMouseLeave={(e) => { if (tier.btnRest.background) e.currentTarget.style.background = tier.btnRest.background; if (tier.btnRest.borderColor) e.currentTarget.style.borderColor = tier.btnRest.borderColor; if (tier.btnRest.boxShadow) e.currentTarget.style.boxShadow = tier.btnRest.boxShadow; }}
         >
-          {product.ctaLabel}
+          <span style={{ position: "relative", zIndex: 1 }}>{product.ctaLabel}</span>
+          {!isBoutique && (
+            <div style={{
+              position: "absolute", top: 0, left: "-100%", width: "55%", height: "100%",
+              pointerEvents: "none",
+              background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
+              transform: "skewX(-20deg)",
+              animation: "storeShimmer 2.5s cubic-bezier(0.4, 0, 0.2, 1) infinite",
+            }} />
+          )}
         </button>
-        <button
-          onClick={(e) => {
-            haptics.light(e);
-            e.stopPropagation();
-            window.location.href = `/store/${product.slug}`;
-          }}
-          style={s.detailsLink}
-          onMouseEnter={(e) => { (e.currentTarget.style.color = "#fff"); }}
-          onMouseLeave={(e) => { (e.currentTarget.style.color = "rgba(255,255,255,0.85)"); }}
-        >
-          See full details →
-        </button>
+
+        {/* Reassurance */}
+        {product.reassurance && (
+          <p style={{
+            fontFamily: "'Roboto Mono', monospace", fontSize: "13px",
+            color: tierReassuranceColor, letterSpacing: "0.12em",
+            textTransform: "uppercase", textAlign: "center", margin: "14px 0 0 0",
+          }}>{product.reassurance}</p>
+        )}
       </div>
     </div>
   );
@@ -982,7 +1081,7 @@ const FaqItem = ({
 }) => {
   const haptics = useHaptics();
   return (
-  <div style={{ borderBottom: "1px solid rgba(212,175,55,0.15)" }}>
+  <div style={{ borderBottom: "1px solid rgba(212,175,55,0.25)" }}>
     <button
       onClick={(e) => { haptics.light(e); onToggle(); }}
       aria-expanded={isOpen}
@@ -1179,7 +1278,7 @@ const Store = () => {
           background: "rgba(6,6,6,0.92)",
           backdropFilter: "blur(40px)",
           WebkitBackdropFilter: "blur(40px)",
-          border: "1px solid rgba(212,175,55,0.12)",
+          border: "1px solid rgba(212,175,55,0.20)",
           boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15)",
           ...reveal(heroVisible),
         }}>
@@ -1189,7 +1288,6 @@ const Store = () => {
             background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.22) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.16) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 60%)",
           }} />
           <div style={{ position: "relative", zIndex: 1 }}>
-            <EyebrowRuled text="On Demand" />
             <h1 style={{
               fontFamily: "'Bebas Neue', sans-serif",
               fontSize: "4.2rem",
@@ -1205,17 +1303,6 @@ const Store = () => {
                 textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
               }}>Investor-Ready.</span>
             </h1>
-            <p style={{
-              fontFamily: "'Bebas Neue', sans-serif",
-              fontSize: "1.5rem",
-              lineHeight: 1.1,
-              color: "#fff",
-              textAlign: "center",
-              marginTop: 8,
-              textShadow: "0 2px 12px rgba(0,0,0,0.9)",
-            }}>
-              Run The Numbers. Own The Presentation.
-            </p>
           </div>
         </section>
       </div>
@@ -1497,7 +1584,7 @@ const Store = () => {
         ref={footerRef}
         style={{
           background: "#0A0A0A",
-          borderTop: "1px solid rgba(212,175,55,0.12)",
+          borderTop: "1px solid rgba(212,175,55,0.20)",
           padding: "32px 24px 40px",
           ...reveal(footerVisible),
         }}
@@ -1514,9 +1601,9 @@ const Store = () => {
           </a>
         </div>
         <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px", marginBottom: "16px" }}>
-          <span onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "12px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }} onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.60)"; }} onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.35)"; }}>Shop</span>
-          <span style={{ color: "rgba(212,175,55,0.20)", fontSize: "12px" }}>·</span>
-          <span onClick={() => window.location.href = "/resources"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "12px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }} onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.60)"; }} onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.35)"; }}>Resources</span>
+          <span onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "13px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.50)", cursor: "pointer", transition: "color 0.2s ease" }} onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.60)"; }} onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.50)"; }}>Shop</span>
+          <span style={{ color: "rgba(212,175,55,0.20)", fontSize: "13px" }}>·</span>
+          <span onClick={() => window.location.href = "/resources"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: "13px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.50)", cursor: "pointer", transition: "color 0.2s ease" }} onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.60)"; }} onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(212,175,55,0.50)"; }}>Resources</span>
         </div>
         <p style={{
           fontFamily: "'Inter', sans-serif",


### PR DESCRIPTION
## Summary

- **Serving 1 — Data Migration**: Features migrated from `string[]` to structured `{title, subtitle, group}` objects with union type for backwards compat. Updated `pickThisIf` values (killed "Pick this one if" prefix). Added `reassurance` field to Product type.
- **Serving 2 — Tier Collapse**: 4-tier system (gold/green/purple/purpleTop) collapsed to 2-tier (gold for on-demand + research, purple for services). Deleted `green` and `purpleTop` tier definitions. Simplified `getTier` routing.
- **Serving 3 — Glass Surfaces**: Card backgrounds updated from solid `#0A0A0A` to `rgba(6,6,6,0.92)` with `backdropFilter: blur(40px)`. Dual atmospheric canopies (gold top + purple bottom on gold cards, inverse on purple cards) added as tier-driven data properties.
- **Serving 4 — Feature Rendering**: New `FeatureGroup` component with Bebas Neue gold group headers, green circled checkmarks with glow, two-line title/subtitle layout. `CometTail` dividers between groups. Fallback rendering for any remaining string features.
- **Serving 5 — Zone Reorder + CTA**: Card zones reordered to Fast Top → Editorial Middle (features) → Commerce Bottom (price + CTA). Volumetric gradient CTAs (`btnGoldVol`, `btnPurpleVol`) with shimmer animation. Centered 3rem price. Reassurance text below CTA. Comp Report gets secondary CTA. Boutique CTA has no shimmer. Killed "See full details →" link and subdivider.
- **Serving 6 — Hero/FAQ/Footer**: Killed hero eyebrow and subtitle. Hero + footer borders updated to 0.20. FAQ borders to gold 0.25. Footer nav links to 13px / `rgba(212,175,55,0.50)`.

## Test plan

- [ ] TypeScript compiles with no errors
- [ ] All four main product cards render (Full Analysis, Comp Report, Producer's Package, Boutique)
- [ ] Gold cards show gold atmospheric top + subtle purple bottom
- [ ] Purple cards show purple atmospheric top + subtle gold bottom
- [ ] Features render in groups with gold Bebas headers and green circled checkmarks
- [ ] Comet tail appears between groups, not after the last group
- [ ] CTAs have volumetric depth and shimmer animation (2.5s cycle)
- [ ] Boutique CTA has no shimmer
- [ ] Comp Report shows two CTAs (primary + secondary "GET 5 COMPS · $595")
- [ ] Price centered at 3rem in Commerce zone
- [ ] Reassurance text appears below CTA
- [ ] Hero has no eyebrow or subtitle
- [ ] FAQ borders are gold (0.25)
- [ ] Footer nav links are 13px with gold 0.50 color
- [ ] No references to green/purpleTop tiers remain
- [ ] Press state (scale 0.98) works on all CTAs
- [ ] No Android touch issues with backdropFilter

https://claude.ai/code/session_01RZVA1nVLphs3LhaaRedMTh