### PR TITLE
Visual consistency pass: metallic CTA gradient, contrast fixes, menu …

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { X as CloseIcon, Home, Calculator, ShoppingBag, BarChart2, Mail, Instagram, Share2, Sparkles } from "lucide-react";
+import { X as CloseIcon, Home, Calculator, ShoppingBag, BarChart2, Mail, Share2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
 import { useHaptics } from "@/hooks/use-haptics";
@@ -120,7 +120,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           }
         `}</style>
 
-        {/* Purple atmospheric glow — pure purple, no gold contamination */}
+        {/* Atmospheric glow layer */}
         <div
           className="absolute top-0 left-0 right-0 pointer-events-none z-0"
           style={{
@@ -262,126 +262,6 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
             ))}
           </div>
 
-          {/* Follow — social links */}
-          <div>
-            <SectionLabel>Follow</SectionLabel>
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "6px", marginBottom: "10px" }}>
-
-              {/* Instagram */}
-              <a
-                href="https://www.instagram.com/filmmaker.og"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Instagram"
-                onClick={() => haptics.light()}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: "6px",
-                  padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
-                  borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
-                  textDecoration: "none",
-                  cursor: "pointer",
-                  transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
-                }}
-              >
-                <Instagram size={18} style={{ color: "#D4AF37" }} />
-                <span style={{
-                  fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.1rem",
-                  letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
-                }}>Instagram</span>
-              </a>
-
-              {/* TikTok — custom SVG */}
-              <a
-                href="https://www.tiktok.com/@filmmaker.og"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="TikTok"
-                onClick={() => haptics.light()}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: "6px",
-                  padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
-                  borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
-                  textDecoration: "none",
-                  cursor: "pointer",
-                  transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
-                }}
-              >
-                <svg width={18} height={18} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-2.88 2.5 2.89 2.89 0 0 1-2.89-2.89 2.89 2.89 0 0 1 2.89-2.89c.28 0 .54.04.79.1v-3.5a6.37 6.37 0 0 0-.79-.05A6.34 6.34 0 0 0 3.15 15a6.34 6.34 0 0 0 6.34 6.34 6.34 6.34 0 0 0 6.34-6.34V8.71a8.2 8.2 0 0 0 4.76 1.52v-3.4a4.85 4.85 0 0 1-1-.14z"/>
-                </svg>
-                <span style={{
-                  fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.1rem",
-                  letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
-                }}>TikTok</span>
-              </a>
-
-              {/* Facebook — custom SVG */}
-              <a
-                href="https://www.facebook.com/filmmaker.og"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Facebook"
-                onClick={() => haptics.light()}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: "6px",
-                  padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
-                  borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
-                  textDecoration: "none",
-                  cursor: "pointer",
-                  transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
-                }}
-              >
-                <svg width={18} height={18} viewBox="0 0 24 24" fill="#D4AF37" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
-                </svg>
-                <span style={{
-                  fontFamily: "'Bebas Neue', sans-serif",
-                  fontSize: "1.1rem",
-                  letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
-                }}>Facebook</span>
-              </a>
-
-            </div>
-          </div>
-
           {/* Connect — home + email + share */}
           <div>
             <SectionLabel>Connect</SectionLabel>
@@ -498,7 +378,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
               fontSize: "11px",
               letterSpacing: "0.02em",
               lineHeight: 1.6,
-              color: "rgba(255,255,255,0.40)",
+              color: "rgba(255,255,255,0.55)",
               textAlign: "center",
             }}>
               For educational and informational purposes only. Not legal, tax, or investment advice.

--- a/src/index.css
+++ b/src/index.css
@@ -701,7 +701,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--gold-cta);
+    background: linear-gradient(180deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0.05) 40%, rgba(0,0,0,0.1) 100%), var(--gold-cta);
     border: none;
     color: #000000;
     font-family: 'Bebas Neue', sans-serif;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1278,7 +1278,7 @@ const styles: Record<string, React.CSSProperties> = {
     position: "relative", overflow: "hidden",
     fontFamily: "'Bebas Neue', sans-serif", fontWeight: 700,
     textTransform: "uppercase", color: "#000",
-    background: "#F9E076", padding: "18px 0",
+    background: "linear-gradient(180deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0.05) 40%, rgba(0,0,0,0.1) 100%), #F9E076", padding: "18px 0",
     letterSpacing: "0.12em", fontSize: "20px",
     borderRadius: "8px", border: "none", borderTop: "1px solid rgba(255,255,255,0.15)", borderBottom: "2px solid rgba(180,145,30,0.30)", cursor: "pointer",
     display: "block", width: "100%", textAlign: "center",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -123,7 +123,7 @@ const Login = () => {
           style={{
             fontFamily: "'Inter', sans-serif",
             fontSize: "14px",
-            color: white(0.48),
+            color: white(0.65),
           }}
         >
           Don't have an account?{" "}

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -162,7 +162,7 @@ const Pricing = () => {
               letterSpacing: "0.06em",
               lineHeight: 1.05,
               margin: "0 0 24px",
-              textShadow: `0 0 30px ${gold(0.55)}, 0 0 80px ${gold(0.18)}`,
+              textShadow: `0 0 20px ${gold(0.25)}, 0 0 50px ${gold(0.10)}`,
             }}
           >
             LOCK IN $19/MO FOR LIFE

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1130,7 +1130,7 @@ const Resources = () => {
         display: "flex",
         flexDirection: "column",
         gap: 16,
-        padding: "0 24px 120px",
+        padding: "0 24px 48px",
         maxWidth: 1000,
         margin: "0 auto",
       }}>
@@ -1182,16 +1182,16 @@ const Resources = () => {
           </a>
         </div>
         <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 10, marginBottom: 16 }}>
-          <span onClick={() => window.location.href = "/"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Home</span>
+          <span onClick={() => window.location.href = "/"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.50)", cursor: "pointer", transition: "color 0.2s ease" }}>Home</span>
           <span style={{ color: "rgba(212,175,55,0.20)", fontSize: 12 }}>&middot;</span>
-          <span onClick={() => window.location.href = "/store"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Shop</span>
+          <span onClick={() => window.location.href = "/store"} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.50)", cursor: "pointer", transition: "color 0.2s ease" }}>Shop</span>
           <span style={{ color: "rgba(212,175,55,0.20)", fontSize: 12 }}>&middot;</span>
-          <span onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.35)", cursor: "pointer", transition: "color 0.2s ease" }}>Resources</span>
+          <span onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })} style={{ fontFamily: "'Roboto Mono', monospace", fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(212,175,55,0.50)", cursor: "pointer", transition: "color 0.2s ease" }}>Resources</span>
         </div>
         <p style={{
           fontFamily: "'Inter', sans-serif",
           fontSize: 14,
-          color: "rgba(255,255,255,0.48)",
+          color: "rgba(255,255,255,0.55)",
           textAlign: "center",
           lineHeight: 1.6,
           margin: 0,

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -123,7 +123,7 @@ const Signup = () => {
           style={{
             fontFamily: "'Inter', sans-serif",
             fontSize: "14px",
-            color: white(0.48),
+            color: white(0.65),
           }}
         >
           Already have an account?{" "}


### PR DESCRIPTION
…cleanup

- Add metallic light-from-above gradient to all CTA buttons (btn-cta-primary in CSS + inline ctaBtn in Index.tsx) for premium feel
- Remove Follow section (social links) from MobileMenu, keeping Navigate + Connect for a cleaner, more professional drawer
- Increase legal disclaimer text contrast across MobileMenu (0.40→0.55), Resources footer (0.48→0.55) for readability
- Increase auth page "have an account?" label contrast (0.48→0.65) on Signup and Login pages
- Increase Resources footer nav link contrast (0.35→0.50)
- Reduce "LOCK IN $19/MO" text glow on Pricing for modern flat aesthetic
- Reduce Resources page bottom padding (120px→48px) to eliminate dead space
- Clean up vestigial purple comment in MobileMenu

https://claude.ai/code/session_01V8qV4KhJher9JeWStm2Sqn