### PR TITLE
fix(calculator): remove extra wrapper card from Project tab hero

### DIFF
--- a/src/components/calculator/tabs/ProjectTab.tsx
+++ b/src/components/calculator/tabs/ProjectTab.tsx
@@ -20,9 +20,8 @@ const STATUSES = ["Development", "Pre-Prod", "Production", "Post"];
 
 const warmCard: React.CSSProperties = {
   position: "relative",
-  background: "#222226",
-  border: "1px solid rgba(212,175,55,0.25)",
-  borderTop: "1px solid rgba(255,255,255,0.08)",
+  background: "#0A0A0A",
+  border: "1px solid rgba(212,175,55,0.15)",
   borderRadius: 8,
   overflow: "hidden",
   marginBottom: 16,
@@ -51,9 +50,8 @@ const warmToplineShimmer: React.CSSProperties = {
 
 const dataCard: React.CSSProperties = {
   position: "relative",
-  background: "#222226",
+  background: "#0A0A0A",
   border: "1px solid rgba(212,175,55,0.15)",
-  borderTop: "1px solid rgba(255,255,255,0.08)",
   borderRadius: 8,
   overflow: "hidden",
   marginBottom: 16,
@@ -367,6 +365,44 @@ const ProjectTab = ({ project, onUpdateProject, onAdvance }: ProjectTabProps) =>
 
   return (
     <div style={s.wrapper}>
+      {/* ═══ Hero — sits directly on black (no wrapper card) ═══ */}
+      <div style={{ position: "relative", marginBottom: 20 }}>
+        <section style={{
+          position: "relative", textAlign: "center",
+          padding: "24px 20px 20px", borderRadius: 8, overflow: "hidden",
+          background: "#0A0A0A",
+          border: "1px solid rgba(212,175,55,0.15)",
+        }}>
+          <div style={{ position: "relative", zIndex: 1 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, padding: "0 8px" }}>
+              <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
+              <span style={{
+                fontFamily: "'Roboto Mono', monospace", fontSize: 13,
+                letterSpacing: "0.15em", textTransform: "uppercase" as const,
+                color: "rgba(212,175,55,0.65)", whiteSpace: "nowrap" as const,
+              }}>Step 00 · Project</span>
+              <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
+            </div>
+            <h1 style={{
+              fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.8rem",
+              letterSpacing: "0.02em", lineHeight: 0.90, color: "#fff", marginBottom: 8,
+              textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
+            }}>
+              What Are You<br />
+              <span style={{
+                color: "#D4AF37",
+                textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.50), 0 0 80px rgba(212,175,55,0.25)",
+              }}>Building?</span>
+            </h1>
+            <p style={{
+              fontFamily: "'Inter', sans-serif", fontSize: 15,
+              color: "rgba(255,255,255,0.75)", lineHeight: 1.45,
+              textShadow: "0 2px 12px rgba(0,0,0,0.9)",
+            }}>Tell us about the project — or jump straight to the numbers.</p>
+          </div>
+        </section>
+      </div>
+
       {/* ═══ Warm Card — Title + Logline + Genre + Status ═══ */}
       <div style={warmCard}>
         <div style={warmGlow} />

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -120,73 +120,6 @@ const ProgressBar = ({ activeTab }: { activeTab: TabId }) => {
   );
 };
 
-/* ═══ Glass hero — per-step welcome surface ═══ */
-const CalcHero = ({ stepLabel, title, titleGold, subtitle, visible }: {
-  stepLabel: string;
-  title: string;
-  titleGold: string;
-  subtitle: string;
-  visible: boolean;
-}) => {
-  const prefersReducedMotion = typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  const heroReveal: React.CSSProperties = {
-    opacity: prefersReducedMotion || visible ? 1 : 0,
-    transform: prefersReducedMotion || visible ? "translateY(0)" : "translateY(20px)",
-    transition: prefersReducedMotion ? "none" : "opacity 0.6s cubic-bezier(0.16,1,0.3,1), transform 0.6s cubic-bezier(0.16,1,0.3,1)",
-  };
-  return (
-    <div style={{ position: "relative", marginBottom: 20, ...heroReveal }}>
-      {/* Outer wrapper — #222226 slate stage (matches landing page section wrappers) */}
-      <section style={{
-        position: "relative",
-        borderRadius: 8, overflow: "hidden",
-        background: "#222226",
-        border: "1px solid rgba(255,255,255,0.10)",
-        borderTop: "1px solid rgba(255,255,255,0.18)",
-        padding: "20px",
-        boxShadow: "0 6px 28px rgba(0,0,0,0.50), 0 0 1px rgba(255,255,255,0.04), 0 0 1px rgba(212,175,55,0.06)",
-      }}>
-        {/* Inner header band — dark well (matches landing page header bands) */}
-        <div style={{
-          background: "linear-gradient(180deg, rgba(212,175,55,0.08), #141416)",
-          border: "1px solid rgba(255,255,255,0.06)",
-          borderTop: "1px solid rgba(255,255,255,0.10)",
-          borderRadius: 6,
-          padding: "28px 24px 24px",
-          textAlign: "center",
-          boxShadow: "inset 0 2px 6px rgba(0,0,0,0.25)",
-        }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, padding: "0 8px" }}>
-            <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
-            <span style={{
-              fontFamily: "'Roboto Mono', monospace", fontSize: 11,
-              letterSpacing: "0.15em", textTransform: "uppercase",
-              color: "rgba(212,175,55,0.75)", whiteSpace: "nowrap",
-            }}>{stepLabel}</span>
-            <div style={{ flex: 1, height: 1, background: "rgba(212,175,55,0.35)" }} />
-          </div>
-          <h1 style={{
-            fontFamily: "'Bebas Neue', sans-serif", fontSize: "2.8rem",
-            letterSpacing: "0.02em", lineHeight: 0.90, color: "#fff",
-            marginBottom: 8,
-            textShadow: "0 2px 20px rgba(0,0,0,0.95), 0 4px 40px rgba(0,0,0,0.5)",
-          }}>
-            {title}<br />
-            <span style={{
-              color: "#D4AF37",
-              textShadow: "0 2px 20px rgba(0,0,0,0.8), 0 0 40px rgba(212,175,55,0.55), 0 0 80px rgba(212,175,55,0.18)",
-            }}>{titleGold}</span>
-          </h1>
-          <p style={{
-            fontFamily: "'Inter', sans-serif", fontSize: 15,
-            color: "rgba(255,255,255,0.80)", lineHeight: 1.45,
-          }}>{subtitle}</p>
-        </div>
-      </section>
-    </div>
-  );
-};
-
 const Calculator = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -380,13 +313,6 @@ const Calculator = () => {
         return (
           <>
             <ProgressBar activeTab={activeTab} />
-            <CalcHero
-              stepLabel="Step 00 · Project"
-              title="What Are You"
-              titleGold="Building?"
-              subtitle="Tell us about the project — or jump straight to the numbers."
-              visible={true}
-            />
             <ProjectTab
               project={project}
               onUpdateProject={setProject}


### PR DESCRIPTION
The Project tab had a card-on-card effect where CalcHero rendered a #222226 slate wrapper, then ProjectTab rendered its own cards inside. The other 4 tabs (Budget, Stack, Deal, Waterfall) sit directly on the black page background with no wrapper.

- Remove CalcHero component (only used by Project tab)
- Add inline hero section to ProjectTab matching Budget's pattern
- Change warmCard/dataCard backgrounds from #222226 to #0A0A0A

https://claude.ai/code/session_01S6kRCgWE2VZLJLKyccjzVD