### PR TITLE
Atmospheric arc: retune canopy opacities and gold header haze for scr…

### DIFF
--- a/LANDING_PAGE_REFERENCE (1).md
+++ b/LANDING_PAGE_REFERENCE (1).md
@@ -70,7 +70,7 @@ Most sections have an atmospheric gradient at the top — a purple radial that c
 }} />
 ```
 
-Opacity varies by section importance: 0.20 standard, 0.22 for Why, 0.25 for Arsenal. Height varies: 200px standard, 180px for Reality (tighter), 240px for Arsenal (most dramatic).
+Opacity and height follow the **Atmospheric Arc** (see §12A below). Values range from 0.10 (Reality — coldest) to 0.28 (Arsenal — hottest). Height ranges from 160px (Reality) to 260px (Arsenal). Reality has NO bottom canopy. Closer has a NEW canopy (0.22, 120% wide ellipse).
 
 ---
 
@@ -849,4 +849,40 @@ Footer text: Inter 14px, white 0.48.
 |------|-----|-------------|
 | March 21 | — | Initial extraction (v16.4, commit d293e0e) |
 | March 25 | #519-526 | CTA volumetric redesign (Inter 700, 180deg, inset shadows), hero glow boost, hero subtitle killed, container paddingTop 24px, How padding 36px, Arsenal card rebuild (grid checkmarks, title+subtitle features, dual atmospheric, comet dividers, cascade animations), Arsenal CTA killed, mid-waterfall CTA added, profit split count-up animation, WITH/WITHOUT slide animations, 4 new keyframes, copy corrections (CAM, feature rewrites), waterfall tier names 1.3→1.4rem |
-| March 27 | — | Closer: baked-in haze (4 radials, glass 0.85, border 0.30, 6-layer contour boxShadow, closerGlowOverlay killed). Arsenal: baked-in atmospheric (gold top 0.14 + purple bottom 0.18, overlay divs killed). Atmospheric warmth hierarchy documented: Hero > Closer > Arsenal |
+| March 27 | — | Closer: baked-in haze (4 radials, glass 0.85, border 0.30, 6-layer contour boxShadow, closerGlowOverlay killed). Arsenal: baked-in atmospheric (gold top 0.14 + purple bottom 0.18, overlay divs killed). Atmospheric warmth hierarchy documented: Hero > Closer > Arsenal. **Atmospheric Arc system** — canopy opacities retuned per scroll position (PEAK→dip→build→build→PEAK→DROP→PEAK), gold header haze escalation (0.08→0.08→0.10→0.12), Reality bottom canopy killed, Closer canopy added |
+
+---
+
+## 12A. ATMOSPHERIC ARC SYSTEM
+
+The landing page uses a deliberate atmospheric arc that controls emotional temperature through scroll position. The pattern is: **PEAK → dip → build → build → PEAK → DROP → PEAK**.
+
+### Canopy Scroll Map (top-to-bottom)
+
+| Section | Opacity | Height | Arc Position | Notes |
+|---------|---------|--------|--------------|-------|
+| §1 Hero | rich (reference) | — | PEAK | No change — baked-in multi-layer system |
+| §2 How | 0.15 | 200px | dip | Cool breather after hero intensity |
+| §3 Waterfall | 0.18 | 200px | build | Slight warmth increase — dread building |
+| §4 Why | 0.22 | 200px | build | Stakes escalating (unchanged from prior) |
+| §5 Arsenal | 0.28 | 260px | PEAK | Hottest non-bookend section — peak before the drop |
+| §6 Reality | 0.10 | 160px | DROP | Clinical cold. Top canopy barely visible. **No bottom canopy** (intentionally killed) |
+| §7 Closer | 0.22 | 200px | PEAK | Warmth floods back. NEW canopy (120% wide ellipse, 80% tall) |
+
+### Gold Header Haze (escalating scale)
+
+| Section | Gold Opacity | Label |
+|---------|-------------|-------|
+| §2 How | 0.08 | "THE PROCESS" |
+| §3 Waterfall | 0.08 | "HOW THE MONEY FLOWS" |
+| §4 Why | 0.10 | "WHY THIS MATTERS" |
+| §5 Arsenal | 0.12 | "WHAT YOU GET" |
+| §6 Reality | none | Clinical — no gold haze |
+| §7 Closer | none | Gold baked into card, not header |
+
+### Design Intent
+
+- **The Drop:** Arsenal → Reality is the key emotional beat. Arsenal is the warmest (0.28, 260px), then Reality strips nearly everything (0.10, 160px, no bottom canopy). This temperature shock makes the WITH/WITHOUT grid feel clinical and stark.
+- **The Return:** Reality → Closer brings warmth back (0.22 canopy). The CTA lives in restored warmth after the cold truth.
+- **Gold escalation** builds subconscious "value accumulation" — by the time you reach Arsenal (0.12), the gold feels earned.
+- **Reality has no gold** — intentional. The truth section should feel unadorned.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -399,7 +399,7 @@ const Index = () => {
 
         {/* ═══ § 2 HOW IT WORKS ═══ */}
         <section ref={howRef} style={styles.howSection}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.20) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.15) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
           <div style={{ ...styles.howHeader, ...reveal(howVisible) }}>
             <EyebrowRuled text="The Process" />
             <h2 style={styles.howH2}>Build in <span style={{ color: "#D4AF37" }}>Minutes</span></h2>
@@ -428,7 +428,7 @@ const Index = () => {
 
         {/* ═══ § 3 WATERFALL — v14 Card-Based Rebuild ═══ */}
         <section ref={(el) => { waterfallSectionRef.current = el; }} style={styles.waterfallSection}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.20) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.18) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
 
           {/* Header */}
           <div ref={waterfallHeaderRef} style={{ ...styles.waterfallHeader, ...reveal(waterfallHeaderVisible) }}>
@@ -748,7 +748,7 @@ const Index = () => {
 
         {/* ═══ § 5 ARSENAL ═══ */}
         <section style={styles.arsenalSection}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "240px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.25) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "260px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.28) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
           <div ref={arsenalHeaderRef} style={{ ...styles.arsenalHeader, ...reveal(arsenalHeaderVisible) }}>
             <EyebrowRuled text="What you get" />
             <h2 style={styles.arsenalH2}>The <span style={{ color: "#D4AF37" }}>Snapshot</span></h2>
@@ -923,8 +923,7 @@ const Index = () => {
 
         {/* ═══ § 6 REALITY ═══ */}
         <section style={styles.realitySection}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "180px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.20) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
-          <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: "240px", background: "radial-gradient(ellipse 80% 100% at 30% 100%, rgba(120,60,180,0.18) 0%, transparent 65%)", pointerEvents: "none", zIndex: 0 }} />
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "160px", background: "radial-gradient(ellipse 100% 70% at 50% 0%, rgba(120,60,180,0.10) 0%, transparent 70%)", pointerEvents: "none", zIndex: 0 }} />
           <div
             ref={realityQuoteRef}
             style={{
@@ -994,6 +993,9 @@ const Index = () => {
         <div style={{ height: "3px", background: "linear-gradient(to right, transparent 0%, rgba(120,60,180,0.50) 20%, rgba(212,175,55,0.40) 50%, rgba(120,60,180,0.50) 80%, transparent 100%)", boxShadow: "0 0 8px rgba(120,60,180,0.35), 0 0 20px rgba(120,60,180,0.20)", margin: "0 24px" }} />
 
         {/* ═══ § 7 CLOSER ═══ */}
+        <div style={{ position: "relative" }}>
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "200px", background: "radial-gradient(ellipse 120% 80% at 50% 0%, rgba(120,60,180,0.22) 0%, transparent 65%)", pointerEvents: "none", zIndex: 0 }} />
+        </div>
         <section ref={closerRef} style={{ ...styles.closerSection, ...reveal(closerVisible) }}>
           <h2 style={styles.closerH2}>Your Investors<br /><span style={{ color: "#D4AF37", display: "block", textShadow: "0 0 40px rgba(212,175,55,0.60), 0 0 80px rgba(212,175,55,0.25)" }}>Will Ask.</span></h2>
           <p style={styles.closerBody}>Stop guessing your backend. Walk into every pitch knowing exactly where the money goes.</p>
@@ -1108,7 +1110,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   /* ── § 2 HOW IT WORKS ── */
   howSection: { position: "relative", background: "#000", padding: "36px 0 0" },
-  howHeader: { textAlign: "center", padding: "16px 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 50% 60%, rgba(120,60,180,0.18) 0%, transparent 70%)" },
+  howHeader: { textAlign: "center", padding: "16px 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.08) 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 50% 60%, rgba(120,60,180,0.18) 0%, transparent 70%)" },
   howH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   stepsContainer: { position: "relative", display: "flex", flexDirection: "column", gap: "1px", background: "rgba(120,60,180,0.10)", borderRadius: "12px", overflow: "hidden", margin: "0 24px", border: "1px solid rgba(120,60,180,0.25)", boxShadow: "0 16px 40px rgba(0,0,0,0.5), 0 0 20px rgba(120,60,180,0.15)" },
   step: {
@@ -1134,7 +1136,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   /* ── § 3 WATERFALL ── */
   waterfallSection: { position: "relative", background: "#000", padding: "32px 0 0" },
-  waterfallHeader: { textAlign: "center", padding: "0 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 60%)" },
+  waterfallHeader: { textAlign: "center", padding: "0 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.08) 0%, transparent 60%)" },
   waterfallH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   waterfallExplainer: {
     fontFamily: "'Inter', sans-serif", fontSize: "18px", color: "rgba(255,255,255,0.88)",
@@ -1146,7 +1148,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   /* ── § 4 WHY THIS MATTERS ── */
   whySection: { position: "relative", background: "#000", textAlign: "center", padding: "48px 0 0" },
-  whyHeader: { padding: "20px 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 60%)" },
+  whyHeader: { padding: "20px 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.10) 0%, transparent 60%)" },
   whyH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", textAlign: "center", lineHeight: 0.95 },
   badgeGridWrapper: {
     margin: "0 24px", borderRadius: "12px", overflow: "hidden", border: "1px solid rgba(120,60,180,0.25)",
@@ -1164,7 +1166,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   /* ── § 5 ARSENAL ── */
   arsenalSection: { position: "relative", background: "#000", textAlign: "center", padding: "48px 0 0" },
-  arsenalHeader: { padding: "0 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.06) 0%, transparent 60%)" },
+  arsenalHeader: { padding: "0 24px 24px", background: "radial-gradient(ellipse 80% 40% at 50% 30%, rgba(212,175,55,0.12) 0%, transparent 60%)" },
   arsenalH2: { fontFamily: "'Bebas Neue', sans-serif", fontSize: "3.2rem", color: "#fff", lineHeight: 0.95 },
   arsenalSub: { fontFamily: "'Inter', sans-serif", fontSize: "18px", marginTop: "10px", color: "rgba(255,255,255,0.88)", lineHeight: 1.5 },
   sectionSub: { fontFamily: "'Inter', sans-serif", fontSize: "18px", marginTop: "10px", color: "rgba(255,255,255,0.88)", lineHeight: 1.5 },


### PR DESCRIPTION
…oll-driven emotional temperature

Implement PEAK→dip→build→build→PEAK→DROP→PEAK atmospheric arc:
- How canopy 0.20→0.15, Waterfall 0.20→0.18, Arsenal 0.25→0.28 (260px)
- Reality 0.20→0.10 (160px), bottom canopy killed entirely
- New Closer canopy at 0.22 (120% wide ellipse)
- Gold header haze escalation: How/Waterfall 0.08, Why 0.10, Arsenal 0.12
- Document atmospheric arc system in LANDING_PAGE_REFERENCE

https://claude.ai/code/session_01JzHNaofNaeynkNXpoz66jo