### PR TITLE
feat: conversion strategy v1 — leads table, kill OTP, update products

### DIFF
--- a/src/components/EmailGateModal.tsx
+++ b/src/components/EmailGateModal.tsx
@@ -109,7 +109,7 @@ const EmailGateModal = ({ isOpen, onClose, onSuccess, onSkip }: EmailGateModalPr
                 inputMode="email"
                 autoComplete="email"
                 autoFocus
-                placeholder="thefilmmaker.og@gmail.com"
+                placeholder="you@company.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="w-full h-12 px-4 bg-bg-header border border-border-subtle text-text-primary placeholder:text-text-dim font-mono text-sm focus:border-gold focus:outline-none transition-colors"

--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -47,33 +47,26 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted }: LeadCaptureModa
     setLoading(true);
 
     try {
-      // Store lead in Supabase auth (OTP sent in background, but we don't wait for click)
-      await supabase.auth.signInWithOtp({
+      // Best-effort lead capture — insert to leads table
+      await supabase.from('leads').insert({
+        name: name.trim(),
         email: email.trim(),
-        options: {
-          data: { full_name: name.trim() },
-          emailRedirectTo: `${window.location.origin}/calculator`,
-        },
+        source: 'calculator',
       });
-      // Save to localStorage so calculator can greet them
-      localStorage.setItem('og_lead_name', name.trim());
-      localStorage.setItem('og_lead_email', email.trim());
-
-      haptics.success();
-      onEmailSubmitted?.(email.trim());
-      onClose();
-      // Navigate straight to calculator — no magic link wait
-      window.location.href = '/calculator';
-    } catch (error) {
-      // Even if OTP fails, let them through — lead capture is best-effort
-      localStorage.setItem('og_lead_name', name.trim());
-      localStorage.setItem('og_lead_email', email.trim());
-      haptics.success();
-      onClose();
-      window.location.href = '/calculator';
-    } finally {
-      setLoading(false);
+    } catch {
+      // Lead capture is best-effort — let them through even if insert fails
     }
+
+    // Save to localStorage so calculator can greet them
+    localStorage.setItem('og_lead_name', name.trim());
+    localStorage.setItem('og_lead_email', email.trim());
+
+    haptics.success();
+    onEmailSubmitted?.(email.trim());
+    onClose();
+    setLoading(false);
+    // Navigate straight to calculator
+    window.location.href = '/calculator';
   };
 
 
@@ -153,7 +146,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted }: LeadCaptureModa
                 autoCapitalize="none"
                 autoCorrect="off"
                 spellCheck={false}
-                placeholder="thefilmmaker.og@gmail.com"
+                placeholder="you@company.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 onKeyDown={(e) => {

--- a/src/components/calculator/WaterfallDeck.tsx
+++ b/src/components/calculator/WaterfallDeck.tsx
@@ -2583,8 +2583,7 @@ const CTASection = ({ result, inputs, project, guilds }: {
       // 2. Determine user email
       let userEmail = email;
       if (!userEmail) {
-        const { data: { session } } = await supabase.auth.getSession();
-        userEmail = session?.user?.email;
+        userEmail = localStorage.getItem('og_lead_email') ?? undefined;
       }
 
       if (!userEmail) {
@@ -2639,8 +2638,8 @@ const CTASection = ({ result, inputs, project, guilds }: {
   }, [result, inputs, project, guilds, haptics]);
 
   const gatedNavigate = useCallback(async (destination: string) => {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (session?.user) {
+    const hasLead = localStorage.getItem('og_lead_email');
+    if (hasLead) {
       navigate(destination);
     } else {
       setShowLeadCapture(true);
@@ -2791,9 +2790,9 @@ const CTASection = ({ result, inputs, project, guilds }: {
               onClick={async (e) => {
                 haptics.light(e);
                 if (exporting) return;
-                const { data: { session } } = await supabase.auth.getSession();
-                if (session?.user?.email) {
-                  handleExportPdf(session.user.email);
+                const leadEmail = localStorage.getItem('og_lead_email');
+                if (leadEmail) {
+                  handleExportPdf(leadEmail);
                 } else {
                   setPendingExport(true);
                   setShowLeadCapture(true);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -76,6 +76,30 @@ export type Database = {
         }
         Relationships: []
       }
+      leads: {
+        Row: {
+          id: string
+          name: string
+          email: string
+          source: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          email: string
+          source?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          email?: string
+          source?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
       intake_submissions: {
         Row: {
           cam_fee_is_default: boolean | null
@@ -268,6 +292,33 @@ export type Database = {
           stripe_session_id?: string
           updated_at?: string | null
           user_id?: string | null
+        }
+        Relationships: []
+      }
+      waterfall_snapshots: {
+        Row: {
+          id: string
+          user_email: string
+          project_name: string
+          snapshot_data: Json
+          product_tier: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_email: string
+          project_name: string
+          snapshot_data: Json
+          product_tier: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_email?: string
+          project_name?: string
+          snapshot_data?: Json
+          product_tier?: string
+          created_at?: string
         }
         Relationships: []
       }

--- a/src/lib/store-products.ts
+++ b/src/lib/store-products.ts
@@ -1,12 +1,11 @@
 /* ═══════════════════════════════════════════════════════════════════
    PRODUCT DATA — filmmaker.og store
    Current architecture (March 2026):
-     0. Snapshot+ ($49) — diagnostic upgrade, credit toward Full Analysis
-     1. The Full Analysis ($197) — automated, first paid tier
-     2. Comp Report ($595 / $995) — standalone market data
-     3. The Producer's Package ($1,797) — turnkey service
-     4. Boutique ($2,997+) — custom scope
-     5. The Working Model ($79) — checkout upsell add-on
+     0. Snapshot+ ($19) — white-labeled snapshot with diagnostics, credit toward Comp Report
+     1. Comp Report ($595 / $995) — standalone market data
+     2. The Producer's Package ($1,797) — turnkey service
+     3. Boutique ($2,997+) — custom scope
+     4. The Working Model ($79) — checkout upsell add-on (requires Producer's Package)
 
      Credit upgrade path: prior purchases apply toward next tier.
 
@@ -14,6 +13,7 @@
      "The Snapshot" as a paid product (now FREE calculator output)
      "The Package" at $597 (replaced by Comp Report + Producer's Package)
      "The Full Package" at $2,497 (replaced by Boutique)
+     "The Full Analysis" at $197 (removed — Snapshot+ now upgrades to Comp Report)
    ═══════════════════════════════════════════════════════════════════ */
 
 export interface Product {
@@ -52,7 +52,7 @@ export const products: Product[] = [
     id: "snapshot-plus",
     slug: "snapshot-plus",
     name: "Snapshot+",
-    price: 49,
+    price: 19,
     priceNote: null,
     originalPrice: null,
     badge: "UPGRADE",
@@ -60,16 +60,16 @@ export const products: Product[] = [
     tier: 0,
     category: "product",
     turnaround: "Instant",
-    shortDescription: "The diagnostic layer behind your free Snapshot.",
+    shortDescription: "Your Snapshot, white-labeled with deal diagnostics.",
     fullDescription:
-      "The free Snapshot shows you the waterfall. Snapshot+ tells you whether it holds up.\n\nFour diagnostic metrics that separate a deal that works from a deal that looks like it works: Margin of Safety, Erosion Rate, Off-the-Top Total, and Cost of Capital.\n\nInstant delivery. Applies as credit toward The Full Analysis.",
+      "The free Snapshot shows you the waterfall. Snapshot+ puts your company name on every page and unlocks four diagnostic metrics that separate a deal that works from a deal that looks like it works: Margin of Safety, Erosion Rate, Off-the-Top Total, and Cost of Capital.\n\nInstant delivery. Applies as credit toward the Comp Report.",
     features: [
       { title: "Margin of Safety", subtitle: "How much room your deal has before it breaks", group: "Unlock" },
       { title: "Erosion Rate", subtitle: "What the off-the-tops actually cost you", group: "Unlock" },
       { title: "Off-the-Top Total", subtitle: "Combined fees before investors see a dollar", group: "Unlock" },
       { title: "Cost of Capital", subtitle: "The real price of every dollar in your stack", group: "Unlock" },
     ],
-    reassurance: "Applies as credit toward The Full Analysis",
+    reassurance: "Applies as credit toward the Comp Report",
     whatsIncluded: [
       { title: "Margin of Safety", body: "The gap between your break-even point and projected revenue." },
       { title: "Erosion Rate", body: "Percentage of gross revenue consumed by off-the-top deductions." },
@@ -79,60 +79,12 @@ export const products: Product[] = [
     pickThisIf: "Find out whether your deal actually works.",
     whoItsFor: "Producers who ran the free calculator and want to know if the deal structure is sound before committing to full documentation.",
     upgradePrompt: {
-      title: "NEED THE FULL DOCUMENT?",
-      body: "The Full Analysis builds the complete investor-ready financial presentation. Your Snapshot+ purchase applies as credit.",
-      cta: "See The Full Analysis →",
-      link: "/store/the-full-analysis",
-    },
-    ctaLabel: "GET SNAPSHOT+",
-  },
-  {
-    id: "the-full-analysis",
-    slug: "the-full-analysis",
-    name: "The Full Analysis",
-    price: 197,
-    priceNote: null,
-    originalPrice: null,
-    badge: "LAUNCH PRICING",
-    featured: false,
-    tier: 1,
-    category: "product",
-    shortDescription: "Your financial model. One document. Investor-ready.",
-    fullDescription:
-      "Your complete financial model — budget, capital stack, waterfall, deal terms, and scenario analysis — presented as a single, designed document that any investor can pick up and understand.\n\nSensitivity modeling across five market conditions shows how your deal performs when the price moves. Not a single scenario — a stress-tested range.\n\nRun your numbers. We make them investor-ready.",
-    features: [
-      { title: "Complete Financial Model", subtitle: "Every section of your deal in one document", group: "Analyze" },
-      { title: "Sensitivity Modeling", subtitle: "What happens when the acquisition price changes", group: "Analyze" },
-      { title: "Investor Return Profiles", subtitle: "How your investors make money and when", group: "Analyze" },
-      { title: "White-Labeled Branding", subtitle: "Your company name on every page", group: "Present" },
-      { title: "Institutional Design", subtitle: "Hand it to your attorney. Hand it to your investor. It holds up.", group: "Present" },
-    ],
-    reassurance: "Instant delivery",
-    priceAnchor: "An entertainment attorney charges $500–850/hr for this work",
-    whatsIncluded: [
-      {
-        title: "Unified Financial Presentation (PDF)",
-        body: "Budget overview, capital stack structure, deal terms, full waterfall cascade, scenario analysis, and investor return summary. One cohesive document, designed to flow.",
-      },
-      {
-        title: "Sensitivity Modeling",
-        body: "Five market scenarios showing how your deal performs when the acquisition price moves — from base case to distressed. The analysis that turns a single number into a range.",
-      },
-      {
-        title: "White-Labeled Branding",
-        body: "Your production company name and project title on every page. Your project, your brand.",
-      },
-    ],
-    pickThisIf: "Your numbers documented, stress-tested, investor-ready.",
-    whoItsFor:
-      "Producers who have their numbers modeled and need a professional document to reference, send, or attach. When someone asks for the numbers, this is what you hand them.",
-    upgradePrompt: {
       title: "NEED TO DEFEND YOUR VALUATION?",
       body: "The Comp Report adds real comparable acquisition data in your genre and budget range — the evidence that turns your valuation from an assumption into a defensible number.",
       cta: "See the Comp Report →",
       link: "/store/comp-report",
     },
-    ctaLabel: "GET THE FULL ANALYSIS",
+    ctaLabel: "GET SNAPSHOT+",
   },
   {
     id: "comp-report",
@@ -304,12 +256,7 @@ export const products: Product[] = [
     tier: 0,
     category: "product",
     isAddOn: true,
-    requiresBase: [
-      "the-full-analysis",
-      "comp-report",
-      "the-producers-package",
-      "boutique",
-    ],
+    requiresBase: ["the-producers-package"],
     shortDescription: "The live Excel engine behind your finance plan. Reuse on every project.",
     fullDescription:
       "The formula-driven Excel engine behind your finance plan.\n\nEvery output cell is connected to every input. Change your budget — the waterfall recalculates. Adjust the sales agent commission — every downstream tier updates. Swap your equity split — investor returns recompute instantly.\n\nThis isn't a snapshot of one deal. It's a financial modeling tool you'll use for years. Buy it once, use it on every project going forward.",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
 import { useHaptics } from "@/hooks/use-haptics";
-import { User } from "@supabase/supabase-js";
 import { calculateWaterfall, WaterfallInputs, GuildState } from "@/lib/waterfall";
 
 // New Tab Components
@@ -184,7 +182,6 @@ const Calculator = () => {
   const haptics = useHaptics();
   const mainRef = useRef<HTMLDivElement>(null);
 
-  const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Default to project step (step 00)
@@ -207,14 +204,14 @@ const Calculator = () => {
     setSourceSelections(prev => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
-  // Gate: redirect to landing page if no session AND no lead capture
+  // Gate: redirect to landing page if no lead capture
   useEffect(() => {
     if (loading) return;
     const hasLead = localStorage.getItem('og_lead_email');
-    if (!user && !hasLead) {
+    if (!hasLead) {
       navigate("/", { replace: true });
     }
-  }, [user, loading, navigate]);
+  }, [loading, navigate]);
 
   // Honor URL ?tab= param if present
   useEffect(() => {
@@ -229,19 +226,9 @@ const Calculator = () => {
     return calculateWaterfall(inputs, guilds);
   }, [inputs, guilds]);
 
-  // Auth
+  // Check lead status on mount
   useEffect(() => {
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-      setUser(session?.user ?? null);
-      setLoading(false);
-    });
-
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setUser(session?.user ?? null);
-      setLoading(false);
-    });
-
-    return () => subscription.unsubscribe();
+    setLoading(false);
   }, []);
 
   // Scroll to top when switching tabs
@@ -291,7 +278,7 @@ const Calculator = () => {
   };
 
   const handleExportClick = () => {
-    if (!user && !emailCaptured) {
+    if (!emailCaptured) {
       setShowEmailGate(true);
     } else {
       navigate('/store/the-full-analysis');

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
 import { useHaptics } from "@/hooks/use-haptics";
 import { useInView } from "@/hooks/useInView";
 import LeadCaptureModal from "@/components/LeadCaptureModal";
@@ -26,32 +25,11 @@ const Index = () => {
 
   const [showLeadCapture, setShowLeadCapture] = useState(false);
 
-  useEffect(() => {
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-      if (session?.user) {
-        if (event === 'SIGNED_IN' && window.location.hash.includes('access_token')) {
-          navigate('/calculator');
-        }
-      }
-    });
-    return () => subscription.unsubscribe();
-  }, [navigate]);
-
   const gatedNavigate = useCallback(async (destination: string) => {
-    try {
-      // Check if they've already given their info (localStorage) or have a session
-      const hasLead = localStorage.getItem('og_lead_email');
-      if (hasLead) {
-        navigate(destination);
-        return;
-      }
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session?.user) {
-        navigate(destination);
-        return;
-      }
-    } catch {
-      // If Supabase fails, fall through to show modal
+    const hasLead = localStorage.getItem('og_lead_email');
+    if (hasLead) {
+      navigate(destination);
+      return;
     }
     setShowLeadCapture(true);
   }, [navigate]);


### PR DESCRIPTION
## Changes
- Kill Supabase OTP auth from lead capture flow (no more confusing magic link emails)
- New `leads` table in Supabase (simple name + email + source)
- LeadCaptureModal inserts to leads table instead of signInWithOtp
- Calculator/Index/WaterfallDeck auth gates use localStorage only
- Snapshot+ reduced from $49 → $19
- The Full Analysis ($197) removed entirely
- Working Model restricted to Producer's Package add-on only
- TypeScript types regenerated