### PR TITLE
Add Dashboard placeholder page with /dashboard route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const Calculator = lazy(() => import("./pages/Calculator"));
 const Store = lazy(() => import("./pages/Store"));
 const StorePackage = lazy(() => import("./pages/StorePackage"));
 const BuildYourPlan = lazy(() => import("./pages/BuildYourPlan"));
+const Dashboard = lazy(() => import("./pages/Dashboard"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -75,6 +76,7 @@ const AppShell = () => {
           <Route path="/store" element={<Store />} />
           <Route path="/store/:slug" element={<StorePackage />} />
           <Route path="/build-your-plan" element={<BuildYourPlan />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,1 @@
+export default function Dashboard() { return <div style={{background:"#000",color:"#fff",minHeight:"100vh",padding:"40px"}}>Dashboard</div>; }


### PR DESCRIPTION
New JSX page with black background/white text placeholder. Lazy-loaded route added before the catch-all. Not in sitemap.

https://claude.ai/code/session_016JqkZPoWtwvWwUi5kYTGWJ