### PR TITLE
Hero canopy boost: replace single weak canopy with two-layer system

### DIFF
--- a/LANDING_PAGE_REFERENCE (1).md
+++ b/LANDING_PAGE_REFERENCE (1).md
@@ -239,9 +239,9 @@ Purple is NOT a hex constant. It lives as `rgba(120,60,180,opacity)` or as the C
 | 0.15 | Section canopy base, badge grid bg, closer glow, eyebrow glow, reality bottom canopy, arsenal atmospheric (bottom) |
 | 0.18 | How header bg, badge card warmth base, blockquote bottom atmospheric, reality bottom canopy |
 | 0.20 | Section canopy standard, hero glow (bottom radial) |
-| 0.22 | Why canopy (warmer), closer glow overlay (bottom), arsenal card boxShadow |
+| 0.22 | Why canopy (warmer), closer glow overlay (bottom), arsenal card boxShadow, **hero page-top wash (new — 120px, 140% wide)** |
 | 0.24 | Hero glow (bottom radial — **increased from 0.20**) |
-| 0.25 | Section borders, stepper border, arsenal canopy (warmest) |
+| 0.25 | Section borders, stepper border, arsenal canopy (warmest), **hero canopy (new — 220px, boosted from 0.18)** |
 | 0.28 | Hero glow (center bridge — **increased from 0.16**), step icon bg radial |
 | 0.30 | Reality check grid border |
 | 0.40 | Arsenal gradient border |
@@ -827,7 +827,7 @@ Footer text: Inter 14px, white 0.48.
 - Do NOT use the old Arsenal feature names (list was rewritten — see §5 data above)
 - Do NOT remove the mid-waterfall CTA (it's at the emotional peak of the profit reveal)
 - Do NOT change "CAM Fee" back to "CAMA Fee" (corrected terminology)
-- Do NOT add a page-level canopy to §1 hero — all atmospheric warmth comes from internal glass card glow
+- §1 hero now uses a two-layer canopy system: page-top wash (0.22, 120px) + hero canopy (0.25, 220px) — stacks additively with internal glass card glow
 - Do NOT change §1 hero padding away from 24/24/16 — this is the canonical standard
 
 ---

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -376,8 +376,9 @@ const Index = () => {
       <div style={{ minHeight: "100vh", background: "#000", paddingTop: "24px", maxWidth: "430px", margin: "0 auto" }}>
 
         {/* ═══ § 1 HERO ═══ */}
+        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "120px", background: "radial-gradient(ellipse 140% 100% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 80%)", pointerEvents: "none", zIndex: 0 }} />
         <div style={{ position: "relative" }}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "160px", background: "radial-gradient(ellipse 120% 100% at 50% 0%, rgba(120,60,180,0.18) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "220px", background: "radial-gradient(ellipse 120% 100% at 50% 0%, rgba(120,60,180,0.25) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
         </div>
         <section ref={heroRef} style={styles.hero}>
           <div style={styles.heroGlow} />


### PR DESCRIPTION
Page-top wash (0.22, 120px, 140% wide) + hero canopy (0.25, 220px) replace the old single 0.18/160px canopy. Layers stack additively so the hero reads at least as warm as peer sections. Updated reference doc.

https://claude.ai/code/session_01Ahkk7YQGsQNGPdRZoNbWC4