### PR TITLE
fix: bake hero glow gradients into background to fix compositing

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -376,12 +376,21 @@ const Index = () => {
       <div style={{ minHeight: "100vh", background: "#000", paddingTop: "24px", maxWidth: "430px", margin: "0 auto" }}>
 
         {/* ═══ § 1 HERO ═══ */}
-        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "120px", background: "radial-gradient(ellipse 140% 100% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 80%)", pointerEvents: "none", zIndex: 0 }} />
+        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 160% 60% at 50% 0%, rgba(120,60,180,0.30) 0%, transparent 70%), radial-gradient(ellipse 120% 80% at 50% 30%, rgba(120,60,180,0.18) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
         <div style={{ position: "relative" }}>
           <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "220px", background: "radial-gradient(ellipse 120% 100% at 50% 0%, rgba(120,60,180,0.25) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
         </div>
+        {/* Bleed glow — soft emission behind card, extends past border-radius */}
+        <div style={{ position: "relative", margin: "0 24px", pointerEvents: "none" }}>
+          <div style={{
+            position: "absolute",
+            top: "-24px", left: "-20px", right: "-20px", bottom: "-24px",
+            background: "radial-gradient(ellipse 100% 35% at 50% 0%, rgba(212,175,55,0.20) 0%, transparent 70%), radial-gradient(ellipse 50% 40% at 90% 15%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(ellipse 100% 40% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 65%), radial-gradient(ellipse 40% 40% at 10% 85%, rgba(120,60,180,0.15) 0%, transparent 60%)",
+            filter: "blur(16px)",
+            zIndex: 0,
+          }} />
+        </div>
         <section ref={heroRef} style={styles.hero}>
-          <div style={styles.heroGlow} />
           <div style={{ ...styles.heroInner, ...reveal(heroVisible) }}>
             <h1 style={styles.heroH1}>
               Model Your
@@ -1121,15 +1130,11 @@ const styles: Record<string, React.CSSProperties> = {
     margin: "0 24px",
     borderRadius: "12px",
     overflow: "hidden",
-    background: "rgba(6,6,6,0.85)",
+    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.40) 0%, transparent 60%), radial-gradient(ellipse 40% 40% at 80% 20%, rgba(120,60,180,0.40) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.45) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.35) 0%, transparent 60%), rgba(6,6,6,0.85)",
     backdropFilter: "blur(40px)",
     WebkitBackdropFilter: "blur(40px)",
     border: "1px solid rgba(212,175,55,0.20)",
     boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15), 0 0 60px rgba(120,60,180,0.12)",
-  },
-  heroGlow: {
-    position: "absolute", top: 0, left: 0, right: 0, bottom: 0, pointerEvents: "none",
-    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.35) 0%, transparent 60%), radial-gradient(ellipse 40% 40% at 80% 20%, rgba(120,60,180,0.35) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.40) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.30) 0%, transparent 60%)",
   },
   heroInner: { position: "relative", zIndex: 1 },
   heroH1: {


### PR DESCRIPTION
Move 4 radial gradients from separate heroGlow overlay div into the hero card's background property, eliminating the backdrop-filter compositing issue that dampened glow intensity. Add bleed glow div with blur(16px) behind the card for soft edge emission past border-radius. Boost page-top canopy wash from single to dual radial gradient at increased opacity and height.

https://claude.ai/code/session_01XRCKkdFPCvaqscnJ9miQGR