### PR TITLE
fix: balance hero purple haze with symmetric gradients

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -376,7 +376,7 @@ const Index = () => {
       <div style={{ minHeight: "100vh", background: "#000", paddingTop: "24px", maxWidth: "430px", margin: "0 auto" }}>
 
         {/* ═══ § 1 HERO ═══ */}
-        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 160% 60% at 50% 0%, rgba(120,60,180,0.30) 0%, transparent 70%), radial-gradient(ellipse 120% 80% at 50% 30%, rgba(120,60,180,0.18) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
+        <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "280px", background: "radial-gradient(ellipse 150% 80% at 50% 0%, rgba(120,60,180,0.30) 0%, transparent 65%), radial-gradient(ellipse 60% 50% at 80% 10%, rgba(212,175,55,0.12) 0%, transparent 60%)", pointerEvents: "none", zIndex: 0 }} />
         <div style={{ position: "relative" }}>
           <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "220px", background: "radial-gradient(ellipse 120% 100% at 50% 0%, rgba(120,60,180,0.25) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
         </div>
@@ -385,7 +385,7 @@ const Index = () => {
           <div style={{
             position: "absolute",
             top: "-24px", left: "-20px", right: "-20px", bottom: "-24px",
-            background: "radial-gradient(ellipse 100% 35% at 50% 0%, rgba(212,175,55,0.20) 0%, transparent 70%), radial-gradient(ellipse 50% 40% at 90% 15%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(ellipse 100% 40% at 50% 100%, rgba(120,60,180,0.20) 0%, transparent 65%), radial-gradient(ellipse 40% 40% at 10% 85%, rgba(120,60,180,0.15) 0%, transparent 60%)",
+            background: "radial-gradient(ellipse 80% 40% at 50% 0%, rgba(212,175,55,0.14) 0%, transparent 60%), radial-gradient(ellipse 80% 40% at 50% 0%, rgba(120,60,180,0.14) 0%, transparent 60%), radial-gradient(ellipse 100% 60% at 50% 100%, rgba(120,60,180,0.18) 0%, transparent 65%)",
             filter: "blur(16px)",
             zIndex: 0,
           }} />
@@ -1130,11 +1130,11 @@ const styles: Record<string, React.CSSProperties> = {
     margin: "0 24px",
     borderRadius: "12px",
     overflow: "hidden",
-    background: "radial-gradient(ellipse 80% 50% at 50% 10%, rgba(212,175,55,0.40) 0%, transparent 60%), radial-gradient(ellipse 40% 40% at 80% 20%, rgba(120,60,180,0.40) 0%, transparent 60%), radial-gradient(ellipse 60% 40% at 50% 50%, rgba(120,60,180,0.45) 0%, transparent 60%), radial-gradient(ellipse 100% 70% at 50% 100%, rgba(120,60,180,0.35) 0%, transparent 60%), rgba(6,6,6,0.85)",
+    background: "radial-gradient(ellipse 70% 30% at 50% 0%, rgba(212,175,55,0.20) 0%, transparent 55%), radial-gradient(ellipse 100% 40% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(circle at 50% 50%, rgba(120,60,180,0.30) 0%, transparent 60%), radial-gradient(ellipse 100% 50% at 50% 100%, rgba(120,60,180,0.22) 0%, transparent 65%), rgba(6,6,6,0.85)",
     backdropFilter: "blur(40px)",
     WebkitBackdropFilter: "blur(40px)",
     border: "1px solid rgba(212,175,55,0.20)",
-    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 20px rgba(120,60,180,0.15), 0 0 60px rgba(120,60,180,0.12)",
+    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 30px rgba(120,60,180,0.20), 0 0 60px rgba(120,60,180,0.12)",
   },
   heroInner: { position: "relative", zIndex: 1 },
   heroH1: {


### PR DESCRIPTION
Simplify hero background from 4 asymmetric gradients to 4 balanced ones: gold kiss at top (0.20), purple top pool (0.22), purple center haze (0.30), purple bottom pool (0.22). Bump purple boxShadow glow 0.15→0.20. Extend canopy to 280px with gold accent. Simplify bleed glow to 3 balanced layers with purple at top matching bottom.

https://claude.ai/code/session_01XRCKkdFPCvaqscnJ9miQGR