### PR TITLE
fix(ui): visual polish — CTA gradient, token standardization, menu refinement

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
+import { gold, black } from "@/lib/tokens";
 
 /* ═══════════════════════════════════════════════════════════════════
    AppHeader — floating bar (matches max-w-xl card column)
@@ -72,8 +73,8 @@ const AppHeader = ({ onMoreOpen }: AppHeaderProps) => {
             marginRight: "24px",
             borderRadius: "8px",
             background: "rgba(26,26,28,0.90)",
-            border: "1px solid rgba(212,175,55,0.25)",
-            boxShadow: "0 2px 24px rgba(0,0,0,0.8), 0 0 12px rgba(212,175,55,0.06)",
+            border: `1px solid ${gold(0.25)}`,
+            boxShadow: `0 2px 24px ${black(0.8)}, 0 0 12px ${gold(0.06)}`,
             backdropFilter: "blur(24px)",
             WebkitBackdropFilter: "blur(24px)",
             paddingLeft: "20px",

--- a/src/components/LeadCaptureModal.tsx
+++ b/src/components/LeadCaptureModal.tsx
@@ -4,6 +4,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useHaptics } from "@/hooks/use-haptics";
 import { ArrowRight, Loader2 } from "lucide-react";
 import { z } from "zod";
+import { gold, GOLD } from "@/lib/tokens";
 import {
   Dialog,
   DialogContent,
@@ -82,7 +83,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted, onSuccess }: Lead
         className="w-[calc(100%-2rem)] max-w-sm mx-auto p-0 gap-0"
         style={{
           background: "#0C0C0E",
-          border: "1px solid rgba(212,175,55,0.15)",
+          border: `1px solid ${gold(0.15)}`,
           borderRadius: "8px",
         }}
       >
@@ -101,7 +102,7 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted, onSuccess }: Lead
           }
         `}</style>
         {/* Gold accent */}
-        <div className="h-[1px] w-full" style={{ background: "linear-gradient(90deg, transparent, #D4AF37, transparent)" }} />
+        <div className="h-[1px] w-full" style={{ background: `linear-gradient(90deg, transparent, ${GOLD}, transparent)` }} />
 
         {
           <form onSubmit={handleSubmit} className="p-6">
@@ -135,8 +136,8 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted, onSuccess }: Lead
                   borderRadius: "8px",
                 }}
                 onFocus={e => {
-                  e.currentTarget.style.borderColor = "#D4AF37";
-                  e.currentTarget.style.boxShadow = "0 0 0 3px rgba(212,175,55,0.15)";
+                  e.currentTarget.style.borderColor = GOLD;
+                  e.currentTarget.style.boxShadow = `0 0 0 3px ${gold(0.15)}`;
                 }}
                 onBlur={e => {
                   e.currentTarget.style.borderColor = "rgba(0,0,0,0.12)";
@@ -168,8 +169,8 @@ const LeadCaptureModal = ({ isOpen, onClose, onEmailSubmitted, onSuccess }: Lead
                   borderRadius: "8px",
                 }}
                 onFocus={e => {
-                  e.currentTarget.style.borderColor = "#D4AF37";
-                  e.currentTarget.style.boxShadow = "0 0 0 3px rgba(212,175,55,0.08)";
+                  e.currentTarget.style.borderColor = GOLD;
+                  e.currentTarget.style.boxShadow = `0 0 0 3px ${gold(0.08)}`;
                 }}
                 onBlur={e => {
                   e.currentTarget.style.borderColor = "rgba(0,0,0,0.12)";

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -4,7 +4,7 @@ import { X as CloseIcon, Home, Calculator, ShoppingBag, BarChart2, Mail, Share2,
 import { cn } from "@/lib/utils";
 import { getShareUrl, SHARE_TEXT, SHARE_TITLE } from "@/lib/constants";
 import { useHaptics } from "@/hooks/use-haptics";
-import { GOLD, CTA, BG, gold } from "@/lib/tokens";
+import { GOLD, CTA, BG, gold, ctaGold, white, black } from "@/lib/tokens";
 
 interface MobileMenuProps {
   isOpen?: boolean;
@@ -64,16 +64,16 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
   /* ─── Section label ─────────────────────────────────────────── */
   const SectionLabel = ({ children }: { children: React.ReactNode }) => (
     <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "10px" }}>
-      <div style={{ flex: 1, height: "1px", background: "rgba(212,175,55,0.25)" }} />
+      <div style={{ flex: 1, height: "1px", background: gold(0.25) }} />
       <span style={{
         fontFamily: "'Roboto Mono', monospace",
-        fontSize: "14px",
+        fontSize: "12px",
         letterSpacing: "0.18em",
         textTransform: "uppercase" as const,
         color: GOLD,
         whiteSpace: "nowrap" as const,
       }}>{children}</span>
-      <div style={{ flex: 1, height: "1px", background: "rgba(212,175,55,0.25)" }} />
+      <div style={{ flex: 1, height: "1px", background: gold(0.25) }} />
     </div>
   );
 
@@ -99,7 +99,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           backdropFilter: "blur(40px)",
           WebkitBackdropFilter: "blur(40px)",
           borderRadius: "12px 12px 0 0",
-          boxShadow: "0 -16px 50px rgba(0,0,0,0.70), 0 -30px 70px rgba(0,0,0,0.90)",
+          boxShadow: `0 -16px 50px ${black(0.70)}, 0 -30px 70px ${black(0.90)}`,
         }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
@@ -108,7 +108,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
         <div
           className="absolute top-0 left-0 right-0 h-[3px] pointer-events-none z-10"
           style={{
-            background: "linear-gradient(to right, transparent 0%, rgba(212,175,55,0.20) 20%, rgba(212,175,55,0.40) 50%, rgba(212,175,55,0.20) 80%, transparent 100%)",
+            background: `linear-gradient(to right, transparent 0%, ${gold(0.20)} 20%, ${gold(0.40)} 50%, ${gold(0.20)} 80%, transparent 100%)`,
             borderRadius: "12px 12px 0 0",
           }}
         />
@@ -142,17 +142,17 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
 
         {/* Drag handle */}
         <div className="flex justify-center pt-3 pb-2">
-          <div className="w-10 h-[3px] rounded-full" style={{ background: "rgba(255,255,255,0.25)" }} />
+          <div className="w-10 h-[3px] rounded-full" style={{ background: white(0.25) }} />
         </div>
 
         {/* Close button — anchored to sheet, clear of ASK THE OG tap zone */}
         <button
           onClick={() => { haptics.light(); setIsOpen(false); }}
           className="absolute top-2 right-4 w-8 h-8 flex items-center justify-center transition-colors z-20"
-          style={{ color: "rgba(255,255,255,0.60)" }}
+          style={{ color: white(0.60) }}
           aria-label="Close menu"
-          onMouseEnter={e => (e.currentTarget.style.color = "rgba(255,255,255,0.80)")}
-          onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.60)")}
+          onMouseEnter={e => (e.currentTarget.style.color = white(0.80))}
+          onMouseLeave={e => (e.currentTarget.style.color = white(0.60))}
         >
           <CloseIcon className="w-5 h-5" />
         </button>
@@ -179,7 +179,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 border: "none",
                 borderRadius: "8px",
                 cursor: "pointer",
-                boxShadow: "0 0 0 1px rgba(212,175,55,0.40), 0 8px 24px rgba(0,0,0,0.5), 0 0 30px rgba(249,224,118,0.20)",
+                boxShadow: `0 0 0 1px ${gold(0.40)}, 0 8px 24px ${black(0.5)}, 0 0 30px ${ctaGold(0.20)}`,
                 transition: "transform 0.15s ease, box-shadow 0.3s ease",
               }}
             >
@@ -187,7 +187,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 width: "36px",
                 height: "36px",
                 borderRadius: "8px",
-                background: "rgba(212,175,55,0.18)",
+                background: gold(0.18),
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
@@ -195,7 +195,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 position: "relative",
                 zIndex: 1,
               }}>
-                <Sparkles style={{ width: "22px", height: "22px", color: GOLD, filter: `drop-shadow(0 0 6px ${gold(0.40)})` }} />
+                <Sparkles size={22} color={GOLD} style={{ filter: `drop-shadow(0 0 6px ${gold(0.40)})` }} />
               </div>
               <span style={{
                 fontFamily: "'Bebas Neue', sans-serif",
@@ -209,14 +209,14 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
               </span>
               <div style={{
                 position: "absolute", top: 0, left: "-100%", width: "55%", height: "100%",
-                background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)",
+                background: `linear-gradient(90deg, transparent, ${white(0.35)}, transparent)`,
                 transform: "skewX(-20deg)",
                 animation: "menu-shimmer 2.5s ease-in-out infinite",
               }} />
             </button>
 
             {/* Separator — premium CTA zone / utility navigation */}
-            <div style={{ height: "1px", background: "rgba(212,175,55,0.15)", marginTop: "10px", marginBottom: "10px", maxWidth: "120px", marginLeft: "auto", marginRight: "auto" }} />
+            <div style={{ height: "1px", background: gold(0.15), marginTop: "10px", marginBottom: "10px", maxWidth: "120px", marginLeft: "auto", marginRight: "auto" }} />
             </>
           )}
 
@@ -232,8 +232,8 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 key={item.path}
                 aria-label={item.label}
                 onClick={() => handleNavigate(item.path)}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.25)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.15)"; }}
+                onMouseEnter={(e) => { e.currentTarget.style.borderColor = gold(0.25); }}
+                onMouseLeave={(e) => { e.currentTarget.style.borderColor = gold(0.15); }}
                 onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
                 onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
@@ -243,7 +243,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: BG.elevated,
+                  background: "transparent",
                   border: `1px solid ${gold(0.15)}`,
                   borderRadius: "8px",
                   cursor: "pointer",
@@ -255,7 +255,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
+                  color: white(0.88),
                 }}>
                   {item.label}
                 </span>
@@ -272,10 +272,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
               <button
                 aria-label="Home"
                 onClick={() => handleNavigate("/")}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
+                onMouseEnter={(e) => { e.currentTarget.style.borderColor = gold(0.18); e.currentTarget.style.background = gold(0.08); }}
+                onMouseLeave={(e) => { e.currentTarget.style.borderColor = gold(0.10); e.currentTarget.style.background = gold(0.04); }}
+                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
+                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
                   display: "flex",
                   flexDirection: "column",
@@ -283,10 +283,9 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
+                  background: gold(0.04),
+                  border: `1px solid ${gold(0.10)}`,
                   borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
                   cursor: "pointer",
                   transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
                 }}
@@ -296,7 +295,7 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
+                  color: white(0.88),
                   lineHeight: 1,
                 }}>Home</span>
               </button>
@@ -306,10 +305,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                 aria-label="Email"
                 href="mailto:og@filmmakerog.com"
                 onClick={() => haptics.light()}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
+                onMouseEnter={(e) => { e.currentTarget.style.borderColor = gold(0.18); e.currentTarget.style.background = gold(0.08); }}
+                onMouseLeave={(e) => { e.currentTarget.style.borderColor = gold(0.10); e.currentTarget.style.background = gold(0.04); }}
+                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
+                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
                   display: "flex",
                   flexDirection: "column",
@@ -317,21 +316,20 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
+                  background: gold(0.04),
+                  border: `1px solid ${gold(0.10)}`,
                   borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
                   textDecoration: "none",
                   cursor: "pointer",
                   transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
                 }}
               >
-                <Mail size={18} style={{ color: GOLD }} />
+                <Mail size={18} color={GOLD} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
+                  color: white(0.88),
                   lineHeight: 1,
                 }}>Email</span>
               </a>
@@ -340,10 +338,10 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
               <button
                 aria-label="Share"
                 onClick={handleShare}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.16) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 24px rgba(212,175,55,0.08), 0 0 12px rgba(212,175,55,0.08)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
-                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.18) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 30px rgba(212,175,55,0.08), 0 0 14px rgba(212,175,55,0.10)"; }}
-                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; e.currentTarget.style.borderColor = "rgba(212,175,55,0.08)"; e.currentTarget.style.background = "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)"; e.currentTarget.style.boxShadow = "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)"; }}
+                onMouseEnter={(e) => { e.currentTarget.style.borderColor = gold(0.18); e.currentTarget.style.background = gold(0.08); }}
+                onMouseLeave={(e) => { e.currentTarget.style.borderColor = gold(0.10); e.currentTarget.style.background = gold(0.04); }}
+                onMouseDown={(e) => { e.currentTarget.style.transform = "scale(0.97)"; }}
+                onMouseUp={(e) => { e.currentTarget.style.transform = "scale(1)"; }}
                 style={{
                   display: "flex",
                   flexDirection: "column",
@@ -351,20 +349,19 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
                   justifyContent: "center",
                   gap: "6px",
                   padding: "10px 8px",
-                  background: "radial-gradient(ellipse 80% 60% at 50% 15%, rgba(212,175,55,0.12) 0%, transparent 65%), radial-gradient(ellipse 90% 70% at 50% 85%, rgba(212,175,55,0.08) 0%, transparent 65%)",
-                  border: "1px solid rgba(212,175,55,0.08)",
+                  background: gold(0.04),
+                  border: `1px solid ${gold(0.10)}`,
                   borderRadius: "6px",
-                  boxShadow: "0 0 20px rgba(212,175,55,0.08), 0 0 10px rgba(212,175,55,0.06)",
                   cursor: "pointer",
                   transition: "transform 0.15s ease, border-color 0.25s ease, background 0.25s ease",
                 }}
               >
-                <Share2 size={18} style={{ color: GOLD }} />
+                <Share2 size={18} color={GOLD} />
                 <span style={{
                   fontFamily: "'Bebas Neue', sans-serif",
                   fontSize: "1.1rem",
                   letterSpacing: "0.1em",
-                  color: "rgba(255,255,255,0.88)",
+                  color: white(0.88),
                   lineHeight: 1,
                 }}>Share</span>
               </button>
@@ -373,13 +370,13 @@ const MobileMenu = ({ isOpen: controlledOpen, onOpenChange, onOpenBot }: MobileM
           </div>
 
           {/* Legal disclaimer */}
-          <div className="pt-3" style={{ borderTop: "1px solid rgba(212,175,55,0.08)" }}>
+          <div className="pt-3" style={{ borderTop: `1px solid ${gold(0.08)}` }}>
             <p style={{
               fontFamily: "'Inter', sans-serif",
               fontSize: "11px",
               letterSpacing: "0.02em",
               lineHeight: 1.6,
-              color: "rgba(255,255,255,0.55)",
+              color: white(0.55),
               textAlign: "center",
             }}>
               For educational and informational purposes only. Not legal, tax, or investment advice.

--- a/src/components/OgBotFab.tsx
+++ b/src/components/OgBotFab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { Sparkles } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
+import { gold, GOLD } from "@/lib/tokens";
 
 /* ═══════════════════════════════════════════════════════════════════
    OgBotFab — floating action button for the OG bot
@@ -43,21 +44,18 @@ const OgBotFab = ({ onTap }: OgBotFabProps) => {
         width: "52px",
         height: "52px",
         borderRadius: "8px",
-        background: "linear-gradient(135deg, rgba(212,175,55,0.25) 0%, rgba(212,175,55,0.15) 100%)",
-        border: "1px solid rgba(212,175,55,0.25)",
-        boxShadow: "0 4px 16px rgba(212,175,55,0.30), 0 0 40px rgba(212,175,55,0.12)",
+        background: `linear-gradient(135deg, ${gold(0.25)} 0%, ${gold(0.15)} 100%)`,
+        border: `1px solid ${gold(0.25)}`,
+        boxShadow: `0 4px 16px ${gold(0.30)}, 0 0 40px ${gold(0.12)}`,
         opacity: hidden ? 0 : 1,
         pointerEvents: hidden ? "none" : "auto",
       }}
       aria-label="Open OG assistant"
     >
       <Sparkles
-        style={{
-          width: "28px",
-          height: "28px",
-          color: "#D4AF37",
-          filter: "drop-shadow(0 0 6px rgba(212,175,55,0.40))",
-        }}
+        size={28}
+        color={GOLD}
+        style={{ filter: `drop-shadow(0 0 6px ${gold(0.40)})` }}
       />
     </button>
   );

--- a/src/components/calculator/ChapterCard.tsx
+++ b/src/components/calculator/ChapterCard.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { gold, white, red, GOLD, BG } from "@/lib/tokens";
 
 export type CardVariant = 'warm' | 'feature' | 'data' | 'neutral';
 
@@ -32,7 +33,7 @@ const eyebrowS: Record<string, React.CSSProperties> = {
   eyebrowLine: {
     flex: 1,
     height: "1px",
-    background: "rgba(212,175,55,0.40)",
+    background: gold(0.40),
   },
   eyebrowLabel: {
     fontFamily: "'Roboto Mono', monospace",
@@ -40,7 +41,7 @@ const eyebrowS: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     letterSpacing: "0.2em",
     textTransform: "uppercase" as const,
-    color: "#D4AF37",
+    color: GOLD,
     whiteSpace: "nowrap" as const,
     display: "flex",
     alignItems: "center",
@@ -56,34 +57,34 @@ const eyebrowS: Record<string, React.CSSProperties> = {
 
 const cardStyles: Record<CardVariant, React.CSSProperties> = {
   warm: {
-    background: "#222226",
-    border: "1px solid rgba(212,175,55,0.25)",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
+    background: BG.elevated,
+    border: `1px solid ${gold(0.25)}`,
+    borderTop: `1px solid ${white(0.08)}`,
     borderRadius: "8px",
     overflow: "hidden",
     position: "relative",
   },
   feature: {
-    background: "#222226",
-    border: "1px solid rgba(212,175,55,0.20)",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
+    background: BG.elevated,
+    border: `1px solid ${gold(0.20)}`,
+    borderTop: `1px solid ${white(0.08)}`,
     borderRadius: "8px",
     overflow: "hidden",
     transition: "box-shadow 0.5s",
     position: "relative",
   },
   data: {
-    background: "#222226",
-    border: "1px solid rgba(212,175,55,0.15)",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
+    background: BG.elevated,
+    border: `1px solid ${gold(0.15)}`,
+    borderTop: `1px solid ${white(0.08)}`,
     borderRadius: "8px",
     overflow: "hidden",
     position: "relative",
   },
   neutral: {
-    background: "#222226",
-    border: "1px solid rgba(212,175,55,0.15)",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
+    background: BG.elevated,
+    border: `1px solid ${gold(0.15)}`,
+    borderTop: `1px solid ${white(0.08)}`,
     borderRadius: "8px",
     overflow: "hidden",
     position: "relative",
@@ -98,7 +99,7 @@ const neutralGlow: React.CSSProperties | null = null;
 
 const warmTopline: React.CSSProperties = {
   height: "2px",
-  background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.60), transparent)",
+  background: `linear-gradient(90deg, transparent, ${gold(0.60)}, transparent)`,
   position: "relative",
   overflow: "hidden",
 };
@@ -109,13 +110,13 @@ const warmToplineShimmer: React.CSSProperties = {
   left: "-100%",
   width: "60%",
   height: "100%",
-  background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.30), transparent)",
+  background: `linear-gradient(90deg, transparent, ${white(0.30)}, transparent)`,
   animation: "toplineShimmer 8s ease-in-out infinite",
 };
 
 const featureTopline: React.CSSProperties = {
   height: "1px",
-  background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.40), transparent)",
+  background: `linear-gradient(90deg, transparent, ${gold(0.40)}, transparent)`,
 };
 
 const cardPad: React.CSSProperties = {
@@ -125,7 +126,7 @@ const cardPad: React.CSSProperties = {
 const cardH: React.CSSProperties = {
   fontFamily: "'Bebas Neue', sans-serif",
   fontSize: "28px",
-  color: "#D4AF37",
+  color: GOLD,
   letterSpacing: "0.06em",
   lineHeight: 1,
   marginBottom: "6px",
@@ -133,7 +134,7 @@ const cardH: React.CSSProperties = {
 
 const cardHSub: React.CSSProperties = {
   fontSize: "13px",
-  color: "rgba(255,255,255,0.48)",
+  color: white(0.48),
   marginBottom: "24px",
 };
 
@@ -170,24 +171,24 @@ const ChapterCard = ({
     // Feature card state-dependent glow
     if (effectiveVariant === 'feature' && glowState) {
       if (glowState === 'positive') {
-        cardStyle.boxShadow = "0 16px 40px rgba(0,0,0,0.6), 0 0 40px rgba(212,175,55,0.15)";
+        cardStyle.boxShadow = `0 16px 40px rgba(0,0,0,0.6), 0 0 40px ${gold(0.15)}`;
       } else if (glowState === 'negative') {
-        cardStyle.boxShadow = "0 16px 40px rgba(0,0,0,0.6), 0 0 40px rgba(200,64,64,0.18)";
+        cardStyle.boxShadow = `0 16px 40px rgba(0,0,0,0.6), 0 0 40px ${red(0.18)}`;
       }
     }
   } else {
     // Legacy fallback for non-variant usage
     cardStyle = isActive
       ? {
-          background: "#222226",
-          border: "1px solid rgba(212,175,55,0.25)",
+          background: BG.elevated,
+          border: `1px solid ${gold(0.25)}`,
           borderRadius: "8px",
           overflow: "hidden",
           transition: "border-color 0.25s ease",
         }
       : {
-          background: "#222226",
-          border: "1px solid rgba(212,175,55,0.15)",
+          background: BG.elevated,
+          border: `1px solid ${gold(0.15)}`,
           borderRadius: "8px",
           overflow: "hidden",
           transition: "border-color 0.25s ease",
@@ -239,8 +240,8 @@ const ChapterCard = ({
           <div
             style={
               isActive
-                ? { height: "2px", background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.60), transparent)", pointerEvents: "none" as const }
-                : { height: "1px", background: "linear-gradient(90deg, transparent, rgba(212,175,55,0.40), transparent)", pointerEvents: "none" as const }
+                ? { height: "2px", background: `linear-gradient(90deg, transparent, ${gold(0.60)}, transparent)`, pointerEvents: "none" as const }
+                : { height: "1px", background: `linear-gradient(90deg, transparent, ${gold(0.40)}, transparent)`, pointerEvents: "none" as const }
             }
           />
         )}

--- a/src/components/calculator/ContextBar.tsx
+++ b/src/components/calculator/ContextBar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { gold, white, BG } from "@/lib/tokens";
 
 interface ContextBarProps {
   budget: number;
@@ -22,9 +23,9 @@ const s: Record<string, React.CSSProperties> = {
     gap: "8px",
     padding: "10px 16px",
     marginBottom: "16px",
-    background: "#222226",
-    border: "1px solid rgba(212,175,55,0.15)",
-    borderTop: "1px solid rgba(255,255,255,0.08)",
+    background: BG.elevated,
+    border: `1px solid ${gold(0.15)}`,
+    borderTop: `1px solid ${white(0.08)}`,
     borderRadius: "8px",
     flexWrap: "wrap",
   },
@@ -33,18 +34,18 @@ const s: Record<string, React.CSSProperties> = {
     fontSize: "13px",
     textTransform: "uppercase" as const,
     letterSpacing: "0.1em",
-    color: "rgba(212,175,55,0.65)",
+    color: gold(0.65),
   },
   val: {
     fontFamily: "'Roboto Mono', monospace",
     fontSize: "13px",
-    color: "rgba(255,255,255,0.75)",
+    color: white(0.75),
   },
   dot: {
     width: "3px",
     height: "3px",
     borderRadius: "50%",
-    background: "rgba(212,175,55,0.30)",
+    background: gold(0.30),
   },
 };
 

--- a/src/components/calculator/StandardStepLayout.tsx
+++ b/src/components/calculator/StandardStepLayout.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useState } from "react";
 import ChapterCard, { CardVariant } from "./ChapterCard";
 import { ArrowRight } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
+import { ctaGold, white } from "@/lib/tokens";
 
 interface StandardStepLayoutProps {
   chapter: string;
@@ -28,14 +29,15 @@ const s: Record<string, React.CSSProperties> = {
     lineHeight: "1.6",
     paddingBottom: "16px",
     marginBottom: "16px",
-    borderBottom: "1px solid rgba(255,255,255,0.08)",
+    borderBottom: `1px solid ${white(0.08)}`,
   },
   cta: {
     width: "100%",
     padding: "16px",
     marginTop: "20px",
-    background: "#F9E076",
+    background: "linear-gradient(180deg, #FBE88A 0%, #F9E076 45%, #E8D06A 100%)",
     border: "none",
+    borderTop: "1px solid rgba(255,255,255,0.15)",
     borderRadius: "8px",
     fontFamily: "'Bebas Neue', sans-serif",
     fontSize: "20px",
@@ -48,11 +50,11 @@ const s: Record<string, React.CSSProperties> = {
     justifyContent: "center",
     gap: "10px",
     transition: "transform 0.12s ease, opacity 0.15s",
-    boxShadow: "0 0 20px rgba(249,224,118,0.25), 0 0 60px rgba(249,224,118,0.15)",
+    boxShadow: `0 0 20px ${ctaGold(0.25)}, 0 0 60px ${ctaGold(0.15)}`,
     minHeight: "56px",
   },
   ctaHover: {
-    boxShadow: "0 0 30px rgba(249,224,118,0.35), 0 0 80px rgba(249,224,118,0.20)",
+    boxShadow: `0 0 30px ${ctaGold(0.35)}, 0 0 80px ${ctaGold(0.20)}`,
   },
   ctaPressed: {
     transform: "scale(0.98)",
@@ -110,7 +112,7 @@ const StandardStepLayout = ({
               }}
             >
               {nextLabel}
-              <ArrowRight style={{ width: "18px", height: "18px" }} />
+              <ArrowRight size={18} />
             </button>
           )}
         </div>

--- a/src/components/shared/WikiCallout.tsx
+++ b/src/components/shared/WikiCallout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { gold } from "@/lib/tokens";
 
 interface WikiCalloutProps {
   label: string;
@@ -10,8 +11,8 @@ const WikiCallout = ({ label, children, icon }: WikiCalloutProps) => (
   <div
     className="p-4 rounded-xl"
     style={{
-      border: '1px solid rgba(212,175,55,0.15)',
-      background: 'rgba(212,175,55,0.03)',
+      border: `1px solid ${gold(0.15)}`,
+      background: gold(0.03),
     }}
   >
     <div className="flex gap-3">

--- a/src/components/shared/WikiSectionHeader.tsx
+++ b/src/components/shared/WikiSectionHeader.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { gold, GOLD } from "@/lib/tokens";
 
 interface WikiSectionHeaderProps {
   number: string;
@@ -22,15 +23,15 @@ const WikiSectionHeader = ({
       isExpanded !== false && "border-b border-bg-card-rule",
       isClickable && "cursor-pointer hover:bg-bg-card transition-colors"
     )}
-    style={{ background: 'rgba(212,175,55,0.03)' }}
+    style={{ background: gold(0.03) }}
     onClick={onClick}
   >
     {/* Gold Left Bar */}
     <div
       className="w-1 flex-shrink-0"
       style={{
-        background: 'linear-gradient(to bottom, #D4AF37, rgba(212,175,55,0.40))',
-        boxShadow: '0 0 12px rgba(212,175,55,0.06)',
+        background: `linear-gradient(to bottom, ${GOLD}, ${gold(0.40)})`,
+        boxShadow: `0 0 12px ${gold(0.06)}`,
       }}
     />
 
@@ -39,7 +40,7 @@ const WikiSectionHeader = ({
       className="flex items-center justify-center px-4 py-4 min-w-[56px]"
       style={{
         borderRight: '1px solid rgba(255,255,255,0.06)',
-        background: 'rgba(212,175,55,0.04)',
+        background: gold(0.04),
       }}
     >
       <span className="font-bebas text-[16px] tracking-wide text-gold">

--- a/src/components/ui/premium-input.tsx
+++ b/src/components/ui/premium-input.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ChevronRight } from "lucide-react";
 import { useHaptics } from "@/hooks/use-haptics";
 import { useMobileKeyboardScroll } from "@/hooks/use-mobile-keyboard";
+import { gold, GOLD } from "@/lib/tokens";
 
 interface PremiumInputProps extends React.ComponentProps<"input"> {
   isCompleted?: boolean;
@@ -53,7 +54,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
               fontFamily: "'Roboto Mono', monospace",
               fontSize: "1.5rem",
               fontWeight: 500,
-              color: hasValue ? "#D4AF37" : "rgba(212,175,55,0.45)",
+              color: hasValue ? GOLD : gold(0.45),
               lineHeight: 1,
               marginRight: "8px",
               flexShrink: 0,
@@ -96,7 +97,7 @@ const PremiumInput = React.forwardRef<HTMLInputElement, PremiumInputProps>(
             alignItems: "center",
             gap: "8px",
             marginTop: "12px",
-            color: "#D4AF37",
+            color: GOLD,
           }}>
             <ChevronRight style={{ width: "16px", height: "16px" }} />
             <span style={{

--- a/src/index.css
+++ b/src/index.css
@@ -701,8 +701,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(180deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0.05) 40%, rgba(0,0,0,0.1) 100%), var(--gold-cta);
+    background: linear-gradient(180deg, #FBE88A 0%, #F9E076 45%, #E8D06A 100%);
     border: none;
+    border-top: 1px solid rgba(255,255,255,0.15);
     color: #000000;
     font-family: 'Bebas Neue', sans-serif;
     font-size: 20px;
@@ -1011,7 +1012,7 @@
   }
   @media (hover: hover) {
     .cta-gold-btn:hover {
-      background: #F9E076 !important;
+      background: linear-gradient(180deg, #FBE88A 0%, #F9E076 45%, #E8D06A 100%) !important;
     }
   }
 


### PR DESCRIPTION
## Summary

Implements the visual consistency handoff audit across 11 files — CTA metallic gradient, GOLD token standardization, MobileMenu Linktree-overlay refinement, and icon consistency fixes.

### Checklist

- [x] **CTA metallic gradient** — `.btn-cta-primary` and `.cta-gold-btn` now use `linear-gradient(180deg, #FBE88A → #F9E076 → #E8D06A)` with a `border-top: 1px solid rgba(255,255,255,0.15)` top-edge light. Same gradient applied to `StandardStepLayout` inline CTA.
- [x] **GOLD token standardization** — Replaced all raw `rgba(212,175,55,...)`, `#D4AF37`, and `rgba(249,224,118,...)` with `gold()`, `GOLD`, `ctaGold()` token imports from `@/lib/tokens` in 10 components:
  - `AppHeader.tsx` — border + boxShadow
  - `OgBotFab.tsx` — gradient, border, shadow, icon color
  - `MobileMenu.tsx` — all inline rgba values (60+ replacements)
  - `ChapterCard.tsx` — all 4 card variants, eyebrow, toplines, legacy styles
  - `ContextBar.tsx` — bar, label, dot backgrounds
  - `StandardStepLayout.tsx` — CTA shadow, subtitle border
  - `WikiSectionHeader.tsx` — left bar gradient, backgrounds
  - `WikiCallout.tsx` — border + background
  - `PremiumInput.tsx` — currency symbol + action hint color
  - `LeadCaptureModal.tsx` — modal border, gold accent line, focus rings
- [x] **MobileMenu Linktree refinement** — Navigate buttons changed from `BG.elevated` to `transparent` (chip style). Connect buttons simplified from multi-radial-gradient to flat `gold(0.04)` with clean hover transitions. Section label font reduced 14px → 12px.
- [x] **Icon consistency** — Standardized to Lucide `size` + `color` props: OgBotFab Sparkles (`size={28} color={GOLD}`), MobileMenu Mail/Share2 (`color={GOLD}` prop), StandardStepLayout ArrowRight (`size={18}`).

### Safety constraints verified

- [x] `src/pages/Pricing.tsx` — untouched
- [x] `src/components/EmailGateModal.tsx` — untouched
- [x] Edge Functions — untouched
- [x] Database migrations — untouched

## Test plan

- [ ] Verify CTA buttons show gold metallic gradient (not flat color) on landing page hero, closer section, calculator steps, and lead capture modal
- [ ] Verify MobileMenu Navigate section has transparent chip-style buttons, Connect section has subtle gold-tinted backgrounds
- [ ] Verify all icon colors render as metallic gold (#D4AF37)
- [ ] Verify `npm run build` passes with zero errors
- [ ] Spot-check pricing page and auth flows are unaffected

https://claude.ai/code/session_01X7wuFkDfw39SNRWLxR2ou7