### PR TITLE
Fix hero contour emission: kill bleed div, boost purple, add 6-layer …

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -377,19 +377,6 @@ const Index = () => {
 
         {/* ═══ § 1 HERO ═══ */}
         <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "280px", background: "radial-gradient(ellipse 150% 80% at 50% 0%, rgba(120,60,180,0.30) 0%, transparent 65%), radial-gradient(ellipse 60% 50% at 80% 10%, rgba(212,175,55,0.12) 0%, transparent 60%)", pointerEvents: "none", zIndex: 0 }} />
-        <div style={{ position: "relative" }}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "220px", background: "radial-gradient(ellipse 120% 100% at 50% 0%, rgba(120,60,180,0.25) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
-        </div>
-        {/* Bleed glow — soft emission behind card, extends past border-radius */}
-        <div style={{ position: "relative", margin: "0 24px", pointerEvents: "none" }}>
-          <div style={{
-            position: "absolute",
-            top: "-24px", left: "-20px", right: "-20px", bottom: "-24px",
-            background: "radial-gradient(ellipse 80% 40% at 50% 0%, rgba(212,175,55,0.14) 0%, transparent 60%), radial-gradient(ellipse 80% 40% at 50% 0%, rgba(120,60,180,0.14) 0%, transparent 60%), radial-gradient(ellipse 100% 60% at 50% 100%, rgba(120,60,180,0.18) 0%, transparent 65%)",
-            filter: "blur(16px)",
-            zIndex: 0,
-          }} />
-        </div>
         <section ref={heroRef} style={styles.hero}>
           <div style={{ ...styles.heroInner, ...reveal(heroVisible) }}>
             <h1 style={styles.heroH1}>
@@ -1127,14 +1114,14 @@ const styles: Record<string, React.CSSProperties> = {
   hero: {
     position: "relative", textAlign: "center",
     padding: "24px 24px 16px",
-    margin: "0 24px",
+    margin: "8px 24px 0",
     borderRadius: "12px",
     overflow: "hidden",
-    background: "radial-gradient(ellipse 70% 30% at 50% 0%, rgba(212,175,55,0.20) 0%, transparent 55%), radial-gradient(ellipse 100% 40% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(circle at 50% 50%, rgba(120,60,180,0.30) 0%, transparent 60%), radial-gradient(ellipse 100% 50% at 50% 100%, rgba(120,60,180,0.22) 0%, transparent 65%), rgba(6,6,6,0.85)",
+    background: "radial-gradient(ellipse 70% 30% at 50% 0%, rgba(212,175,55,0.20) 0%, transparent 55%), radial-gradient(ellipse 100% 40% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 60%), radial-gradient(circle at 50% 50%, rgba(120,60,180,0.35) 0%, transparent 60%), radial-gradient(ellipse 100% 50% at 50% 100%, rgba(120,60,180,0.22) 0%, transparent 65%), rgba(6,6,6,0.85)",
     backdropFilter: "blur(40px)",
     WebkitBackdropFilter: "blur(40px)",
     border: "1px solid rgba(212,175,55,0.20)",
-    boxShadow: "0 16px 40px rgba(0,0,0,0.6), 0 0 24px rgba(212,175,55,0.10), 0 0 30px rgba(120,60,180,0.20), 0 0 60px rgba(120,60,180,0.12)",
+    boxShadow: "0 -16px 50px rgba(120,60,180,0.18), 0 20px 50px rgba(120,60,180,0.18), 0 -10px 35px rgba(212,175,55,0.10), 0 16px 40px rgba(0,0,0,0.6), 0 0 30px rgba(120,60,180,0.22), 0 0 80px rgba(120,60,180,0.15)",
   },
   heroInner: { position: "relative", zIndex: 1 },
   heroH1: {


### PR DESCRIPTION
…boxShadow

- Remove second canopy wrapper and rectangular bleed glow div from render
- Replace flat 4-layer boxShadow with 6-layer contour emission that follows border-radius
- Boost center purple haze from 0.30 to 0.35 opacity
- Add 8px top margin for breathing room between pill nav and hero card

https://claude.ai/code/session_01EqUWWqEawiwfdfvEnYTMsR