### PR TITLE
Fix Project tab cards to use slate backgrounds matching other wizard tabs

### DIFF
--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -20,8 +20,9 @@ const STATUSES = ["Development", "Pre-Prod", "Production", "Post"];
 
 const warmCard: React.CSSProperties = {
   position: "relative",
-  background: "#0A0A0A",
-  border: "1px solid rgba(212,175,55,0.35)",
+  background: "#222226",
+  border: "1px solid rgba(212,175,55,0.25)",
+  borderTop: "1px solid rgba(255,255,255,0.08)",
   borderRadius: 8,
   overflow: "hidden",
   marginBottom: 16,
@@ -50,8 +51,9 @@ const warmToplineShimmer: React.CSSProperties = {
 
 const dataCard: React.CSSProperties = {
   position: "relative",
-  background: "#0A0A0A",
-  border: "1px solid rgba(212,175,55,0.20)",
+  background: "#222226",
+  border: "1px solid rgba(212,175,55,0.15)",
+  borderTop: "1px solid rgba(255,255,255,0.08)",
   borderRadius: 8,
   overflow: "hidden",
   marginBottom: 16,


### PR DESCRIPTION
## Summary
- Updated Project tab `warmCard` and `dataCard` backgrounds from `#0A0A0A` (near-black) to `#222226` (slate) to match the `ChapterCard` styling used by Budget, Stack, Deal, and Waterfall tabs
- Aligned border opacities and added `borderTop` white edge treatment for consistency with the design system

## Test plan
- [ ] Verify all 5 wizard tabs show consistent slate (`#222226`) card backgrounds
- [ ] Confirm Project tab warm card and data card match Budget tab ChapterCard appearance
- [ ] Check input fields, genre pills, and team section render correctly on new background
- [ ] Test on mobile viewport

https://claude.ai/code/session_01QHnoFhbAhsvdjHJpZiPAsY